### PR TITLE
Namespace fields

### DIFF
--- a/colrev/env/local_index.py
+++ b/colrev/env/local_index.py
@@ -563,6 +563,7 @@ class LocalIndex:
             self.thread_lock.acquire(timeout=60)
             cur = self.__get_sqlite_cursor()
             selected_row = None
+            print(f"{self.SELECT_ALL_QUERIES[self.RECORD_INDEX] } {query}")
             cur.execute(f"{self.SELECT_ALL_QUERIES[self.RECORD_INDEX] } {query}")
             for row in cur.fetchall():
                 selected_row = row
@@ -573,8 +574,8 @@ class LocalIndex:
                     record_dict=retrieved_record, include_file=False
                 )
                 records_to_return.append(colrev.record.Record(data=retrieved_record))
-        except sqlite3.OperationalError:
-            pass
+        except sqlite3.OperationalError as exc:
+            print(exc)
         finally:
             self.thread_lock.release()
 

--- a/colrev/ops/built_in/search_sources/abi_inform_proquest.py
+++ b/colrev/ops/built_in/search_sources/abi_inform_proquest.py
@@ -43,6 +43,7 @@ class ABIInformProQuestSearchSource(JsonSchemaMixin):
     ) -> None:
         self.search_source = from_dict(data_class=self.settings_class, data=settings)
         self.quality_model = source_operation.review_manager.get_qm()
+        self.review_manager = source_operation.review_manager
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
@@ -76,6 +77,38 @@ class ABIInformProQuestSearchSource(JsonSchemaMixin):
         """Not implemented"""
         return record
 
+    def __remove_duplicates(self, *, records: dict) -> None:
+        to_delete = []
+        for record in records.values():
+            if re.search(r"-\d{1,2}$", record["ID"]):
+                original_record_id = re.sub(r"-\d{1,2}$", "", record["ID"])
+                if original_record_id not in records:
+                    continue
+                original_record = records[original_record_id]
+
+                # Note: between duplicate records,
+                # there are variations in spelling and completeness
+                if (
+                    colrev.record.Record.get_record_similarity(
+                        record_a=colrev.record.Record(data=record),
+                        record_b=colrev.record.Record(data=original_record),
+                    )
+                    < 0.9
+                ):
+                    continue
+
+                if original_record_id not in records:
+                    continue
+                to_delete.append(record["ID"])
+        if to_delete:
+            for rid in to_delete:
+                self.review_manager.logger.info(f" remove duplicate {rid}")
+                del records[rid]
+
+            self.review_manager.dataset.save_records_dict_to_file(
+                records=records, save_path=self.search_source.filename
+            )
+
     def load(self, load_operation: colrev.ops.load.Load) -> dict:
         """Load the records from the SearchSource file"""
 
@@ -83,38 +116,7 @@ class ABIInformProQuestSearchSource(JsonSchemaMixin):
             records = colrev.ops.load_utils_bib.load_bib_file(
                 load_operation=load_operation, source=self.search_source
             )
-            to_delete = []
-            for record in records.values():
-                if re.search(r"-\d{1,2}$", record["ID"]):
-                    original_record_id = re.sub(r"-\d{1,2}$", "", record["ID"])
-                    if original_record_id not in records:
-                        continue
-                    original_record = records[original_record_id]
-
-                    # Note: between duplicate records,
-                    # there are variations in spelling and completeness
-                    if (
-                        colrev.record.Record.get_record_similarity(
-                            record_a=colrev.record.Record(data=record),
-                            record_b=colrev.record.Record(data=original_record),
-                        )
-                        < 0.9
-                    ):
-                        continue
-
-                    if original_record_id not in records:
-                        continue
-                    to_delete.append(record["ID"])
-            if to_delete:
-                for rid in to_delete:
-                    load_operation.review_manager.logger.info(
-                        f" remove duplicate {rid}"
-                    )
-                    del records[rid]
-
-                load_operation.review_manager.dataset.save_records_dict_to_file(
-                    records=records, save_path=self.search_source.filename
-                )
+            self.__remove_duplicates(records=records)
             return records
 
         raise NotImplementedError

--- a/colrev/ops/built_in/search_sources/aisel.py
+++ b/colrev/ops/built_in/search_sources/aisel.py
@@ -34,6 +34,7 @@ class AISeLibrarySearchSource(JsonSchemaMixin):
     settings_class = colrev.env.package_manager.DefaultSourceSettings
     source_identifier = "url"
     search_type = colrev.settings.SearchType.DB
+    endpoint = "colrev.ais_library"
     api_search_supported = True
     ci_supported: bool = True
     heuristic_status = colrev.env.package_manager.SearchSourceHeuristicStatus.supported
@@ -150,6 +151,10 @@ class AISeLibrarySearchSource(JsonSchemaMixin):
     def add_endpoint(cls, operation: colrev.ops.search.Search, params: str) -> None:
         """Add SearchSource as an endpoint (based on query provided to colrev search -a )"""
 
+        # if params is None:
+        #     operation.add_interactively(endpoint=cls.endpoint)
+        #     return
+
         params = params.lstrip("colrev.ais_library:").rstrip('"').lstrip('"')
 
         host = urlparse(params).hostname
@@ -158,7 +163,7 @@ class AISeLibrarySearchSource(JsonSchemaMixin):
             q_params = cls.__parse_query(query=params)
             filename = operation.get_unique_filename(file_path_string="ais")
             add_source = colrev.settings.SearchSource(
-                endpoint="colrev.ais_library",
+                endpoint=cls.endpoint,
                 filename=filename,
                 search_type=colrev.settings.SearchType.DB,
                 search_parameters={"query": q_params},

--- a/colrev/ops/built_in/search_sources/colrev_project.py
+++ b/colrev/ops/built_in/search_sources/colrev_project.py
@@ -36,6 +36,7 @@ class ColrevProjectSearchSource(JsonSchemaMixin):
     settings_class = colrev.env.package_manager.DefaultSourceSettings
     source_identifier = "colrev_project_identifier"
     search_type = colrev.settings.SearchType.OTHER
+    endpoint = "colrev.colrev_project"
     api_search_supported = True
     ci_supported: bool = True
     heuristic_status = colrev.env.package_manager.SearchSourceHeuristicStatus.supported
@@ -71,12 +72,17 @@ class ColrevProjectSearchSource(JsonSchemaMixin):
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.search.Search, params: str) -> None:
         """Add SearchSource as an endpoint (based on query provided to colrev search -a )"""
