### PR TITLE
Add Pycharm .idea/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ analysis/__pycache__/*
 .rstudio/*
 
 .ipynb_checkpoints
+
+# PyCharm
+.idea/


### PR DESCRIPTION
Pycharm adds the `.idea/` folder to local directory during development and we could ignore it simply so it doesn't pop up changes everytime we develop anything locally.