### PR TITLE
Fixed bug due to remote not being iterable

### DIFF
--- a/colrev/env/environment_manager.py
+++ b/colrev/env/environment_manager.py
@@ -112,7 +112,10 @@ class EnvironmentManager:
             "repo_source_path": path_to_register,
         }
         git_repo = git.Repo(path_to_register)
-        remotes = [x["repo"] for x in git_repo.remotes if "repo" in x and x["repo"]]
+        remotes = []
+        for remote in git_repo.remotes:
+            if remote.repo:
+                remotes.append(remote.repo)
         new_record["repo_source_url"] = remotes and remotes.pop() or None
         self.environment_registry.append(new_record)
         self.save_environment_registry(updated_registry=self.environment_registry)

--- a/colrev/exceptions.py
+++ b/colrev/exceptions.py
@@ -387,6 +387,14 @@ class UnsupportedImportFormatError(CoLRevException):
 class RecordNotFoundInPrepSourceException(CoLRevException):
     """The record was not found in the prep search source."""
 
+    def __init__(
+        self,
+        *,
+        msg: str,
+    ) -> None:
+        self.message = msg
+        super().__init__(self.message)
+
 
 class PreparationBreak(CoLRevException):
     """Event interrupting the preparation."""

--- a/colrev/ops/built_in/search_sources/crossref.py
+++ b/colrev/ops/built_in/search_sources/crossref.py
@@ -176,9 +176,13 @@ class CrossrefSearchSource(JsonSchemaMixin):
             requests.exceptions.JSONDecodeError,
             requests.exceptions.ConnectTimeout,
         ) as exc:
-            raise colrev_exceptions.RecordNotFoundInPrepSourceException() from exc
+            raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                msg="Record not found in crossref (based on doi)"
+            ) from exc
         if crossref_query_return is None:
-            raise colrev_exceptions.RecordNotFoundInPrepSourceException()
+            raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                msg="Record not found in crossref (based on doi)"
+            )
         retrieved_record_dict = connector_utils.json_to_record(
             item=crossref_query_return
         )
@@ -463,7 +467,9 @@ class CrossrefSearchSource(JsonSchemaMixin):
                     retrieved_record = retrieved_records.pop()
 
             if 0 == len(retrieved_record.data) or "doi" not in retrieved_record.data:
-                raise colrev_exceptions.RecordNotFoundInPrepSourceException()
+                raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                    msg="Record not found in crossref"
+                )
 
             similarity = colrev.record.PrepRecord.get_retrieval_similarity(
                 record_original=record, retrieved_record_original=retrieved_record

--- a/colrev/ops/built_in/search_sources/open_library.py
+++ b/colrev/ops/built_in/search_sources/open_library.py
@@ -194,11 +194,15 @@ class OpenLibrarySearchSource(JsonSchemaMixin):
                         + record.data.get("editor", "NA").split(",")[0]
                     )
             if base_url not in url:
-                raise colrev_exceptions.RecordNotFoundInPrepSourceException()
+                raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                    msg="OpenLibrary: base_url not in url"
+                )
 
             title = record.data.get("title", record.data.get("booktitle", "NA"))
             if len(title) < 10:
-                raise colrev_exceptions.RecordNotFoundInPrepSourceException()
+                raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                    msg="OpenLibrary: len(title) < 10"
+                )
             if ":" in title:
                 title = title[: title.find(":")]  # To catch sub-titles
             url = url + "&title=" + title.replace(" ", "+")
@@ -213,12 +217,16 @@ class OpenLibrarySearchSource(JsonSchemaMixin):
 
             # if we have an exact match, we don't need to check the similarity
             if '"numFoundExact": true,' not in ret.text:
-                raise colrev_exceptions.RecordNotFoundInPrepSourceException()
+                raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                    msg="OpenLibrary: numFoundExact true missing"
+                )
 
             data = json.loads(ret.text)
             items = data["docs"]
             if not items:
-                raise colrev_exceptions.RecordNotFoundInPrepSourceException()
+                raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                    msg="OpenLibrary: no items"
+                )
             item = items[0]
 
         retrieved_record = self.__open_library_json_to_record(item=item, url=url)

--- a/colrev/ops/built_in/search_sources/pubmed.py
+++ b/colrev/ops/built_in/search_sources/pubmed.py
@@ -378,7 +378,9 @@ class PubMedSearchSource(JsonSchemaMixin):
                 )
 
             if not retrieved_record_dict:
-                raise colrev_exceptions.RecordNotFoundInPrepSourceException()
+                raise colrev_exceptions.RecordNotFoundInPrepSourceException(
+                    msg="Pubmed: no records retrieved"
+                )
 
             retrieved_record = colrev.record.Record(data=retrieved_record_dict)
 

--- a/tests/1_env/environment_manager_test.py
+++ b/tests/1_env/environment_manager_test.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+"""Test the environment manager"""
+
 import os
 from pathlib import Path
 
@@ -16,6 +19,9 @@ def script_loc(request) -> Path:  # type: ignore
 
 
 def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ignore
+    """
+    Environment manager details test
+    """
     identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
     if any("true" == os.getenv(x) for x in identifier_list):
         return