+
+        if params is None:
+            operation.add_interactively(endpoint=cls.endpoint)
+            return
+
         if params.startswith("url="):
             filename = operation.get_unique_filename(
                 file_path_string=params.split("/")[-1]
             )
             add_source = colrev.settings.SearchSource(
-                endpoint="colrev.colrev_project",
+                endpoint=cls.endpoint,
                 filename=filename,
                 search_type=colrev.settings.SearchType.OTHER,
                 search_parameters={"scope": {"url": params[4:]}},

--- a/colrev/ops/built_in/search_sources/crossref.py
+++ b/colrev/ops/built_in/search_sources/crossref.py
@@ -660,7 +660,7 @@ class CrossrefSearchSource(JsonSchemaMixin):
         params = self.search_source.search_parameters
 
         if "query" in params and "mode" not in params:
-            crossref_query = {"bibliographic": params["query"]}
+            crossref_query = {"bibliographic": params["query"].replace(" ", "+")}
             # potential extension : add the container_title:
             # crossref_query_return = works.query(
             #     container_title=
@@ -1055,8 +1055,6 @@ class CrossrefSearchSource(JsonSchemaMixin):
 
         # if query_type == "k":
         keywords = input("Enter the keywords:")
-        keywords = keywords.replace(" ", "+")
-        # query = f"https://search.crossref.org/?q={keywords}"
 
         filename = operation.get_unique_filename(
             file_path_string=f"crossref_{keywords}"

--- a/colrev/ops/built_in/search_sources/dblp.py
+++ b/colrev/ops/built_in/search_sources/dblp.py
@@ -41,6 +41,7 @@ class DBLPSearchSource(JsonSchemaMixin):
 
     source_identifier = "dblp_key"
     search_type = colrev.settings.SearchType.DB
+    endpoint = "colrev.dblp"
     api_search_supported = True
     ci_supported: bool = True
     heuristic_status = colrev.env.package_manager.SearchSourceHeuristicStatus.supported
@@ -95,7 +96,7 @@ class DBLPSearchSource(JsonSchemaMixin):
                 self.search_source = dblp_md_source_l[0]
             else:
                 self.search_source = colrev.settings.SearchSource(
-                    endpoint="colrev.dblp",
+                    endpoint=self.endpoint,
                     filename=self.__dblp_md_filename,
                     search_type=colrev.settings.SearchType.OTHER,
                     search_parameters={},
@@ -571,6 +572,10 @@ class DBLPSearchSource(JsonSchemaMixin):
     def add_endpoint(cls, operation: colrev.ops.search.Search, params: str) -> None:
         """Add SearchSource as an endpoint (based on query provided to colrev search -a )"""
 
+        if params is None:
+            operation.add_interactively(endpoint=cls.endpoint)
+            return
+
         if (
             "https://dblp.org/search?q=" in params
             or "https://dblp.org/search/publ?q=" in params
@@ -583,7 +588,7 @@ class DBLPSearchSource(JsonSchemaMixin):
                 file_path_string=f"dblp_{params.replace(cls.__api_url, '')}"
             )
             add_source = colrev.settings.SearchSource(
-                endpoint="colrev.dblp",
+                endpoint=cls.endpoint,
                 filename=filename,
                 search_type=colrev.settings.SearchType.DB,
                 search_parameters={"query": params},
@@ -651,8 +656,11 @@ class DBLPSearchSource(JsonSchemaMixin):
             for retrieved_record in self.__retrieve_dblp_records(
                 query=query,
             ):
-                if "dblp_key" in record.data:
-                    if retrieved_record.data["dblp_key"] != record.data["dblp_key"]:
+                if "colrev.dblp.dblp_key" in record.data:
+                    if (
+                        retrieved_record.data["dblp_key"]
+                        != record.data["colrev.dblp.dblp_key"]
+                    ):
                         continue
 
                 similarity = colrev.record.PrepRecord.get_retrieval_similarity(

--- a/colrev/ops/built_in/search_sources/dblp.py
+++ b/colrev/ops/built_in/search_sources/dblp.py
@@ -620,10 +620,10 @@ class DBLPSearchSource(JsonSchemaMixin):
                 source="dblp",
                 keep_source_if_equal=True,
             )
-        record.remove_field(key="bibsource")
+        record.remove_field(key="colrev.dblp.bibsource")
         if any(x in record.data.get("url", "") for x in ["dblp.org", "doi.org"]):
             record.remove_field(key="url")
-        record.remove_field(key="timestamp")
+        record.remove_field(key="colrev.dblp.timestamp")
 
         return record
 

--- a/colrev/ops/built_in/search_sources/europe_pmc.py
+++ b/colrev/ops/built_in/search_sources/europe_pmc.py
@@ -47,6 +47,7 @@ class EuropePMCSearchSource(JsonSchemaMixin):
     # settings_class = colrev.env.package_manager.DefaultSourceSettings
     source_identifier = "europe_pmc_id"
     search_type = colrev.settings.SearchType.DB
+    endpoint = "colrev.europe_pmc"
     api_search_supported = True
     ci_supported: bool = True
     heuristic_status = colrev.env.package_manager.SearchSourceHeuristicStatus.supported
@@ -102,7 +103,7 @@ class EuropePMCSearchSource(JsonSchemaMixin):
                 self.search_source = europe_pmc_md_source_l[0]
             else:
                 self.search_source = colrev.settings.SearchSource(
-                    endpoint="colrev.europe_pmc",
+                    endpoint=self.endpoint,
                     filename=self.__europe_pmc_md_filename,
                     search_type=colrev.settings.SearchType.OTHER,
                     search_parameters={},
@@ -522,6 +523,10 @@ class EuropePMCSearchSource(JsonSchemaMixin):
     def add_endpoint(cls, operation: colrev.ops.search.Search, params: str) -> None:
         """Add SearchSource as an endpoint (based on query provided to colrev search -a )"""
 
+        if params is None:
+            operation.add_interactively(endpoint=cls.endpoint)
+            return
+
         host = urlparse(params).hostname
 
         if host and host.endswith("europepmc.org"):
@@ -533,7 +538,7 @@ class EuropePMCSearchSource(JsonSchemaMixin):
                 + params
             )
             add_source = colrev.settings.SearchSource(
-                endpoint="colrev.europe_pmc",
+                endpoint=cls.endpoint,
                 filename=filename,
                 search_type=colrev.settings.SearchType.DB,
                 search_parameters={"query": params},

--- a/colrev/ops/built_in/search_sources/ieee.py
+++ b/colrev/ops/built_in/search_sources/ieee.py
@@ -33,6 +33,7 @@ class IEEEXploreSearchSource(JsonSchemaMixin):
     settings_class = colrev.env.package_manager.DefaultSourceSettings
     source_identifier = "ID"
     search_type = colrev.settings.SearchType.DB
+    endpoint = "colrev.ieee"
     api_search_supported = True
     ci_supported: bool = True
     heuristic_status = colrev.env.package_manager.SearchSourceHeuristicStatus.oni
@@ -103,7 +104,7 @@ class IEEEXploreSearchSource(JsonSchemaMixin):
             )
         else:
             self.search_source = colrev.settings.SearchSource(
-                endpoint="colrev.ieee",
+                endpoint=self.endpoint,
                 filename=Path("data/search/ieee.bib"),
                 search_type=colrev.settings.SearchType.OTHER,
                 search_parameters={},
@@ -124,6 +125,11 @@ class IEEEXploreSearchSource(JsonSchemaMixin):
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.search.Search, params: str) -> None:
         """Add SearchSource as an endpoint (based on query provided to colrev search -a )"""
+
+        if params is None:
+            operation.add_interactively(endpoint=cls.endpoint)
+            return
+
         if "https://ieeexploreapi.ieee.org/api/v1/search/articles?" in params:
             params = params.replace(
                 "https://ieeexploreapi.ieee.org/api/v1/search/articles?", ""
@@ -142,7 +148,7 @@ class IEEEXploreSearchSource(JsonSchemaMixin):
             )
 
             add_source = colrev.settings.SearchSource(
-                endpoint="colrev.ieee",
+                endpoint=cls.endpoint,
                 filename=filename,
                 search_type=colrev.settings.SearchType.DB,
                 search_parameters=search_parameters,

--- a/colrev/ops/built_in/search_sources/open_alex.py
+++ b/colrev/ops/built_in/search_sources/open_alex.py
@@ -134,7 +134,7 @@ class OpenAlexSearchSource(JsonSchemaMixin):
                 record_dict["ENTRYTYPE"] = "misc"
 
         record_dict = {}
-        record_dict["openalex_id"] = item["id"].replace("https://openalex.org/", "")
+        record_dict["id"] = item["id"].replace("https://openalex.org/", "")
         if "title" in item and item["title"] is not None:
             record_dict["title"] = item["title"].lstrip("[").rstrip("].")
         set_entrytype(record_dict=record_dict, item=item)
@@ -180,7 +180,7 @@ class OpenAlexSearchSource(JsonSchemaMixin):
     ) -> colrev.record.Record:
         try:
             retrieved_record = self.__parse_item_to_record(
-                item=Works()[record.data["openalex_id"]]
+                item=Works()[record.data["colrev.open_alex.id"]]
             )
 
             self.open_alex_lock.acquire(timeout=120)
@@ -229,7 +229,7 @@ class OpenAlexSearchSource(JsonSchemaMixin):
     ) -> colrev.record.Record:
         """Retrieve masterdata from OpenAlex based on similarity with the record provided"""
 
-        if "openalex_id" not in record.data:
+        if "colrev.open_alex.id" not in record.data:
             # Note: not yet implemented
             # https://github.com/OpenAPC/openapc-de/blob/master/python/import_dois.py
             # if len(record.data.get("title", "")) < 35 and "doi" not in record.data:

--- a/colrev/ops/built_in/search_sources/psycinfo.py
+++ b/colrev/ops/built_in/search_sources/psycinfo.py
@@ -135,4 +135,8 @@ class PsycINFOSearchSource(JsonSchemaMixin):
     ) -> colrev.record.Record:
         """Source-specific preparation for PsycINFO"""
 
+        record.rename_field(
+            key="colrev.psycinfo.pubmedid", new_key="colrev.pubmed.pubmedid"
+        )
+
         return record

--- a/colrev/ops/built_in/search_sources/scopus.py
+++ b/colrev/ops/built_in/search_sources/scopus.py
@@ -102,34 +102,42 @@ class ScopusSearchSource(JsonSchemaMixin):
                 record.rename_field(key="title", new_key="booktitle")
                 record.rename_field(key="journal", new_key="title")
 
-        if "document_type" in record.data:
-            if record.data["document_type"] == "Conference Paper":
+        if "colrev.scopus.document_type" in record.data:
+            if record.data["colrev.scopus.document_type"] == "Conference Paper":
                 record.change_entrytype(
                     new_entrytype="inproceedings", qm=self.quality_model
                 )
 
-            elif record.data["document_type"] == "Conference Review":
+            elif record.data["colrev.scopus.document_type"] == "Conference Review":
                 record.change_entrytype(
                     new_entrytype="proceedings", qm=self.quality_model
                 )
 
-            elif record.data["document_type"] == "Article":
+            elif record.data["colrev.scopus.document_type"] == "Article":
                 record.change_entrytype(new_entrytype="article", qm=self.quality_model)
 
-            record.remove_field(key="document_type")
+            record.remove_field(key="colrev.scopus.document_type")
 
-        if "Start_Page" in record.data and "End_Page" in record.data:
-            if record.data["Start_Page"] != "nan" and record.data["End_Page"] != "nan":
+        if (
+            "colrev.scopus.Start_Page" in record.data
+            and "colrev.scopus.End_Page" in record.data
+        ):
+            if (
+                record.data["colrev.scopus.Start_Page"] != "nan"
+                and record.data["colrev.scopus.End_Page"] != "nan"
+            ):
                 record.data["pages"] = (
-                    record.data["Start_Page"] + "--" + record.data["End_Page"]
+                    record.data["colrev.scopus.Start_Page"]
+                    + "--"
+                    + record.data["colrev.scopus.End_Page"]
                 )
                 record.data["pages"] = record.data["pages"].replace(".0", "")
-                record.remove_field(key="Start_Page")
-                record.remove_field(key="End_Page")
+                record.remove_field(key="colrev.scopus.Start_Page")
+                record.remove_field(key="colrev.scopus.End_Page")
 
-        if "note" in record.data:
-            if "cited By " in record.data["note"]:
-                record.rename_field(key="note", new_key="cited_by")
+        if "colrev.scopus.note" in record.data:
+            if "cited By " in record.data["colrev.scopus.note"]:
+                record.rename_field(key="colrev.scopus.note", new_key="cited_by")
                 record.data["cited_by"] = record.data["cited_by"].replace(
                     "cited By ", ""
                 )
@@ -137,7 +145,6 @@ class ScopusSearchSource(JsonSchemaMixin):
         if "author" in record.data:
             record.data["author"] = record.data["author"].replace("; ", " and ")
 
-        record.remove_field(key="source")
-        record.remove_field(key="art_number")
+        record.remove_field(key="colrev.scopus.source")
 
         return record

--- a/colrev/ops/built_in/search_sources/synergy_datasets.py
+++ b/colrev/ops/built_in/search_sources/synergy_datasets.py
@@ -326,6 +326,16 @@ class SYNERGYDatasetsSearchSource(JsonSchemaMixin):
         self, record: colrev.record.Record, source: colrev.settings.SearchSource
     ) -> colrev.record.Record:
         """Source-specific preparation for SYNERGY-datasets"""
-        if not any(x in record.data for x in ["pmid", "doi", "openalex_id"]):
+
+        record.rename_field(
+            key="colrev.synergy_datasets.pubmedid", new_key="colrev.pubmed.pubmedid"
+        )
+        record.rename_field(
+            key="colrev.synergy_datasets.openalex_id", new_key="colrev.open_alex.id"
+        )
+        if not any(
+            x in record.data
+            for x in ["colrev.pubmed.pubmedid", "doi", "colrev.open_alex.id"]
+        ):
             record.prescreen_exclude(reason="no-metadata-available")
         return record

--- a/colrev/ops/built_in/search_sources/taylor_and_francis.py
+++ b/colrev/ops/built_in/search_sources/taylor_and_francis.py
@@ -99,8 +99,10 @@ class TaylorAndFrancisSearchSource(JsonSchemaMixin):
             r"PMID: \d*", record.data["colrev.taylor_and_francis.note"]
         ):
             record.rename_field(
-                key="colrev.taylor_and_francis.note", new_key="pubmed.pubmedid"
+                key="colrev.taylor_and_francis.note", new_key="colrev.pubmed.pubmedid"
             )
