### PR TITLE
Fixed bug with adding `repo_source_url` 

### DIFF
--- a/colrev/env/environment_manager.py
+++ b/colrev/env/environment_manager.py
@@ -112,8 +112,10 @@ class EnvironmentManager:
             "repo_source_path": path_to_register,
         }
         git_repo = git.Repo(path_to_register)
-        remotes = [x["repo"] for x in git_repo.remotes if "repo" in x and x["repo"]]
-        new_record["repo_source_url"] = remotes and remotes.pop() or None
+        for remote in git_repo.remotes:
+            if remote.url:
+                new_record["repo_source_url"] = remote.url
+                break
         self.environment_registry.append(new_record)
         self.save_environment_registry(updated_registry=self.environment_registry)
         print(f"Registered path ({path_to_register})")

--- a/tests/1_env/environment_manager_test.py
+++ b/tests/1_env/environment_manager_test.py
@@ -1,59 +1,60 @@
 #!/usr/bin/env python
-# from pathlib import Path
-# import pytest
-# import os
-# import colrev.env.environment_manager
-# import colrev.env.tei_parser
-# import colrev.review_manager
-# @pytest.fixture(scope="module")
-# def script_loc(request) -> Path:  # type: ignore
-#     """Return the directory of the currently running test script"""
-#     return Path(request.fspath).parent
-# def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ignore
-#     pass
-# identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
-# if any("true" == os.getenv(x) for x in identifier_list):
-#     return
-# temp_env = tmp_path
-# with mocker.patch.object(
-#     colrev.env.environment_manager.EnvironmentManager,
-#     "registry",
-#     temp_env / Path("reg.yml"),
-# ):
-#     env_man = colrev.env.environment_manager.EnvironmentManager()
-#     env_man.register_repo(path_to_register=Path(script_loc.parents[1]))
-#     actual = env_man.environment_registry  # type: ignore
-#     expected = [  # type: ignore
-#         {
-#             "repo_name": "colrev",
-#             "repo_source_path": Path(colrev.__file__).parents[1],
-#             "repo_source_url": actual[0]["repo_source_url"],
-#         }
-#     ]
-#     print(actual)
-#     assert expected == actual
-#     expected = {  # type: ignore
-#         "index": {
-#             "size": 0,
-#             "last_modified": "NOT_INITIATED",
-#             "path": "/home/gerit/colrev",
-#             "status": "TODO",
-#         },
-#         "local_repos": {
-#             "repos": [],
-#             "broken_links": [
-#                 {
-#                     "repo_name": "colrev",
-#                     "repo_source_path": str(Path(colrev.__file__).parents[1]),
-#                     "repo_source_url": actual[0]["repo_source_url"],
-#                 }
-#             ],
-#         },
-#     }
-#     actual = env_man.get_environment_details()  # type: ignore
-#     actual["index"]["path"] = "/home/gerit/colrev"  # type: ignore
-#     print(actual)
-#     assert expected == actual
-#     env_man.stop_docker_services()
-# env_man.build_docker_image()
-# env_man.save_environment_registry(updated_registry=env_man.environment_registry)
+
+from pathlib import Path
+import pytest
+import os
+import colrev.env.environment_manager
+import colrev.env.tei_parser
+import colrev.review_manager
+
+
+@pytest.fixture(scope="module")
+def script_loc(request) -> Path:  # type: ignore
+    """Return the directory of the currently running test script"""
+    return Path(request.fspath).parent
+
+
+def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ignore
+    identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
+    if any("true" == os.getenv(x) for x in identifier_list):
+        return
+    temp_env = tmp_path
+    with mocker.patch.object(
+            colrev.env.environment_manager.EnvironmentManager,
+            "registry",
+            temp_env / Path("reg.yml"),
+    ):
+        env_man = colrev.env.environment_manager.EnvironmentManager()
+        env_man.register_repo(path_to_register=Path(script_loc.parents[1]))
+        actual = env_man.environment_registry  # type: ignore
+        expected = [  # type: ignore
+            {
+                "repo_name": "colrev",
+                "repo_source_path": Path(colrev.__file__).parents[1],
+                "repo_source_url": actual[0]["repo_source_url"],
+            }
+        ]
+        print(actual)
+        assert expected == actual
+        expected = {  # type: ignore
+            "index": {
+                "size": 0,
+                "last_modified": "NOT_INITIATED",
+                "path": "/home/gerit/colrev",
+                "status": "TODO",
+            },
+            "local_repos": {
+                "repos": [],
+                "broken_links": [
+                    {
+                        "repo_name": "colrev",
+                        "repo_source_path": str(Path(colrev.__file__).parents[1]),
+                        "repo_source_url": actual[0]["repo_source_url"],
+                    }
+                ],
+            },
+        }
+        actual = env_man.get_environment_details()  # type: ignore
+        actual["index"]["path"] = "/home/gerit/colrev"  # type: ignore
+        print(actual)
+        assert expected == actual

--- a/tests/1_env/environment_manager_test.py
+++ b/tests/1_env/environment_manager_test.py
@@ -16,6 +16,7 @@ def script_loc(request) -> Path:  # type: ignore
 
 
 def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ignore
+    """Testing environment manager returning correct environment details"""
     identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
     if any("true" == os.getenv(x) for x in identifier_list):
         return

--- a/tests/1_env/environment_manager_test.py
+++ b/tests/1_env/environment_manager_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-
-from pathlib import Path
-import pytest
 import os
+from pathlib import Path
+
+import pytest
+
 import colrev.env.environment_manager
 import colrev.env.tei_parser
 import colrev.review_manager
@@ -20,9 +21,9 @@ def test_environment_manager(mocker, tmp_path, script_loc) -> None:  # type: ign
         return
     temp_env = tmp_path
     with mocker.patch.object(
-            colrev.env.environment_manager.EnvironmentManager,
-            "registry",
-            temp_env / Path("reg.yml"),
+        colrev.env.environment_manager.EnvironmentManager,
+        "registry",
+        temp_env / Path("reg.yml"),
     ):
         env_man = colrev.env.environment_manager.EnvironmentManager()
         env_man.register_repo(path_to_register=Path(script_loc.parents[1]))


### PR DESCRIPTION
Reverted to for loop as `remotes` does not work in list comprehension, and Bug was I was not taking the URL from the repo.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

## What is the new behavior?

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
Environment Manger Test is enabled to make sure env_manager work correctly.