### PR TITLE
Export to xlsx when user is on Windows

### DIFF
--- a/colrev/ops/built_in/prep_man/prep_man_export.py
+++ b/colrev/ops/built_in/prep_man/prep_man_export.py
@@ -2,6 +2,7 @@
 """Export of bib/pdfs as a prep-man operation"""
 from __future__ import annotations
 
+import platform
 import typing
 from dataclasses import dataclass
 from pathlib import Path
@@ -35,6 +36,7 @@ class ExportManPrep(JsonSchemaMixin):
 
     RELATIVE_PREP_MAN_PATH = Path("records_prep_man.bib")
     RELATIVE_PREP_MAN_INFO_PATH = Path("records_prep_man_info.csv")
+    RELATIVE_PREP_MAN_INFO_PATH_XLS = Path("records_prep_man_info.xlsx")
 
     __FIELDS_TO_KEEP = [
         "ENTRYTYPE",
@@ -88,6 +90,10 @@ class ExportManPrep(JsonSchemaMixin):
 
         self.prep_man_csv_path = (
             self.review_manager.prep_dir / self.RELATIVE_PREP_MAN_INFO_PATH
+        )
+
+        self.prep_man_xlsx_path = (
+            self.review_manager.prep_dir / self.RELATIVE_PREP_MAN_INFO_PATH_XLS
         )
 
         self.review_manager.prep_dir.mkdir(exist_ok=True, parents=True)
@@ -161,7 +167,11 @@ class ExportManPrep(JsonSchemaMixin):
                     )
 
         man_prep_info_df = pd.DataFrame(man_prep_info)
-        man_prep_info_df.to_csv(self.prep_man_csv_path, index=False)
+        if platform.system() == "Windows":
+            with pd.ExcelWriter(self.prep_man_xlsx_path) as writer:
+                man_prep_info_df.to_excel(writer)
+        else:
+            man_prep_info_df.to_csv(self.prep_man_csv_path, index=False)
 
     def __drop_unnecessary_provenance_fiels(
         self, *, record: colrev.record.Record
@@ -334,9 +344,14 @@ class ExportManPrep(JsonSchemaMixin):
 
     def __print_export_prep_man_instructions(self) -> None:
         print("Created two files:")
-        print(
-            f" - {self.prep_man_csv_path.relative_to(self.review_manager.path)}  (CSV file)"
-        )
+        if platform.system() == "Windows":
+            print(
+                f" - {self.prep_man_xlsx_path.relative_to(self.review_manager.path)}  (EXCEL file)"
+            )
+        else:
+            print(
+                f" - {self.prep_man_csv_path.relative_to(self.review_manager.path)}  (CSV file)"
+            )
         print(
             f" - {self.prep_man_bib_path.relative_to(self.review_manager.path)}       (BIB file)"
         )

--- a/colrev/ops/built_in/prep_man/prep_man_export.py
+++ b/colrev/ops/built_in/prep_man/prep_man_export.py
@@ -116,7 +116,7 @@ class ExportManPrep(JsonSchemaMixin):
                     pdf_reader = PdfFileReader(str(record["file"]), strict=False)
                     if len(pdf_reader.pages) >= 1:
                         writer = PdfFileWriter()
-                        writer.addPage(pdf_reader.getPage(0))
+                        writer.addPage(pdf_reader.pages[0])
                         with open(target_path, "wb") as outfile:
                             writer.write(outfile)
 

--- a/colrev/ops/built_in/prep_man/prep_man_export.py
+++ b/colrev/ops/built_in/prep_man/prep_man_export.py
@@ -169,7 +169,7 @@ class ExportManPrep(JsonSchemaMixin):
         man_prep_info_df = pd.DataFrame(man_prep_info)
         if platform.system() == "Windows":
             with pd.ExcelWriter(self.prep_man_xlsx_path) as writer:
-                man_prep_info_df.to_excel(writer)
+                man_prep_info_df.to_excel(writer, index=False)
         else:
             man_prep_info_df.to_csv(self.prep_man_csv_path, index=False)
 

--- a/tests/2_ops/prep_man_operation_test.py
+++ b/tests/2_ops/prep_man_operation_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 """Tests of the CoLRev prep-man operation"""
+import shutil
+from unittest.mock import patch
+
 import colrev.review_manager
 
 
@@ -12,3 +15,28 @@ def test_prep_man(  # type: ignore
     prep_man_operation = base_repo_review_manager.get_prep_man_operation()
     prep_man_operation.prep_man_stats()
     prep_man_operation.main()
+
+
+@patch("platform.system")
+def test_prep_man_excel_on_windows(  # type: ignore
+    platform_patcher,
+    base_repo_review_manager: colrev.review_manager.ReviewManager,
+    helpers,
+) -> None:
+    """Test the prep-man operation"""
+
+    # clear files
+    shutil.rmtree(base_repo_review_manager.prep_dir)
+    base_repo_review_manager.prep_dir.mkdir(parents=True)
+    # On Windows it should create an Excel file
+    platform_patcher.return_value = "Windows"
+    test_prep_man(base_repo_review_manager, helpers)
+    path = base_repo_review_manager.prep_dir / "records_prep_man_info.xlsx"
+    assert path.exists()
+
+    shutil.rmtree(base_repo_review_manager.prep_dir)
+    base_repo_review_manager.prep_dir.mkdir(parents=True)
+    platform_patcher.return_value = "Linux"
+    test_prep_man(base_repo_review_manager, helpers)
+    path = base_repo_review_manager.prep_dir / "records_prep_man_info.csv"
+    assert path.exists()

--- a/tests/2_ops/prep_man_operation_test.py
+++ b/tests/2_ops/prep_man_operation_test.py
@@ -23,7 +23,7 @@ def test_prep_man_excel_on_windows(  # type: ignore
     base_repo_review_manager: colrev.review_manager.ReviewManager,
     helpers,
 ) -> None:
-    """Test the prep-man operation"""
+    """Test the prep-man operation generating excel on windows"""
 
     # clear files
     shutil.rmtree(base_repo_review_manager.prep_dir)
@@ -33,6 +33,15 @@ def test_prep_man_excel_on_windows(  # type: ignore
     test_prep_man(base_repo_review_manager, helpers)
     path = base_repo_review_manager.prep_dir / "records_prep_man_info.xlsx"
     assert path.exists()
+
+
+@patch("platform.system")
+def test_prep_man_csv_on_linux(  # type: ignore
+    platform_patcher,
+    base_repo_review_manager: colrev.review_manager.ReviewManager,
+    helpers,
+) -> None:
+    """Test the prep-man operation generating csv on Linux"""
 
     shutil.rmtree(base_repo_review_manager.prep_dir)
     base_repo_review_manager.prep_dir.mkdir(parents=True)


### PR DESCRIPTION
Will detect user's platform and export CSV file in case it's Linux or any other OS except Windows. For Windows, an Excel file will be generated

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Exports CSV file on every OS

Issue Number: N/A

## What is the new behavior?

Generates Excel when in Windows, CSV when in Linux or other OS

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Replaced depreciated function, `getPage` with index access