-            record.data["pubmed.pubmedid"] = record.data["pubmed.pubmedid"][6:]
+            record.data["colrev.pubmed.pubmedid"] = record.data[
+                "colrev.pubmed.pubmedid"
+            ][6:]
 
         return record

--- a/colrev/ops/built_in/search_sources/taylor_and_francis.py
+++ b/colrev/ops/built_in/search_sources/taylor_and_francis.py
@@ -94,11 +94,13 @@ class TaylorAndFrancisSearchSource(JsonSchemaMixin):
         """Source-specific preparation for Taylor and Francis"""
 
         # remove eprint and URL fields (they only have dois...)
-        record.remove_field(key="url")
-        record.remove_field(key="eprint")
-        if "note" in record.data and re.match(r"PMID: \d*", record.data["note"]):
-            record.rename_field(key="note", new_key="pmid")
-            record.data["pmid"] = record.data["pmid"][6:]
-        record.remove_field(key="publisher")
+        record.remove_field(key="colrev.taylor_and_francis.eprint")
+        if "colrev.taylor_and_francis.note" in record.data and re.match(
+            r"PMID: \d*", record.data["colrev.taylor_and_francis.note"]
+        ):
+            record.rename_field(
+                key="colrev.taylor_and_francis.note", new_key="pubmed.pubmedid"
+            )
+            record.data["pubmed.pubmedid"] = record.data["pubmed.pubmedid"][6:]
 
         return record

--- a/colrev/ops/built_in/search_sources/unknown_source.py
+++ b/colrev/ops/built_in/search_sources/unknown_source.py
@@ -448,6 +448,8 @@ class UnknownSearchSource(JsonSchemaMixin):
         if not record.has_quality_defects() or record.masterdata_is_curated():
             return record
 
+        # TODO : assign fields (e.g., to colrev.pubmed.pubmedid)
+
         self.__heuristically_fix_entrytypes(
             record=record,
         )

--- a/colrev/ops/built_in/search_sources/web_of_science.py
+++ b/colrev/ops/built_in/search_sources/web_of_science.py
@@ -113,7 +113,7 @@ class WebOfScienceSearchSource(JsonSchemaMixin):
         record.format_if_mostly_upper(key="booktitle", case="title")
         record.format_if_mostly_upper(key="author", case="title")
 
-        record.remove_field(key="researcherid-numbers")
-        record.remove_field(key="orcid-numbers")
+        record.remove_field(key="colrev.web_of_science.researcherid-numbers")
+        record.remove_field(key="colrev.web_of_science.orcid-numbers")
 
         return record

--- a/colrev/ops/built_in/search_sources/wiley.py
+++ b/colrev/ops/built_in/search_sources/wiley.py
@@ -82,6 +82,10 @@ class WileyOnlineLibrarySearchSource(JsonSchemaMixin):
             records = colrev.ops.load_utils_bib.load_bib_file(
                 load_operation=load_operation, source=self.search_source
             )
+            for record_dict in records.values():
+                if "eprint" not in record_dict:
+                    continue
+                record_dict["fulltext"] = record_dict.pop("eprint")
             return records
 
         raise NotImplementedError
@@ -91,12 +95,8 @@ class WileyOnlineLibrarySearchSource(JsonSchemaMixin):
     ) -> colrev.record.Record:
         """Source-specific preparation for Wiley"""
 
-        record.rename_field(key="eprint", new_key="fulltext")
-
         if record.data.get("ENTRYTYPE", "") == "inbook":
             record.rename_field(key="title", new_key="chapter")
             record.rename_field(key="booktitle", new_key="title")
-
-        record.rename_field(key="eprint", new_key="fulltext")
 
         return record

--- a/colrev/ops/load.py
+++ b/colrev/ops/load.py
@@ -384,6 +384,14 @@ class Load(colrev.operation.Operation):
         self.__setup_source_for_load(source=source)
         records = self.review_manager.dataset.load_records_dict()
         for source_record in source.search_source.source_records_list:
+            # prefix non-standardized field keys
+            for key in list(source_record.keys()):
+                if key in colrev.record.Record.standardized_field_keys:
+                    continue
+                source_record[
+                    f"{source.search_source.endpoint}.{key}"
+                ] = source_record.pop(key)
+
             source_record = self.__import_record(record_dict=source_record)
 
             # Make sure not to replace existing records
@@ -397,6 +405,7 @@ class Load(colrev.operation.Operation):
                     appends = list(itertools.product(letters, repeat=order))
                 next_unique_id = source_record["ID"] + "".join(list(appends.pop(0)))
             source_record["ID"] = next_unique_id