--- a/tests/1_env/environment_manager_test.py
+++ b/tests/1_env/environment_manager_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Test the environment manager"""
-
 import os
 from pathlib import Path
 

--- a/tests/1_env/environment_manager_test.py
+++ b/tests/1_env/environment_manager_test.py
@@ -22,9 +22,9 @@ def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ign
 
     temp_env = tmp_path
     with mocker.patch.object(
-            colrev.env.environment_manager.EnvironmentManager,
-            "registry",
-            temp_env / Path("reg.yml"),
+        colrev.env.environment_manager.EnvironmentManager,
+        "registry",
+        temp_env / Path("reg.yml"),
     ):
         env_man = colrev.env.environment_manager.EnvironmentManager()
 
@@ -65,4 +65,3 @@ def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ign
         # env_man.stop_docker_services()
         # env_man.build_docker_image()
         # env_man.save_environment_registry(updated_registry=env_man.environment_registry)
-

--- a/tests/1_env/environment_manager_test.py
+++ b/tests/1_env/environment_manager_test.py
@@ -1,59 +1,68 @@
-#!/usr/bin/env python
-# from pathlib import Path
-# import pytest
-# import os
-# import colrev.env.environment_manager
-# import colrev.env.tei_parser
-# import colrev.review_manager
-# @pytest.fixture(scope="module")
-# def script_loc(request) -> Path:  # type: ignore
-#     """Return the directory of the currently running test script"""
-#     return Path(request.fspath).parent
-# def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ignore
-#     pass
-# identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
-# if any("true" == os.getenv(x) for x in identifier_list):
-#     return
-# temp_env = tmp_path
-# with mocker.patch.object(
-#     colrev.env.environment_manager.EnvironmentManager,
-#     "registry",
-#     temp_env / Path("reg.yml"),
-# ):
-#     env_man = colrev.env.environment_manager.EnvironmentManager()
-#     env_man.register_repo(path_to_register=Path(script_loc.parents[1]))
-#     actual = env_man.environment_registry  # type: ignore
-#     expected = [  # type: ignore
-#         {
-#             "repo_name": "colrev",
-#             "repo_source_path": Path(colrev.__file__).parents[1],
-#             "repo_source_url": actual[0]["repo_source_url"],
-#         }
-#     ]
-#     print(actual)
-#     assert expected == actual
-#     expected = {  # type: ignore
-#         "index": {
-#             "size": 0,
-#             "last_modified": "NOT_INITIATED",
-#             "path": "/home/gerit/colrev",
-#             "status": "TODO",
-#         },
-#         "local_repos": {
-#             "repos": [],
-#             "broken_links": [
-#                 {
-#                     "repo_name": "colrev",
-#                     "repo_source_path": str(Path(colrev.__file__).parents[1]),
-#                     "repo_source_url": actual[0]["repo_source_url"],
-#                 }
-#             ],
-#         },
-#     }
-#     actual = env_man.get_environment_details()  # type: ignore
-#     actual["index"]["path"] = "/home/gerit/colrev"  # type: ignore
-#     print(actual)
-#     assert expected == actual
-#     env_man.stop_docker_services()
-# env_man.build_docker_image()
-# env_man.save_environment_registry(updated_registry=env_man.environment_registry)
+import os
+from pathlib import Path
+
+import pytest
+
+import colrev.env.environment_manager
+import colrev.env.tei_parser
+import colrev.review_manager
+
+
+@pytest.fixture(scope="module")
+def script_loc(request) -> Path:  # type: ignore
+    """Return the directory of the currently running test script"""
+
+    return Path(request.fspath).parent
+
+
+def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ignore
+    identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
+    if any("true" == os.getenv(x) for x in identifier_list):
+        return
+
+    temp_env = tmp_path
+    with mocker.patch.object(
+            colrev.env.environment_manager.EnvironmentManager,
+            "registry",
+            temp_env / Path("reg.yml"),
+    ):
+        env_man = colrev.env.environment_manager.EnvironmentManager()
+
+        env_man.register_repo(path_to_register=Path(script_loc.parents[1]))
+        actual = env_man.environment_registry  # type: ignore
+
+        expected = [  # type: ignore
+            {
+                "repo_name": "colrev",
+                "repo_source_path": Path(colrev.__file__).parents[1],
+                "repo_source_url": actual[0]["repo_source_url"],
+            }
+        ]
+        assert expected == actual
+
+        expected = {  # type: ignore
+            "index": {
+                "size": 0,
+                "last_modified": "NOT_INITIATED",
+                "path": "/home/gerit/colrev",
+                "status": "TODO",
+            },
+            "local_repos": {
+                "repos": [],
+                "broken_links": [
+                    {
+                        "repo_name": "colrev",
+                        "repo_source_path": str(Path(colrev.__file__).parents[1]),
+                        "repo_source_url": str(actual[0]["repo_source_url"]),
+                    }
+                ],
+            },
+        }
+        actual = env_man.get_environment_details()  # type: ignore
+        actual["index"]["path"] = "/home/gerit/colrev"  # type: ignore
+        assert expected == actual
+
+        # env_man.stop_docker_services()
+        # env_man.build_docker_image()
+        # env_man.save_environment_registry(updated_registry=env_man.environment_registry)
+


### PR DESCRIPTION
The remotes attribute in repo is not usable in list comprehension. So it's throwing an exception. Have reverted to for loop. 

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

## What is the new behavior?

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
The test that is covering it was disabled. I have enabled with docker code disabled. So matrix tests still passes