### PR TITLE
Filter man-prep export fields

### DIFF
--- a/colrev/ops/built_in/prep_man/prep_man_export.py
+++ b/colrev/ops/built_in/prep_man/prep_man_export.py
@@ -120,7 +120,20 @@ class ExportManPrep(JsonSchemaMixin):
         }
 
         # Filter out fields that are not needed for manual preparation
-        fields_to_keep = ["ENTRYTYPE", "author", "title", "year", "journal", "booktitle", "incollection", "colrev_status", "volume", "number", "pages", "doi"]
+        fields_to_keep = [
+            "ENTRYTYPE",
+            "author",
+            "title",
+            "year",
+            "journal",
+            "booktitle",
+            "incollection",
+            "colrev_status",
+            "volume",
+            "number",
+            "pages",
+            "doi",
+        ]
         filtered_man_prep_recs = {}
         for citation, fields in man_prep_recs.copy().items():
             for k, v in fields.copy().items():

--- a/colrev/ops/built_in/prep_man/prep_man_export.py
+++ b/colrev/ops/built_in/prep_man/prep_man_export.py
@@ -118,8 +118,18 @@ class ExportManPrep(JsonSchemaMixin):
             if colrev.record.RecordState.md_needs_manual_preparation
             == v["colrev_status"]
         }
+
+        # Filter out fields that are not needed for manual preparation
+        fields_to_keep = ["ENTRYTYPE", "author", "title", "year", "journal", "booktitle", "incollection", "colrev_status", "volume", "number", "pages", "doi"]
+        filtered_man_prep_recs = {}
+        for citation, fields in man_prep_recs.copy().items():
+            for k, v in fields.copy().items():
+                if not k in fields_to_keep:
+                    del fields[k]
+            filtered_man_prep_recs.update({citation: fields})
+
         prep_man_operation.review_manager.dataset.save_records_dict_to_file(
-            records=man_prep_recs, save_path=self.prep_man_bib_path
+            records=filtered_man_prep_recs, save_path=self.prep_man_bib_path
         )
         if any("file" in r for r in man_prep_recs.values()):
             self.__copy_files_for_man_prep(records=man_prep_recs)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We are exporting all fields, which may be overwhelming when one only has to touch a few fields for man-prep

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduce fields_to_keep list
- Filter fields including only what it is in fields_to_keep

## Does this introduce a breaking change?

Not sure how the import works with the reduced field set. Do we drop fields in records.bib if we do not import all fields back in?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