+
             records[source_record["ID"]] = source_record
 
             self.review_manager.logger.info(

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -120,6 +120,25 @@ class Search(colrev.operation.Operation):
 
         return check_accepts
 
+    def add_interactively(self, *, endpoint: str) -> None:
+        """Add a SearchSource interactively"""
+        print(f"Interactively add {endpoint} as a SearchSource")
+        print()
+
+        keywords = input("Enter the keywords:")
+
+        filename = self.get_unique_filename(
+            file_path_string=f"{endpoint.replace('colrev.', '')}_{keywords}"
+        )
+        add_source = colrev.settings.SearchSource(
+            endpoint=endpoint,
+            filename=filename,
+            search_type=colrev.settings.SearchType.DB,
+            search_parameters={"query": keywords},
+            comment="",
+        )
+        self.review_manager.settings.sources.append(add_source)
+
     @check_source_selection_exists(  # pylint: disable=too-many-function-args
         "selection_str"
     )

--- a/colrev/ops/trace.py
+++ b/colrev/ops/trace.py
@@ -94,7 +94,10 @@ class Trace(colrev.operation.Operation):
 
         prev_record: dict = {}
         for commit in reversed(list(revlist)):
-            filecontents = (commit.tree / "data" / "records.bib").data_stream.read()
+            try:
+                filecontents = (commit.tree / "data" / "records.bib").data_stream.read()
+            except KeyError:
+                continue
 
             commit_message_first_line = str(commit.message).partition("\n")[0]
 

--- a/colrev/ops/upgrade.py
+++ b/colrev/ops/upgrade.py
@@ -405,6 +405,32 @@ class Upgrade(colrev.operation.Operation):
     def __migrate_0_9_3(self) -> bool:
         records = self.review_manager.dataset.load_records_dict()
         for record_dict in records.values():
+            # TODO : call methods in repare.py
+
+            if "pubmedid" in record_dict:
+                record = colrev.record.Record(data=record_dict)
+                record.rename_field(key="pubmedid", new_key="colrev.pubmed.pubmedid")
+
+            if "pii" in record_dict:
+                record = colrev.record.Record(data=record_dict)
+                record.rename_field(key="pii", new_key="colrev.pubmed.pii")
+
+            if "pmc" in record_dict:
+                record = colrev.record.Record(data=record_dict)
+                record.rename_field(key="pmc", new_key="colrev.pubmed.pmc")
+
+            if "label_included" in record_dict:
+                record = colrev.record.Record(data=record_dict)
+                record.rename_field(
+                    key="label_included",
+                    new_key="colrev.synergy_datasets.label_included",
+                )
+            if "method" in record_dict:
+                record = colrev.record.Record(data=record_dict)
+                record.rename_field(
+                    key="method", new_key="colrev.synergy_datasets.method"
+                )
+
             if "dblp_key" in record_dict:
                 record = colrev.record.Record(data=record_dict)
                 record.rename_field(key="dblp_key", new_key="colrev.dblp.dblp_key")

--- a/colrev/ops/upgrade.py
+++ b/colrev/ops/upgrade.py
@@ -423,10 +423,7 @@ class Upgrade(colrev.operation.Operation):
             # TODO : update open_alex source
             if "openalex_id" in record_dict:
                 record = colrev.record.Record(data=record_dict)
-                record.rename_field(
-                    key="openalex_id", new_key="colrev.open_alex.id"
-                )
-
+                record.rename_field(key="openalex_id", new_key="colrev.open_alex.id")
 
         self.review_manager.dataset.save_records_dict(records=records)
         self.review_manager.dataset.add_record_changes()

--- a/colrev/record.py
+++ b/colrev/record.py
@@ -89,6 +89,30 @@ class Record:
 
     time_variant_fields = ["cited_by"]
 
+    # TODO : link to CEP
+    standardized_field_keys = (
+        identifying_field_keys
+        + provenance_keys
+        + [
+            "ID",
+            "ENTRYTYPE",
+            "doi",
+            "url",
+            "issn",
+            "isbn",
+            "fulltext",
+            "abstract",
+            "keywords",
+            "cited_by",
+            "file",
+            "institution",
+            "month",
+            "series",
+            "language",
+        ]
+    )
+    """Standardized field keys"""
+
     pp = pprint.PrettyPrinter(indent=4, width=140, compact=False)
 
     def __init__(self, *, data: dict) -> None:

--- a/colrev/settings.py
+++ b/colrev/settings.py
@@ -202,7 +202,7 @@ class SearchSource(JsonSchemaMixin):
 
     def get_origin_prefix(self) -> str:
         """Get the corresponding origin prefix"""
-        assert ";" not in str(self.filename.name)
+        assert not any(x in str(self.filename.name) for x in [";", "/"])
         return (
             str(self.filename.name)
             .replace(str(colrev.review_manager.ReviewManager.SEARCHDIR_RELATIVE), "")

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -2187,11 +2187,10 @@ def validate(
 
     \b
     The validation scope argument can be
-    - a commit-sha,
-    - a commit tree,
+    - A commit-sha,
     - '.' for the latest commit,
     - HEAD~4 for commit 4 before HEAD
-    - a contributor name
+    - A contributor name
     """
 
     review_manager = get_review_manager(

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.aisel.AISeLibrarySearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.aisel.AISeLibrarySearchSource.rst
@@ -42,6 +42,7 @@ colrev.ops.built\_in.search\_sources.aisel.AISeLibrarySearchSource
 
       ~AISeLibrarySearchSource.api_search_supported
       ~AISeLibrarySearchSource.ci_supported
+      ~AISeLibrarySearchSource.endpoint
       ~AISeLibrarySearchSource.heuristic_status
       ~AISeLibrarySearchSource.link
       ~AISeLibrarySearchSource.search_type

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.colrev_project.ColrevProjectSearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.colrev_project.ColrevProjectSearchSource.rst
@@ -42,6 +42,7 @@ colrev.ops.built\_in.search\_sources.colrev\_project.ColrevProjectSearchSource
 
       ~ColrevProjectSearchSource.api_search_supported
       ~ColrevProjectSearchSource.ci_supported
+      ~ColrevProjectSearchSource.endpoint
       ~ColrevProjectSearchSource.heuristic_status
       ~ColrevProjectSearchSource.link
       ~ColrevProjectSearchSource.search_type

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.dblp.DBLPSearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.dblp.DBLPSearchSource.rst
@@ -43,6 +43,7 @@ colrev.ops.built\_in.search\_sources.dblp.DBLPSearchSource
 
       ~DBLPSearchSource.api_search_supported
       ~DBLPSearchSource.ci_supported
+      ~DBLPSearchSource.endpoint
       ~DBLPSearchSource.heuristic_status
       ~DBLPSearchSource.link
       ~DBLPSearchSource.search_type

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.eric.ERICSearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.eric.ERICSearchSource.rst
@@ -45,6 +45,7 @@ colrev.ops.built\_in.search\_sources.eric.ERICSearchSource
       ~ERICSearchSource.FIELD_MAPPING
       ~ERICSearchSource.api_search_supported
       ~ERICSearchSource.ci_supported
+      ~ERICSearchSource.endpoint
       ~ERICSearchSource.heuristic_status
       ~ERICSearchSource.link
       ~ERICSearchSource.search_type

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.europe_pmc.EuropePMCSearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.europe_pmc.EuropePMCSearchSource.rst
@@ -42,6 +42,7 @@ colrev.ops.built\_in.search\_sources.europe\_pmc.EuropePMCSearchSource
 
       ~EuropePMCSearchSource.api_search_supported
       ~EuropePMCSearchSource.ci_supported
+      ~EuropePMCSearchSource.endpoint
       ~EuropePMCSearchSource.heuristic_status
       ~EuropePMCSearchSource.link
       ~EuropePMCSearchSource.search_type

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.ieee.IEEEXploreSearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.ieee.IEEEXploreSearchSource.rst
@@ -45,6 +45,7 @@ colrev.ops.built\_in.search\_sources.ieee.IEEEXploreSearchSource
       ~IEEEXploreSearchSource.SETTINGS
       ~IEEEXploreSearchSource.api_search_supported
       ~IEEEXploreSearchSource.ci_supported
+      ~IEEEXploreSearchSource.endpoint
       ~IEEEXploreSearchSource.flag
       ~IEEEXploreSearchSource.heuristic_status
       ~IEEEXploreSearchSource.link

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.local_index.LocalIndexSearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.local_index.LocalIndexSearchSource.rst
@@ -43,6 +43,7 @@ colrev.ops.built\_in.search\_sources.local\_index.LocalIndexSearchSource
 
       ~LocalIndexSearchSource.api_search_supported
       ~LocalIndexSearchSource.ci_supported
+      ~LocalIndexSearchSource.endpoint
       ~LocalIndexSearchSource.essential_md_keys
       ~LocalIndexSearchSource.heuristic_status
       ~LocalIndexSearchSource.link

--- a/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.pubmed.PubMedSearchSource.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.built_in.search_sources.pubmed.PubMedSearchSource.rst
@@ -43,6 +43,7 @@ colrev.ops.built\_in.search\_sources.pubmed.PubMedSearchSource
 
       ~PubMedSearchSource.api_search_supported
       ~PubMedSearchSource.ci_supported
+      ~PubMedSearchSource.endpoint
       ~PubMedSearchSource.heuristic_status
       ~PubMedSearchSource.link
       ~PubMedSearchSource.search_type

--- a/docs/source/foundations/_autosummary/colrev.ops.search.Search.rst
+++ b/docs/source/foundations/_autosummary/colrev.ops.search.Search.rst
@@ -16,6 +16,7 @@ colrev.ops.search.Search
    .. autosummary::
       :nosignatures:
 
+      ~Search.add_interactively
       ~Search.check_precondition
       ~Search.check_source_selection_exists
       ~Search.conclude

--- a/docs/source/foundations/_autosummary/colrev.record.PrepRecord.rst
+++ b/docs/source/foundations/_autosummary/colrev.record.PrepRecord.rst
@@ -91,5 +91,6 @@ colrev.record.PrepRecord
       ~PrepRecord.pp
       ~PrepRecord.preferred_sources
       ~PrepRecord.provenance_keys
+      ~PrepRecord.standardized_field_keys
       ~PrepRecord.time_variant_fields
       ~PrepRecord.data

--- a/docs/source/foundations/_autosummary/colrev.record.Record.rst
+++ b/docs/source/foundations/_autosummary/colrev.record.Record.rst
@@ -81,5 +81,6 @@ colrev.record.Record
       ~Record.pp
       ~Record.preferred_sources
       ~Record.provenance_keys
+      ~Record.standardized_field_keys
       ~Record.time_variant_fields
       ~Record.data

--- a/tests/data/built_in_search_sources/acm_result.bib
+++ b/tests/data/built_in_search_sources/acm_result.bib
@@ -8,7 +8,10 @@
                                     volume:acm.bib/10.1111/7777777;;
                                     year:acm.bib/10.1111/7777777;;},
    colrev_data_provenance        = {abstract:acm.bib/10.1111/7777777;;
-                                    articleno:acm.bib/10.1111/7777777;;
+                                    colrev.acm_digital_library.address:acm.bib/10.1111/7777777;;
+                                    colrev.acm_digital_library.articleno:acm.bib/10.1111/7777777;;
+                                    colrev.acm_digital_library.issue_date:acm.bib/10.1111/7777777;;
+                                    colrev.acm_digital_library.numpages:acm.bib/10.1111/7777777;;
                                     doi:acm.bib/10.1111/7777777;;
                                     keywords:acm.bib/10.1111/7777777;;},
    doi                           = {10.3333/7777777},
@@ -19,7 +22,10 @@
    volume                        = {4},
    number                        = {1},
    abstract                      = {This is an exciting paper abstract.},
-   articleno                     = {4},
+   colrev.acm_digital_library.address  = {New York, NY, USA},
+   colrev.acm_digital_library.articleno  = {4},
+   colrev.acm_digital_library.issue_date  = {March 1900},
+   colrev.acm_digital_library.numpages  = {54},
    keywords                      = {creative writing, funny writing, lazy writing},
 }
 
@@ -33,11 +39,13 @@
                                     year:acm.bib/10.2222/7777777.7777778;year-format;
                                     isbn:ORIGINAL;inconsistent-with-entrytype;},
    colrev_data_provenance        = {abstract:acm.bib/10.2222/7777777.7777778;;
-                                    articleno:acm.bib/10.2222/7777777.7777778;;
+                                    colrev.acm_digital_library.address:acm.bib/10.2222/7777777.7777778;;
+                                    colrev.acm_digital_library.articleno:acm.bib/10.2222/7777777.7777778;;
+                                    colrev.acm_digital_library.location:acm.bib/10.2222/7777777.7777778;;
+                                    colrev.acm_digital_library.numpages:acm.bib/10.2222/7777777.7777778;;
                                     doi:acm.bib/10.2222/7777777.7777778;;
                                     isbn:acm.bib/10.2222/7777777.7777778;;
                                     keywords:acm.bib/10.2222/7777777.7777778;;
-                                    location:acm.bib/10.2222/7777777.7777778;;
                                     series:acm.bib/10.2222/7777777.7777778;;},
    doi                           = {10.2222/7777777.7777778},
    author                        = {Proceedingswriter, Susan},
@@ -46,10 +54,12 @@
    year                          = {888},
    pages                         = {123--456},
    abstract                      = {This is an exciting abstract.},
-   articleno                     = {999999999999999999999},
+   colrev.acm_digital_library.address  = {New York, NY, USA},
+   colrev.acm_digital_library.articleno  = {999999999999999999999},
+   colrev.acm_digital_library.location  = {Barcelona, Spain},
+   colrev.acm_digital_library.numpages  = {99},
    isbn                          = {2222222222222},
    keywords                      = {ghostwriting, structure, organisation},
-   location                      = {Barcelona, Spain},
    series                        = {Ghostwriter '17},
 }
 

--- a/tests/data/built_in_search_sources/dblp_result.bib
+++ b/tests/data/built_in_search_sources/dblp_result.bib
@@ -8,7 +8,7 @@
                                     publisher:dblp.bib/DBLP:conf/shortconferencename/Articlewriter19;;
                                     title:dblp.bib/DBLP:conf/shortconferencename/Articlewriter19;;
                                     year:dblp.bib/DBLP:conf/shortconferencename/Articlewriter19;;},
-   colrev_data_provenance        = {biburl:dblp.bib/DBLP:conf/shortconferencename/Articlewriter19;;
+   colrev_data_provenance        = {colrev.dblp.biburl:dblp.bib/DBLP:conf/shortconferencename/Articlewriter19;;
                                     doi:dblp.bib/DBLP:conf/shortconferencename/Articlewriter19;;},
    doi                           = {10.3333/7777777.7777778},
    author                        = {Articlewriter, Tom},
@@ -18,7 +18,7 @@
    pages                         = {465:1--465:20},
    editor                        = {Editorowner, Lisa},
    publisher                     = {{IDONTKNOW}},
-   biburl                        = {https://dblp.org/rec/conf/idontknow/Articlewriter19.bib},
+   colrev.dblp.biburl            = {https://dblp.org/rec/conf/idontknow/Articlewriter19.bib},
 }
 
 @article{Articlewriter2022,
@@ -31,7 +31,7 @@
                                     title:dblp.bib/DBLP:journals/shortjournalname/Articlewriter22;;
                                     volume:dblp.bib/DBLP:journals/shortjournalname/Articlewriter22;;
                                     year:dblp.bib/DBLP:journals/shortjournalname/Articlewriter22;;},
-   colrev_data_provenance        = {biburl:dblp.bib/DBLP:journals/shortjournalname/Articlewriter22;;
+   colrev_data_provenance        = {colrev.dblp.biburl:dblp.bib/DBLP:journals/shortjournalname/Articlewriter22;;
                                     doi:dblp.bib/DBLP:journals/shortjournalname/Articlewriter22;;},
    doi                           = {10.1111/7777777},
    author                        = {Articlewriter, Tom},
@@ -41,6 +41,6 @@
    volume                        = {6},
    number                        = {78},
    pages                         = {1--20},
-   biburl                        = {https://dblp.org/rec/journals/jfew/Articlewriter22.bib},
+   colrev.dblp.biburl            = {https://dblp.org/rec/journals/jfew/Articlewriter22.bib},
 }
 

--- a/tests/data/built_in_search_sources/pdfs_dir_result.bib
+++ b/tests/data/built_in_search_sources/pdfs_dir_result.bib
@@ -20,14 +20,14 @@
                                     booktitle:pdfs_dir.bib/0000000259;;
                                     title:pdfs_dir.bib/0000000259;;
                                     year:pdfs_dir.bib/0000000259;;},
-   colrev_data_provenance        = {file:pdfs_dir.bib/0000000259;;
-                                    note:pdfs_dir.bib/0000000259;;},
+   colrev_data_provenance        = {colrev.pdfs_dir.note:pdfs_dir.bib/0000000259;;
+                                    file:pdfs_dir.bib/0000000259;;},
    file                          = {data/pdfs/1997/Underwood1997.pdf},
    author                        = {Underwood, Jim},
    booktitle                     = {Pacific Asia Conference on Information Systems},
    title                         = {Discovering Meaning in IS Design},
    year                          = {1997},
-   note                          = {Contents},
+   colrev.pdfs_dir.note          = {Contents},
 }
 
 @inproceedings{PauleenHarmerSanders2007,

--- a/tests/data/built_in_search_sources/psycinfo_result.bib
+++ b/tests/data/built_in_search_sources/psycinfo_result.bib
@@ -12,7 +12,7 @@
    colrev_data_provenance        = {abstract:psycinfo.ris/00001;;
                                     doi:psycinfo.ris/00001;;
                                     keywords:psycinfo.ris/00001;;
-                                    pubmedid:psycinfo.ris/00001;;},
+                                    colrev.pubmed.pubmedid:psycinfo.ris/00001|rename-from:colrev.psycinfo.pubmedid;;},
    doi                           = {10.1011/HEA0004444},
    author                        = {Author-One, Matthias and Author-Two, Martin and Author-Three, Hans E. and Author-Four, Bob and Author-Five, David B.},
    journal                       = {Journal/Periodical name: full format},
@@ -23,7 +23,7 @@
    pages                         = {1023--1095},
    publisher                     = {Publisher},
    abstract                      = {Abstract. This is a free text field and can contain alphanumeric characters. There is no practical length limit to this field.},
+   colrev.pubmed.pubmedid        = {33355555},
    keywords                      = {*Keyword one, *Keyword two, *Keyword three, *Keyword four, *Keyword five, Keyword six without asterisk, Keyword seven without asterisk, Keyword eight without asterisk},
-   pubmedid                      = {33355555},
 }
 

--- a/tests/data/built_in_search_sources/pubmed_result.bib
+++ b/tests/data/built_in_search_sources/pubmed_result.bib
@@ -8,10 +8,10 @@
                                     title:pubmed.csv/1;;
                                     volume:pubmed.csv/1;;
                                     year:pubmed.csv/1;;},
-   colrev_data_provenance        = {create_date:pubmed.csv/1;;
-                                    doi:pubmed.csv/1;;
-                                    pmcid:pubmed.csv/1;;
-                                    pmid:pubmed.csv/1;;},
+   colrev_data_provenance        = {colrev.pubmed.create_date:pubmed.csv/1;;
+                                    colrev.pubmed.pmcid:pubmed.csv/1;;
+                                    colrev.pubmed.pmid:pubmed.csv/1;;
+                                    doi:pubmed.csv/1;;},
    doi                           = {10.1111/NATURE1111},
    author                        = {Smith, A and Walter, B},
    journal                       = {Nature},
@@ -20,8 +20,8 @@
    volume                        = {1},
    number                        = {2},
    pages                         = {10--11},
-   create_date                   = {2021/12/21},
-   pmcid                         = {PMC1122334},
-   pmid                          = {11223344},
+   colrev.pubmed.create_date     = {2021/12/21},
+   colrev.pubmed.pmcid           = {PMC1122334},
+   colrev.pubmed.pmid            = {11223344},
 }
 

--- a/tests/data/built_in_search_sources/scopus_result.bib
+++ b/tests/data/built_in_search_sources/scopus_result.bib
@@ -7,9 +7,10 @@
                                     title:scopus.bib/Articlewriter2022;;
                                     volume:scopus.bib/Articlewriter2022;;
                                     year:scopus.bib/Articlewriter2022;;},
-   colrev_data_provenance        = {doi:scopus.bib/Articlewriter2022;;
+   colrev_data_provenance        = {colrev.scopus.art_number:scopus.bib/Articlewriter2022;;
+                                    doi:scopus.bib/Articlewriter2022;;
                                     url:scopus.bib/Articlewriter2022;;
-                                    cited_by:scopus.bib/Articlewriter2022|rename-from:note;;},
+                                    cited_by:scopus.bib/Articlewriter2022|rename-from:colrev.scopus.note;;},
    doi                           = {10.1222/2222222.2022.2222222},
    author                        = {Articlewriter, C.},
    journal                       = {Public Dummy Review Two},
@@ -19,6 +20,7 @@
    number                        = {999},
    url                           = {https://www.scopus.com/inward/record.uri?eid=2222222222222222222},
    cited_by                      = {0},
+   colrev.scopus.art_number      = {333444},
 }
 
 @inproceedings{Conferencepaperwriter2022,
@@ -29,9 +31,10 @@
                                     volume:scopus.bib/Conferencepaperwriter2022;;
                                     year:scopus.bib/Conferencepaperwriter2022;;
                                     booktitle:scopus.bib/Conferencepaperwriter2022|rename-from:journal;;},
-   colrev_data_provenance        = {doi:scopus.bib/Conferencepaperwriter2022;;
+   colrev_data_provenance        = {colrev.scopus.art_number:scopus.bib/Conferencepaperwriter2022;;
+                                    doi:scopus.bib/Conferencepaperwriter2022;;
                                     url:scopus.bib/Conferencepaperwriter2022;;
-                                    cited_by:scopus.bib/Conferencepaperwriter2022|rename-from:note;;},
+                                    cited_by:scopus.bib/Conferencepaperwriter2022|rename-from:colrev.scopus.note;;},
    doi                           = {10.1000/1.1000001},
    author                        = {Conferencepaperwriter, A.},
    booktitle                     = {Public Dummy Review Ten},
@@ -40,6 +43,7 @@
    volume                        = {1999},
    url                           = {https://www.scopus.com/inward/record.uri?eid=101010101010101010},
    cited_by                      = {0},
+   colrev.scopus.art_number      = {224444},
 }
 
 @book{BookchapterwriterBookwritertwoBookwriterthreeEtAl2021,
@@ -53,7 +57,7 @@
                                     title:scopus.bib/Bookchapterwriter202150|rename-from:journal;;},
    colrev_data_provenance        = {doi:scopus.bib/Bookchapterwriter202150;;
                                     url:scopus.bib/Bookchapterwriter202150;;
-                                    cited_by:scopus.bib/Bookchapterwriter202150|rename-from:note;;},
+                                    cited_by:scopus.bib/Bookchapterwriter202150|rename-from:colrev.scopus.note;;},
    doi                           = {10.18888/888-8-8888-8888-8.CH008},
    author                        = {Bookchapterwriter, I.I. and Bookwritertwo, M.Y. and Bookwriterthree, V.A. and Bookwriterfour, N.A.},
    booktitle                     = {Book classified as document_type Book Chapter},
@@ -76,7 +80,7 @@
                                     booktitle:scopus.bib/Conferencepaper2022775|rename-from:journal;;},
    colrev_data_provenance        = {doi:scopus.bib/Conferencepaper2022775;;
                                     url:scopus.bib/Conferencepaper2022775;;
-                                    cited_by:scopus.bib/Conferencepaper2022775|rename-from:note;;},
+                                    cited_by:scopus.bib/Conferencepaper2022775|rename-from:colrev.scopus.note;;},
    doi                           = {10.1011/111-111-11-1111-1_11},
    author                        = {Conferencepaper, M.},
    booktitle                     = {Public Dummy Review Eleven},
@@ -97,9 +101,10 @@
                                     volume:scopus.bib/Datapaperwriter2019;;
                                     year:scopus.bib/Datapaperwriter2019;;
                                     number:generic_field_requirements;missing;},
-   colrev_data_provenance        = {doi:scopus.bib/Datapaperwriter2019;;
+   colrev_data_provenance        = {colrev.scopus.art_number:scopus.bib/Datapaperwriter2019;;
+                                    doi:scopus.bib/Datapaperwriter2019;;
                                     url:scopus.bib/Datapaperwriter2019;;
-                                    cited_by:scopus.bib/Datapaperwriter2019|rename-from:note;;},
+                                    cited_by:scopus.bib/Datapaperwriter2019|rename-from:colrev.scopus.note;;},
    doi                           = {10.1333/33333.2019.3333333},
    author                        = {Datapaperwriter, T. and Seconddatawriter, D.},
    journal                       = {Public Dummy Review Three},
@@ -109,6 +114,7 @@
    number                        = {UNKNOWN},
    url                           = {https://www.scopus.com/inward/record.uri?eid=33333333333333333333},
    cited_by                      = {4},
+   colrev.scopus.art_number      = {133331},
 }
 
 @article{EditorialwriterSecondeditorialwriter2021,
@@ -123,7 +129,7 @@
                                     year:scopus.bib/Editorialwriter2021133;;},
    colrev_data_provenance        = {doi:scopus.bib/Editorialwriter2021133;;
                                     url:scopus.bib/Editorialwriter2021133;;
-                                    cited_by:scopus.bib/Editorialwriter2021133|rename-from:note;;},
+                                    cited_by:scopus.bib/Editorialwriter2021133|rename-from:colrev.scopus.note;;},
    doi                           = {10.1444/44444444444444},
    author                        = {Editorialwriter, G. and Secondeditorialwriter, S.},
    journal                       = {Public Dummy Review Four},
@@ -148,7 +154,7 @@
                                     number:generic_field_requirements;missing;},
    colrev_data_provenance        = {doi:scopus.bib/Erratumwriter2018314;;
                                     url:scopus.bib/Erratumwriter2018314;;
-                                    cited_by:scopus.bib/Erratumwriter2018314|rename-from:note;;},
+                                    cited_by:scopus.bib/Erratumwriter2018314|rename-from:colrev.scopus.note;;},
    doi                           = {10.15555/5555555555.2017.555555},
    author                        = {Erratumwriter, S. and Erratumwritertwo, T.},
    journal                       = {Public Dummy Review Five},
@@ -172,7 +178,7 @@
                                     number:generic_field_requirements;missing;},
    colrev_data_provenance        = {doi:scopus.bib/Firstwriter2022;;
                                     url:scopus.bib/Firstwriter2022;;
-                                    cited_by:scopus.bib/Firstwriter2022|rename-from:note;;},
+                                    cited_by:scopus.bib/Firstwriter2022|rename-from:colrev.scopus.note;;},
    doi                           = {10.1111/88888888.2022.7777777},
    author                        = {Firstwriter, Z. and Secondwriter, T. and Thirdwriter, L.},
    journal                       = {Public Dummy Review One},
@@ -194,7 +200,7 @@
                                     booktitle:scopus.bib/NoAuthor2013a|rename-from:journal;;
                                     editor:generic_field_requirements;missing;},
    colrev_data_provenance        = {url:scopus.bib/NoAuthor2013a;;
-                                    cited_by:scopus.bib/NoAuthor2013a|rename-from:note;;},
+                                    cited_by:scopus.bib/NoAuthor2013a|rename-from:colrev.scopus.note;;},
    booktitle                     = {Public Dummy Review Twelve},
    title                         = {Conference classified as document_type Conference Review},
    year                          = {2013},
@@ -216,7 +222,7 @@
                                     year:scopus.bib/Notewriter2017349;;},
    colrev_data_provenance        = {doi:scopus.bib/Notewriter2017349;;
                                     url:scopus.bib/Notewriter2017349;;
-                                    cited_by:scopus.bib/Notewriter2017349|rename-from:note;;},
+                                    cited_by:scopus.bib/Notewriter2017349|rename-from:colrev.scopus.note;;},
    doi                           = {10.1666/6666666666666},
    author                        = {Notewriter, F.},
    journal                       = {Public Dummy Review Six},
@@ -238,9 +244,10 @@
                                     title:scopus.bib/Reviewwriter2021;;
                                     volume:scopus.bib/Reviewwriter2021;;
                                     year:scopus.bib/Reviewwriter2021;;},
-   colrev_data_provenance        = {doi:scopus.bib/Reviewwriter2021;;
+   colrev_data_provenance        = {colrev.scopus.art_number:scopus.bib/Reviewwriter2021;;
+                                    doi:scopus.bib/Reviewwriter2021;;
                                     url:scopus.bib/Reviewwriter2021;;
-                                    cited_by:scopus.bib/Reviewwriter2021|rename-from:note;;},
+                                    cited_by:scopus.bib/Reviewwriter2021|rename-from:colrev.scopus.note;;},
    doi                           = {10.6116/JJJJ.RANDOMDOI.2021.666999},
    author                        = {Reviewwriter, G. and Secondreviewwriter, J},
    journal                       = {Public Dummy Review Seven},
@@ -250,5 +257,6 @@
    number                        = {4},
    url                           = {https://www.scopus.com/inward/record.uri?eid=2-s2.0-85116700878&doi=10.6116%2fjjjj.randomdoi.2021.666999&partnerID=40&md5=9d70d186602f569a36b870da6080624a},
    cited_by                      = {0},
+   colrev.scopus.art_number      = {666999},
 }
 

--- a/tests/data/built_in_search_sources/taylor_and_francis_result.bib
+++ b/tests/data/built_in_search_sources/taylor_and_francis_result.bib
@@ -5,11 +5,13 @@
                                     journal:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
                                     number:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
                                     pages:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
+                                    publisher:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
                                     title:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
                                     volume:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
                                     year:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;},
    colrev_data_provenance        = {doi:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
-                                    pmid:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666|rename-from:note;;},
+                                    url:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
+                                    pubmed.pubmedid:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666|rename-from:colrev.taylor_and_francis.note;;},
    doi                           = {10.1111/07777777.2018.1666666},
    author                        = {Does, Tandf and Follow, Not and Conventions, Naming},
    journal                       = {Journal of Dummy article engineering},
@@ -18,7 +20,9 @@
    volume                        = {99},
    number                        = {9},
    pages                         = {199--222},
-   pmid                          = {33355555},
+   publisher                     = {Taylor & Francis},
+   url                           = {https://doi.org/10.1111/07777777.2018.1666666},
+   pubmed.pubmedid               = {33355555},
 }
 
 @article{LastnameMusterMusterfrau2019,
@@ -28,11 +32,13 @@
                                     journal:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
                                     number:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
                                     pages:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
+                                    publisher:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
                                     title:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
                                     volume:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
                                     year:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;},
    colrev_data_provenance        = {doi:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
-                                    pmid:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444|rename-from:note;;},
+                                    url:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
+                                    pubmed.pubmedid:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444|rename-from:colrev.taylor_and_francis.note;;},
    doi                           = {10.1122/07777777.2018.3334444},
    author                        = {Lastname, Firstname A. and Muster, Tom and Musterfrau, Ashley},
    journal                       = {Journal of Dummy Sciences},
@@ -41,6 +47,8 @@
    volume                        = {69},
    number                        = {2},
    pages                         = {1400--14114059},
-   pmid                          = {33314444},
+   publisher                     = {Routledge},
+   url                           = {https://doi.org/10.1122/07777777.2018.3334444},
+   pubmed.pubmedid               = {33314444},
 }
 

--- a/tests/data/built_in_search_sources/taylor_and_francis_result.bib
+++ b/tests/data/built_in_search_sources/taylor_and_francis_result.bib
@@ -11,7 +11,7 @@
                                     year:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;},
    colrev_data_provenance        = {doi:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
                                     url:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666;;
-                                    pubmed.pubmedid:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666|rename-from:colrev.taylor_and_francis.note;;},
+                                    colrev.pubmed.pubmedid:taylor_and_francis.bib/doi:10.1111/07777777.2018.1666666|rename-from:colrev.taylor_and_francis.note;;},
    doi                           = {10.1111/07777777.2018.1666666},
    author                        = {Does, Tandf and Follow, Not and Conventions, Naming},
    journal                       = {Journal of Dummy article engineering},
@@ -22,7 +22,7 @@
    pages                         = {199--222},
    publisher                     = {Taylor & Francis},
    url                           = {https://doi.org/10.1111/07777777.2018.1666666},
-   pubmed.pubmedid               = {33355555},
+   colrev.pubmed.pubmedid        = {33355555},
 }
 
 @article{LastnameMusterMusterfrau2019,
@@ -38,7 +38,7 @@
                                     year:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;},
    colrev_data_provenance        = {doi:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
                                     url:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444;;
-                                    pubmed.pubmedid:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444|rename-from:colrev.taylor_and_francis.note;;},
+                                    colrev.pubmed.pubmedid:taylor_and_francis.bib/doi:10.1122/07777777.2018.3334444|rename-from:colrev.taylor_and_francis.note;;},
    doi                           = {10.1122/07777777.2018.3334444},
    author                        = {Lastname, Firstname A. and Muster, Tom and Musterfrau, Ashley},
    journal                       = {Journal of Dummy Sciences},
@@ -49,6 +49,6 @@
    pages                         = {1400--14114059},
    publisher                     = {Routledge},
    url                           = {https://doi.org/10.1122/07777777.2018.3334444},
-   pubmed.pubmedid               = {33314444},
+   colrev.pubmed.pubmedid        = {33314444},
 }
 

--- a/tests/data/built_in_search_sources/web_of_science_result.bib
+++ b/tests/data/built_in_search_sources/web_of_science_result.bib
@@ -12,9 +12,7 @@
    colrev_data_provenance        = {colrev.web_of_science.book-group-author:web_of_science.bib/WOS:000223334444221;;
                                     colrev.web_of_science.eissn:web_of_science.bib/WOS:000223334444221;;
                                     colrev.web_of_science.note:web_of_science.bib/WOS:000223334444221;;
-                                    colrev.web_of_science.orcid-numbers:web_of_science.bib/WOS:000223334444221;;
                                     colrev.web_of_science.organization:web_of_science.bib/WOS:000223334444221;;
-                                    colrev.web_of_science.researcherid-numbers:web_of_science.bib/WOS:000223334444221;;
                                     colrev.web_of_science.unique-id:web_of_science.bib/WOS:000223334444221;;
                                     doi:web_of_science.bib/WOS:000223334444221;;
                                     isbn:web_of_science.bib/WOS:000223334444221;;
@@ -31,9 +29,7 @@
    colrev.web_of_science.book-group-author  = {Author},
    colrev.web_of_science.eissn   = {1111-3333},
    colrev.web_of_science.note    = {Placeholder for Notes},
-   colrev.web_of_science.orcid-numbers  = {Writerone, Julia/0000-0002-2222-4444 Writertwo, Paul/0000-0002-3333-5555},
    colrev.web_of_science.organization  = {Some; Institution},
-   colrev.web_of_science.researcherid-numbers  = {Writerone, Julia/GLU-2222-2022 Writertwo, Paul/F-3333-2012},
    colrev.web_of_science.unique-id  = {WOS:000223334444221},
    isbn                          = {999-9-999-99999-9; 999-8-888-99999-8},
    issn                          = {0111-9119},
@@ -53,8 +49,6 @@
    colrev_data_provenance        = {colrev.web_of_science.article-number:web_of_science.bib/WOS:000444488888888;;
                                     colrev.web_of_science.earlyaccessdate:web_of_science.bib/WOS:000444488888888;;
                                     colrev.web_of_science.eissn:web_of_science.bib/WOS:000444488888888;;
-                                    colrev.web_of_science.orcid-numbers:web_of_science.bib/WOS:000444488888888;;
-                                    colrev.web_of_science.researcherid-numbers:web_of_science.bib/WOS:000444488888888;;
                                     colrev.web_of_science.unique-id:web_of_science.bib/WOS:000444488888888;;
                                     doi:web_of_science.bib/WOS:000444488888888;;
                                     issn:web_of_science.bib/WOS:000444488888888;;
@@ -70,8 +64,6 @@
    colrev.web_of_science.article-number  = {6756},
    colrev.web_of_science.earlyaccessdate  = {FEB 2022},
    colrev.web_of_science.eissn   = {4444-1223},
-   colrev.web_of_science.orcid-numbers  = {Articlewriter, Julian/0000-0001-3333-5555},
-   colrev.web_of_science.researcherid-numbers  = {Articlewriter, Julian/E-4444-2010},
    colrev.web_of_science.unique-id  = {WOS:000444488888888},
    issn                          = {4444-1221},
    month                         = {MAR 1},

--- a/tests/data/built_in_search_sources/web_of_science_result.bib
+++ b/tests/data/built_in_search_sources/web_of_science_result.bib
@@ -9,15 +9,17 @@
                                     volume:web_of_science.bib/WOS:000223334444221;;
                                     year:web_of_science.bib/WOS:000223334444221;;
                                     isbn:ORIGINAL;inconsistent-with-entrytype,isbn-not-matching-pattern;},
-   colrev_data_provenance        = {book-group-author:web_of_science.bib/WOS:000223334444221;;
+   colrev_data_provenance        = {colrev.web_of_science.book-group-author:web_of_science.bib/WOS:000223334444221;;
+                                    colrev.web_of_science.eissn:web_of_science.bib/WOS:000223334444221;;
+                                    colrev.web_of_science.note:web_of_science.bib/WOS:000223334444221;;
+                                    colrev.web_of_science.orcid-numbers:web_of_science.bib/WOS:000223334444221;;
+                                    colrev.web_of_science.organization:web_of_science.bib/WOS:000223334444221;;
+                                    colrev.web_of_science.researcherid-numbers:web_of_science.bib/WOS:000223334444221;;
+                                    colrev.web_of_science.unique-id:web_of_science.bib/WOS:000223334444221;;
                                     doi:web_of_science.bib/WOS:000223334444221;;
-                                    eissn:web_of_science.bib/WOS:000223334444221;;
                                     isbn:web_of_science.bib/WOS:000223334444221;;
                                     issn:web_of_science.bib/WOS:000223334444221;;
-                                    note:web_of_science.bib/WOS:000223334444221;;
-                                    organization:web_of_science.bib/WOS:000223334444221;;
-                                    series:web_of_science.bib/WOS:000223334444221;;
-                                    unique-id:web_of_science.bib/WOS:000223334444221;;},
+                                    series:web_of_science.bib/WOS:000223334444221;;},
    doi                           = {10.1007/999-9-999-99999-9\_3},
    author                        = {Writerone, Julia and Writertwo, Paul},
    booktitle                     = {A Booktitle},
@@ -26,14 +28,16 @@
    volume                        = {123456},
    pages                         = {48--98},
    editor                        = {Editorone, M and Editortwo, M},
-   book-group-author             = {Author},
-   eissn                         = {1111-3333},
+   colrev.web_of_science.book-group-author  = {Author},
+   colrev.web_of_science.eissn   = {1111-3333},
+   colrev.web_of_science.note    = {Placeholder for Notes},
+   colrev.web_of_science.orcid-numbers  = {Writerone, Julia/0000-0002-2222-4444 Writertwo, Paul/0000-0002-3333-5555},
+   colrev.web_of_science.organization  = {Some; Institution},
+   colrev.web_of_science.researcherid-numbers  = {Writerone, Julia/GLU-2222-2022 Writertwo, Paul/F-3333-2012},
+   colrev.web_of_science.unique-id  = {WOS:000223334444221},
    isbn                          = {999-9-999-99999-9; 999-8-888-99999-8},
    issn                          = {0111-9119},
-   note                          = {Placeholder for Notes},
-   organization                  = {Some; Institution},
    series                        = {Dummy Lecture Notes},
-   unique-id                     = {WOS:000223334444221},
 }
 
 @article{ArticlewriterGuestwriter2022,
@@ -46,13 +50,15 @@
                                     title:web_of_science.bib/WOS:000444488888888;;
                                     volume:web_of_science.bib/WOS:000444488888888;;
                                     year:web_of_science.bib/WOS:000444488888888;;},
-   colrev_data_provenance        = {article-number:web_of_science.bib/WOS:000444488888888;;
+   colrev_data_provenance        = {colrev.web_of_science.article-number:web_of_science.bib/WOS:000444488888888;;
+                                    colrev.web_of_science.earlyaccessdate:web_of_science.bib/WOS:000444488888888;;
+                                    colrev.web_of_science.eissn:web_of_science.bib/WOS:000444488888888;;
+                                    colrev.web_of_science.orcid-numbers:web_of_science.bib/WOS:000444488888888;;
+                                    colrev.web_of_science.researcherid-numbers:web_of_science.bib/WOS:000444488888888;;
+                                    colrev.web_of_science.unique-id:web_of_science.bib/WOS:000444488888888;;
                                     doi:web_of_science.bib/WOS:000444488888888;;
-                                    earlyaccessdate:web_of_science.bib/WOS:000444488888888;;
-                                    eissn:web_of_science.bib/WOS:000444488888888;;
                                     issn:web_of_science.bib/WOS:000444488888888;;
-                                    month:web_of_science.bib/WOS:000444488888888;;
-                                    unique-id:web_of_science.bib/WOS:000444488888888;;},
+                                    month:web_of_science.bib/WOS:000444488888888;;},
    doi                           = {10.1111/ARTJUL.2021.0011},
    author                        = {Articlewriter, Julian and Guestwriter, Paul},
    journal                       = {Dummy Journal for nice writing},
@@ -61,11 +67,13 @@
    volume                        = {22},
    number                        = {3},
    pages                         = {111--188},
-   article-number                = {6756},
-   earlyaccessdate               = {FEB 2022},
-   eissn                         = {4444-1223},
+   colrev.web_of_science.article-number  = {6756},
+   colrev.web_of_science.earlyaccessdate  = {FEB 2022},
+   colrev.web_of_science.eissn   = {4444-1223},
+   colrev.web_of_science.orcid-numbers  = {Articlewriter, Julian/0000-0001-3333-5555},
+   colrev.web_of_science.researcherid-numbers  = {Articlewriter, Julian/E-4444-2010},
+   colrev.web_of_science.unique-id  = {WOS:000444488888888},
    issn                          = {4444-1221},
    month                         = {MAR 1},
-   unique-id                     = {WOS:000444488888888},
 }
 

--- a/tests/data/built_in_search_sources/wiley_result.bib
+++ b/tests/data/built_in_search_sources/wiley_result.bib
@@ -9,10 +9,10 @@
                                     title:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29|rename-from:booktitle;;},
    colrev_data_provenance        = {abstract:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29;;
                                     doi:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29;;
+                                    fulltext:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29;;
                                     isbn:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29;;
                                     keywords:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29;;
-                                    url:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29;;
-                                    fulltext:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29|rename-from:eprint;;},
+                                    url:wiley.bib/doi:https://doi.org/10.1111/1111222233334.ch29;;},
    doi                           = {10.1111/1111222233334.CH29},
    author                        = {Inbookwriter, Luise},
    title                         = {Dummy in Practice},
@@ -39,9 +39,9 @@
                                     year:wiley.bib/https://doi.org/10.1111/gps.4444;;},
    colrev_data_provenance        = {abstract:wiley.bib/https://doi.org/10.1111/gps.4444;;
                                     doi:wiley.bib/https://doi.org/10.1111/gps.4444;;
+                                    fulltext:wiley.bib/https://doi.org/10.1111/gps.4444;;
                                     keywords:wiley.bib/https://doi.org/10.1111/gps.4444;;
-                                    url:wiley.bib/https://doi.org/10.1111/gps.4444;;
-                                    fulltext:wiley.bib/https://doi.org/10.1111/gps.4444|rename-from:eprint;;},
+                                    url:wiley.bib/https://doi.org/10.1111/gps.4444;;},
    doi                           = {10.1111/GPS.4444},
    author                        = {Writerone, Davide and Writertwo, Horst and Writerthree, Olaf},
    journal                       = {International Journal of Dummy Writing},


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Upon load, the original field names are used, assuming that the same field name corresponds to the same meaning. This is not always the case (e.g., for the ``note`` field or the ``method`` field). Fields that are not part of the standardized fields (see colrev.record.Record) should be prefixed with a "namespace".

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Upon import, non-standardized fields are prefixed with a namespace.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

``colrev upgrade`` should update existing field names.