### PR TITLE
replaced xdg-open subprocess calls with webbrowser.open

### DIFF
--- a/colrev/ops/built_in/pdf_prep/completeness_validation.py
+++ b/colrev/ops/built_in/pdf_prep/completeness_validation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-import timeout_decorator
 import zope.interface
 from dataclasses_jsonschema import JsonSchemaMixin
 
@@ -68,7 +67,6 @@ class PDFCompletenessValidation(JsonSchemaMixin):
                 return True
         return False
 
-    @timeout_decorator.timeout(60, use_signals=False)
     def prep_pdf(
         self,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,

--- a/colrev/ops/built_in/pdf_prep/cover_page.py
+++ b/colrev/ops/built_in/pdf_prep/cover_page.py
@@ -7,7 +7,6 @@ import typing
 from dataclasses import dataclass
 from pathlib import Path
 
-import timeout_decorator
 import zope.interface
 from dataclasses_jsonschema import JsonSchemaMixin
 from PyPDF2 import PdfFileReader
@@ -171,7 +170,6 @@ class PDFCoverPage(JsonSchemaMixin):
 
         return list(set(coverpages))
 
-    @timeout_decorator.timeout(60, use_signals=False)
     def prep_pdf(
         self,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,

--- a/colrev/ops/built_in/pdf_prep/last_page.py
+++ b/colrev/ops/built_in/pdf_prep/last_page.py
@@ -7,7 +7,6 @@ import typing
 from dataclasses import dataclass
 from pathlib import Path
 
-import timeout_decorator
 import zope.interface
 from dataclasses_jsonschema import JsonSchemaMixin
 from PyPDF2 import PdfFileReader
@@ -43,7 +42,6 @@ class PDFLastPage(JsonSchemaMixin):
     ) -> None:
         self.settings = self.settings_class.load_settings(data=settings)
 
-    @timeout_decorator.timeout(60, use_signals=False)
     def prep_pdf(
         self,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,

--- a/colrev/ops/built_in/pdf_prep/metadata_validation.py
+++ b/colrev/ops/built_in/pdf_prep/metadata_validation.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-import timeout_decorator
 import zope.interface
 from dataclasses_jsonschema import JsonSchemaMixin
 
@@ -120,7 +119,6 @@ class PDFMetadataValidation(JsonSchemaMixin):
 
         return validation_info
 
-    @timeout_decorator.timeout(60, use_signals=False)
     def prep_pdf(
         self,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,

--- a/colrev/ops/built_in/pdf_prep_man/pdf_prep_man_cli.py
+++ b/colrev/ops/built_in/pdf_prep_man/pdf_prep_man_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import platform
 import re
-import subprocess
+import webbrowser
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -104,11 +104,7 @@ class CoLRevCLIPDFManPrep(JsonSchemaMixin):
 
     def __open_pdf(self, *, filepath: Path) -> None:
         # pylint: disable=no-member
-        current_platform = platform.system()
-        if current_platform == "Linux":
-            subprocess.call(["xdg-open", filepath])
-        else:
-            os.startfile(filepath)  # type: ignore
+        webbrowser.open(str(filepath))
 
     def __remove_page(
         self,

--- a/colrev/ops/built_in/prep_man/prep_man_export.py
+++ b/colrev/ops/built_in/prep_man/prep_man_export.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import typing
+import webbrowser
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -119,7 +119,7 @@ class ExportManPrep(JsonSchemaMixin):
             self.__copy_files_for_man_prep(records=man_prep_recs)
         if "pytest" not in os.getcwd():
             # os.system('%s %s' % (os.getenv('EDITOR'), self.prep_man_bib_path))
-            subprocess.call(["xdg-open", str(self.prep_man_bib_path)])
+            webbrowser.open(str(self.prep_man_bib_path))
 
     def __update_provenance(
         self, *, record: colrev.record.Record, records: dict

--- a/colrev/ops/built_in/search_sources/local_index.py
+++ b/colrev/ops/built_in/search_sources/local_index.py
@@ -407,7 +407,6 @@ class LocalIndexSearchSource(JsonSchemaMixin):
         record: colrev.record.Record,
         retrieval_similarity: float,
     ) -> colrev.record.Record:
-
         # add colrev_pdf_id
         added_colrev_pdf_id = self.__add_cpid(record=record)
 
@@ -506,12 +505,10 @@ class LocalIndexSearchSource(JsonSchemaMixin):
             except OSError:
                 pass
 
-        except (
-            colrev_exceptions.InvalidMerge,
-        ):
+        except (colrev_exceptions.InvalidMerge,):
             print("invalid-merge")
         except colrev_exceptions.NotFeedIdentifiableException:
-            print('not-feed-identifiable')
+            print("not-feed-identifiable")
         finally:
             self.local_index_lock.release()
 

--- a/colrev/record.py
+++ b/colrev/record.py
@@ -384,6 +384,8 @@ class Record:
                 value_provenance["source"] += f"|rename-from:{key}"
             self.data["colrev_masterdata_provenance"][new_key] = value_provenance
         else:
+            if "colrev_data_provenance" not in self.data:
+                self.data["colrev_data_provenance"] = {}
             if key in self.data["colrev_data_provenance"]:
                 value_provenance = self.data["colrev_data_provenance"][key]
                 if "source" in value_provenance:

--- a/colrev/record.py
+++ b/colrev/record.py
@@ -1583,7 +1583,7 @@ class Record:
         try:
             self.set_pages_in_pdf(project_path=project_path)
             text = self.extract_text_by_page(pages=[0, 1, 2], project_path=project_path)
-            self.data["text_from_pdf"] = text
+            self.data["text_from_pdf"] = text.replace("\n", " ").replace("\x0c", "")
 
         except PDFSyntaxError:  # pragma: no cover
             self.add_data_provenance_note(key="file", note="pdf_reader_error")

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import typing
+import webbrowser
 from pathlib import Path
 
 import click
@@ -1095,15 +1096,9 @@ def pdfs(
             # pylint: disable=import-outside-toplevel
             # pylint: disable=consider-using-with
             # pylint: disable=no-member
-            import platform
 
             path = review_manager.path / Path("data/pdfs")
-            if platform.system() == "Windows":
-                os.startfile(path)  # type: ignore
-            elif platform.system() == "Darwin":
-                subprocess.Popen(["open", path])
-            else:
-                subprocess.Popen(["xdg-open", path])
+            webbrowser.open(str(path))
             return
 
         if discard:
@@ -2692,9 +2687,6 @@ def man(
     force: bool,
 ) -> None:
     """Show the CoLRev manual."""
-
-    # pylint: disable=import-outside-toplevel
-    import webbrowser
 
     webbrowser.open(
         str(Path(colrev.__file__).resolve()).replace(

--- a/tests/0_core/record_test.py
+++ b/tests/0_core/record_test.py
@@ -1537,7 +1537,7 @@ def test_set_text_from_pdf(
     script_loc: Path, record_with_pdf: colrev.record.Record
 ) -> None:
     record_with_pdf
-    expected = WagnerLukyanenkoParEtAl2022_pdf_content
+    expected = WagnerLukyanenkoParEtAl2022_pdf_content.replace("\n", " ")
     record_with_pdf.set_text_from_pdf(project_path=script_loc.parent)
     actual = record_with_pdf.data["text_from_pdf"]
     actual = actual[0:4234]


### PR DESCRIPTION
Instead of executing `xdg-open` with `subprocess`, using `webbrowser.open`, which opens the file using system designated application, and we do not have to consider which platform is being used.

Also replaced docker subprocess call in `check_ocr` with python docker module


<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
