### PR TITLE
Refactored ENLLoader to match new API

### DIFF
--- a/colrev/ops/built_in/search_sources/aisel.py
+++ b/colrev/ops/built_in/search_sources/aisel.py
@@ -413,13 +413,7 @@ class AISeLibrarySearchSource(JsonSchemaMixin):
 
         entrytype_map = {
             "Journal Article": ENTRYTYPES.ARTICLE,
-            "HICSS": ENTRYTYPES.INPROCEEDINGS,
-            "ICIS": ENTRYTYPES.INPROCEEDINGS,
-            "ECIS": ENTRYTYPES.INPROCEEDINGS,
-            "AMCIS": ENTRYTYPES.INPROCEEDINGS,
-            "Proceedings": ENTRYTYPES.INPROCEEDINGS,
             "Inproceedings": ENTRYTYPES.INPROCEEDINGS,
-            "All Sprouts Content": ENTRYTYPES.INPROCEEDINGS,
         }
 
         # pylint: disable=colrev-missed-constant-usage
@@ -441,7 +435,6 @@ class AISeLibrarySearchSource(JsonSchemaMixin):
                 record_dict["ID"] = record_dict[Fields.URL].replace(
                     "https://aisel.aisnet.org/", ""
                 )
-            # records = enl_loader.convert_to_records(entries=records, enl_mapping=enl_mapping)
             return records
 
         # for API-based searches

--- a/colrev/ops/built_in/search_sources/unknown_source.py
+++ b/colrev/ops/built_in/search_sources/unknown_source.py
@@ -339,7 +339,7 @@ class UnknownSearchSource(JsonSchemaMixin):
                 "8": "date",
                 "0": "type",
             },
-            ENTRYTYPES.INPROCEEDINGS: {
+            ENTRYTYPES.MISC: {
                 "T": Fields.TITLE,
                 "A": Fields.AUTHOR,
                 "D": Fields.YEAR,
@@ -356,13 +356,7 @@ class UnknownSearchSource(JsonSchemaMixin):
 
         entrytype_map = {
             "Journal Article": ENTRYTYPES.ARTICLE,
-            "HICSS": ENTRYTYPES.INPROCEEDINGS,
-            "ICIS": ENTRYTYPES.INPROCEEDINGS,
-            "ECIS": ENTRYTYPES.INPROCEEDINGS,
-            "AMCIS": ENTRYTYPES.INPROCEEDINGS,
-            "Proceedings": ENTRYTYPES.INPROCEEDINGS,
-            "Inproceedings": ENTRYTYPES.INPROCEEDINGS,
-            "All Sprouts Content": ENTRYTYPES.INPROCEEDINGS,
+            "Inproceedings": ENTRYTYPES.MISC,
         }
 
         list_fields = {"A": " and "}

--- a/colrev/ops/built_in/search_sources/unknown_source.py
+++ b/colrev/ops/built_in/search_sources/unknown_source.py
@@ -325,11 +325,69 @@ class UnknownSearchSource(JsonSchemaMixin):
         return records
 
     def __load_enl(self, *, load_operation: colrev.ops.load.Load) -> dict:
+        enl_mapping = {
+            ENTRYTYPES.ARTICLE: {
+                "T": Fields.TITLE,
+                "A": Fields.AUTHOR,
+                "D": Fields.YEAR,
+                "B": Fields.JOURNAL,
+                "V": Fields.VOLUME,
+                "N": Fields.NUMBER,
+                "P": Fields.PAGES,
+                "X": Fields.ABSTRACT,
+                "U": Fields.URL,
+                "8": "date",
+                "0": "type",
+            },
+            ENTRYTYPES.INPROCEEDINGS: {
+                "T": Fields.TITLE,
+                "A": Fields.AUTHOR,
+                "D": Fields.YEAR,
+                "B": Fields.JOURNAL,
+                "V": Fields.VOLUME,
+                "N": Fields.NUMBER,
+                "P": Fields.PAGES,
+                "X": Fields.ABSTRACT,
+                "U": Fields.URL,
+                "8": "date",
+                "0": "type",
+            },
+        }
+
+        entrytype_map = {
+            "Journal Article": ENTRYTYPES.ARTICLE,
+            "HICSS": ENTRYTYPES.INPROCEEDINGS,
+            "ICIS": ENTRYTYPES.INPROCEEDINGS,
+            "ECIS": ENTRYTYPES.INPROCEEDINGS,
+            "AMCIS": ENTRYTYPES.INPROCEEDINGS,
+            "Proceedings": ENTRYTYPES.INPROCEEDINGS,
+            "Inproceedings": ENTRYTYPES.INPROCEEDINGS,
+            "All Sprouts Content": ENTRYTYPES.INPROCEEDINGS,
+        }
+
+        list_fields = {"A": " and "}
         enl_loader = colrev.ops.load_utils_enl.ENLLoader(
-            load_operation=load_operation, source=self.search_source
+            load_operation=load_operation,
+            source=self.search_source,
+            list_fields=list_fields,
         )
-        entries = enl_loader.load_enl_entries()
-        records = enl_loader.convert_to_records(entries=entries)
+        records = enl_loader.load_enl_entries()
+
+        for record_dict in records.values():
+            if "0" not in record_dict:
+                keys_to_check = ["V", "N"]
+                if any([k in record_dict for k in keys_to_check]):
+                    record_dict["0"] = "Journal Article"
+                else:
+                    record_dict["0"] = "Inproceedings"
+            enl_loader.apply_entrytype_mapping(
+                record_dict=record_dict, entrytype_map=entrytype_map
+            )
+            enl_loader.map_keys(record_dict=record_dict, key_map=enl_mapping)
+            record_dict["ID"] = record_dict[Fields.URL].replace(
+                "https://aisel.aisnet.org/", ""
+            )
+
         return records
 
     def load(self, load_operation: colrev.ops.load.Load) -> dict:

--- a/colrev/ops/load_utils_enl.py
+++ b/colrev/ops/load_utils_enl.py
@@ -30,7 +30,7 @@ import re
 import typing
 from typing import TYPE_CHECKING
 
-from colrev.constants import ENTRYTYPES
+from colrev.constants import Colors
 from colrev.constants import Fields
 
 if TYPE_CHECKING:
@@ -57,6 +57,7 @@ class ENLLoader:
         *,
         load_operation: colrev.ops.load.Load,
         source: colrev.settings.SearchSource,
+        list_fields: dict,
         unique_id_field: str = "",
     ):
         self.load_operation = load_operation
@@ -65,20 +66,7 @@ class ENLLoader:
 
         self.current: dict = {}
         self.pattern = re.compile(self.PATTERN)
-        self.mapping = {
-            "T": Fields.TITLE,
-            "A": Fields.AUTHOR,
-            "D": Fields.YEAR,
-            "B": Fields.JOURNAL,
-            "V": Fields.VOLUME,
-            "N": Fields.NUMBER,
-            "P": Fields.PAGES,
-            "X": Fields.ABSTRACT,
-            "U": Fields.URL,
-            "8": "date",
-            "0": "type",
-        }
-        self.list_tags = {"A": " and "}
+        self.list_fields = list_fields
 
     def is_tag(self, line: str) -> bool:
         """Determine if the line has a tag using regex."""
@@ -104,16 +92,12 @@ class ENLLoader:
             self.current[name] = [value]
 
     def _add_tag(self, tag: str, line: str) -> None:
-        if tag not in self.mapping:
-            print(f"load_utils_enl error: tag {tag} not in mapping")
-            return
-        name = self.mapping[tag]
         new_value = self.get_content(line)
 
-        if tag in self.list_tags:
-            self._add_list_value(name, new_value)
+        if tag in self.list_fields:
+            self._add_list_value(tag, new_value)
         else:
-            self._add_single_value(name, new_value)
+            self._add_single_value(tag, new_value)
 
     def _parse_tag(self, line: str) -> dict:
         tag = self.get_tag(line)
@@ -150,34 +134,45 @@ class ENLLoader:
 
         records = {}
         for ind, record in enumerate(records_list):
-            record[Fields.ID] = str(ind).rjust(6, "0")
+            record[Fields.ID] = str(ind + 1).rjust(6, "0")
+            for list_field, connective in self.list_fields.items():
+                if list_field in record:
+                    record[list_field] = connective.join(record[list_field])
             records[record[Fields.ID]] = record
-
         return records
 
-    def convert_to_records(self, *, entries: dict) -> dict:
+    def apply_entrytype_mapping(
+        self, *, record_dict: dict, entrytype_map: dict
+    ) -> None:
+        typ = record_dict["0"]
+        if typ not in entrytype_map:
+            msg = f"{Colors.RED}0={typ} not yet supported{Colors.END}"
+            if not self.load_operation.review_manager.force_mode:
+                raise NotImplementedError(msg)
+
+            self.load_operation.review_manager.logger.error(msg)
+            return
+
+        entrytype = entrytype_map[typ]
+        record_dict[Fields.ENTRYTYPE] = entrytype
+
+    def map_keys(self, *, record_dict: dict, key_map: dict) -> dict:
         """Converts enl entries it to bib records"""
+        entrytype = record_dict[Fields.ENTRYTYPE]
 
         records: dict = {}
-        for counter, entry in enumerate(entries.values()):
-            if "type" in entry:
-                if "Journal Article" == entry["type"]:
-                    entry[Fields.ENTRYTYPE] = ENTRYTYPES.ARTICLE
-                del entry["type"]
-            else:
-                entry[Fields.ENTRYTYPE] = ENTRYTYPES.MISC
+        for enl_key in list(record_dict.keys()):
+            if enl_key in [Fields.ENTRYTYPE, Fields.ID]:
+                continue
 
-            for list_tag, delimiter in self.list_tags.items():
-                list_field = self.mapping[list_tag]
-                if list_field not in entry:
-                    continue
-                entry[list_field] = delimiter.join(entry[list_field])
+            if enl_key not in key_map[entrytype]:
+                del record_dict[enl_key]
+                # print/notify: ris_key
+                continue
+            standard_key = key_map[entrytype][enl_key]
+            record_dict[standard_key] = record_dict.pop(enl_key)
 
-            if self.unique_id_field == "":
-                _id = str(counter + 1).zfill(5)
-            else:
-                _id = entry[self.unique_id_field].replace(" ", "").replace(";", "_")
-            entry[Fields.ID] = _id
-            records[_id] = entry
-
+        if self.unique_id_field != "":
+            _id = record_dict[self.unique_id_field].replace(" ", "").replace(";", "_")
+            record_dict[Fields.ID] = _id
         return records

--- a/colrev/ops/load_utils_enl.py
+++ b/colrev/ops/load_utils_enl.py
@@ -144,16 +144,15 @@ class ENLLoader:
     def apply_entrytype_mapping(
         self, *, record_dict: dict, entrytype_map: dict
     ) -> None:
-        typ = record_dict["0"]
-        if typ not in entrytype_map:
-            msg = f"{Colors.RED}0={typ} not yet supported{Colors.END}"
+        if record_dict["0"] not in entrytype_map:
+            msg = f"{Colors.RED}0={record_dict['0']} not yet supported{Colors.END}"
             if not self.load_operation.review_manager.force_mode:
                 raise NotImplementedError(msg)
 
             self.load_operation.review_manager.logger.error(msg)
             return
 
-        entrytype = entrytype_map[typ]
+        entrytype = entrytype_map[record_dict["0"]]
         record_dict[Fields.ENTRYTYPE] = entrytype
 
     def map_keys(self, *, record_dict: dict, key_map: dict) -> dict:

--- a/tests/2_ops/load_utils_enl_test.py
+++ b/tests/2_ops/load_utils_enl_test.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import colrev.ops.load_utils_enl
 import colrev.review_manager
 import colrev.settings
+from colrev.constants import ENTRYTYPES
+from colrev.constants import Fields
 
 
 def test_load(  # type: ignore
@@ -22,6 +24,45 @@ def test_load(  # type: ignore
         comment="",
     )
 
+    enl_mapping = {
+        ENTRYTYPES.ARTICLE: {
+            "T": Fields.TITLE,
+            "A": Fields.AUTHOR,
+            "D": Fields.YEAR,
+            "B": Fields.JOURNAL,
+            "V": Fields.VOLUME,
+            "N": Fields.NUMBER,
+            "P": Fields.PAGES,
+            "X": Fields.ABSTRACT,
+            "U": Fields.URL,
+            "8": "date",
+            "0": "type",
+        },
+        ENTRYTYPES.INPROCEEDINGS: {
+            "T": Fields.TITLE,
+            "A": Fields.AUTHOR,
+            "D": Fields.YEAR,
+            "B": Fields.JOURNAL,
+            "V": Fields.VOLUME,
+            "N": Fields.NUMBER,
+            "P": Fields.PAGES,
+            "X": Fields.ABSTRACT,
+            "U": Fields.URL,
+            "8": "date",
+            "0": "type",
+        },
+    }
+    entrytype_map = {
+        "Journal Article": ENTRYTYPES.ARTICLE,
+        "HICSS": ENTRYTYPES.INPROCEEDINGS,
+        "ICIS": ENTRYTYPES.INPROCEEDINGS,
+        "ECIS": ENTRYTYPES.INPROCEEDINGS,
+        "AMCIS": ENTRYTYPES.INPROCEEDINGS,
+        "Proceedings": ENTRYTYPES.INPROCEEDINGS,
+        "Inproceedings": ENTRYTYPES.INPROCEEDINGS,
+        "All Sprouts Content": ENTRYTYPES.INPROCEEDINGS,
+    }
+
     helpers.retrieve_test_file(
         source=Path("load_utils/") / Path("ais.txt"),
         target=Path("data/search/") / Path("ais.txt"),
@@ -29,10 +70,27 @@ def test_load(  # type: ignore
     load_operation = base_repo_review_manager.get_load_operation()
 
     enl_loader = colrev.ops.load_utils_enl.ENLLoader(
-        load_operation=load_operation, source=search_source
+        load_operation=load_operation,
+        source=search_source,
+        list_fields={"A": " and "},
     )
-    entries = enl_loader.load_enl_entries()
-    records = enl_loader.convert_to_records(entries=entries)
+    records = enl_loader.load_enl_entries()
+
+    for record_dict in records.values():
+        if "0" not in record_dict:
+            keys_to_check = ["V", "N"]
+            if any([k in record_dict for k in keys_to_check]):
+                record_dict["0"] = "Journal Article"
+            else:
+                record_dict["0"] = "Inproceedings"
+        enl_loader.apply_entrytype_mapping(
+            record_dict=record_dict, entrytype_map=entrytype_map
+        )
+        enl_loader.map_keys(record_dict=record_dict, key_map=enl_mapping)
+        record_dict["ID"] = record_dict[Fields.URL].replace(
+            "https://aisel.aisnet.org/", ""
+        )
+
     expected = (
         helpers.test_data_path / Path("load_utils/") / Path("ais_expected.bib")
     ).read_text(encoding="utf-8")

--- a/tests/data/built_in_search_sources/ais_result.bib
+++ b/tests/data/built_in_search_sources/ais_result.bib
@@ -10,6 +10,7 @@
                                     year:ais.txt/misq/vol45/iss3/13;;},
    colrev_data_provenance        = {abstract:ais.txt/misq/vol45/iss3/13;;
                                     colrev.ais_library.date:ais.txt/misq/vol45/iss3/13;;
+                                    colrev.ais_library.type:ais.txt/misq/vol45/iss3/13;;
                                     url:ais.txt/misq/vol45/iss3/13;;},
    author                        = {Guo, Wenbo and Straub, Detmar W. and Zhang, Pengzhu and Cai, Zhao},
    journal                       = {MIS Quarterly},
@@ -21,6 +22,7 @@
    url                           = {https://aisel.aisnet.org/misq/vol45/iss3/13},
    abstract                      = {IS research has extensively examined the role of trust in client-vendor relationships, as well as the role of governance in information technology (IT) outsourcing, but little research has been carried out on the latest manifestation of outsourcing—namely, microsourcing, i.e., the sourcing of smaller scale projects. To extend the literature on the traditional IT outsourcing literature—a stream that largely focuses on medium-to-large scale offline projects—we investigate how to develop trust and commitment in a triadic microsourcing relationship which includes the microsourcer, the microsourcee, and the microsourcing platform (MP). We draw on transaction cost economics (TCE) to theorize a model specifically adapted to the microsourcing phenomenon to scrutinize the influences of formal contractual mechanisms, relational mechanisms, and third-party mechanisms. Combining data from a matched sample of microsourcers and microsourcees on the leading Chinese MP, Zbj.com, the paper deploys degree-symmetric modeling (DSM) for construct conceptualization, measurement, and data analysis. DSM is consistent with the holistic view used to develop the research model for triadic relationships. Findings confirm that the MP is critical in delivering governance mechanisms to ensure the development of triadic trust and commitment. The results suggest that researchers and practitioners should pay closer attention to triadic trust and commitment building through proper governance mechanisms in the online microsourcing marketplace. We argue that this work could be extended to other online digital platforms that involve multiple transacting parties.},
    colrev.ais_library.date       = {September 1, 2021},
+   colrev.ais_library.type       = {Journal Article},
 }
 
 @article{Unknown2021,
@@ -34,6 +36,7 @@
                                     year:ais.txt/misq/vol45/iss3/1;;
                                     author:generic_field_requirements;missing;},
    colrev_data_provenance        = {colrev.ais_library.date:ais.txt/misq/vol45/iss3/1;;
+                                    colrev.ais_library.type:ais.txt/misq/vol45/iss3/1;;
                                     url:ais.txt/misq/vol45/iss3/1;;},
    prescreen_exclusion           = {complementary material},
    author                        = {UNKNOWN},
@@ -45,6 +48,7 @@
    pages                         = {i--ii},
    url                           = {https://aisel.aisnet.org/misq/vol45/iss3/1},
    colrev.ais_library.date       = {September 1, 2021},
+   colrev.ais_library.type       = {Journal Article},
 }
 
 @article{Unknown2021a,
@@ -58,6 +62,7 @@
                                     year:ais.txt/misq/vol45/iss4/25;;
                                     author:generic_field_requirements;missing;},
    colrev_data_provenance        = {colrev.ais_library.date:ais.txt/misq/vol45/iss4/25;;
+                                    colrev.ais_library.type:ais.txt/misq/vol45/iss4/25;;
                                     url:ais.txt/misq/vol45/iss4/25;;},
    author                        = {UNKNOWN},
    journal                       = {MIS Quarterly},
@@ -68,6 +73,7 @@
    pages                         = {2281--2284},
    url                           = {https://aisel.aisnet.org/misq/vol45/iss4/25},
    colrev.ais_library.date       = {December 2, 2021},
+   colrev.ais_library.type       = {Journal Article},
 }
 
 @inproceedings{RokrokShafiekhahOsorioEtAl2019,
@@ -79,6 +85,7 @@
                                     booktitle:ais.txt/hicss-52/da/sustainability/2|rename-from:journal|prep_ais_source;;},
    colrev_data_provenance        = {abstract:ais.txt/hicss-52/da/sustainability/2;;
                                     colrev.ais_library.date:ais.txt/hicss-52/da/sustainability/2;;
+                                    colrev.ais_library.type:ais.txt/hicss-52/da/sustainability/2;;
                                     url:ais.txt/hicss-52/da/sustainability/2;;},
    author                        = {Rokrok, Ebrahim and Shafie-khah, Miadreza and Osório, Gerardo and Carvalho, João P. P. and Catalao, Joao},
    booktitle                     = {Hawaii International Conference on System Sciences},
@@ -87,6 +94,7 @@
    url                           = {https://aisel.aisnet.org/hicss-52/da/sustainability/2},
    abstract                      = {A significant procedure to ensure the consumer supply is Power System Restoration (PSR). Due to the increase of the number of distributed generators in the grid, it is possible to shift from the conventional PSR to a new strategy involving the use of distributed energy resources (DER). In this paper, a decentralized multi-agent system (MAS) is proposed to cope with the restoration procedure in a microgrid (MG). Each agent is assigned to a specific consumer or microsource (MS), communicating with other agents at every stage of the restoration procedure so that a common decision is reached. The 0/1 knapsack problem is the problem that every agent solves to determine the best load connection sequence during the restoration of the MG. Two different case studies are used to test the MAS on a dynamically modeled benchmark MG: a total blackout and a partial blackout. Regarding the partial blackout case, demand response emergency programs are considered to manage the loads in the MG. The MAS is developed in Matlab/Simulink environment and by performing the corresponding dynamic simulations it is possible to validate this system towards sustainability.},
    colrev.ais_library.date       = {January 8, 2019},
+   colrev.ais_library.type       = {Inproceedings},
 }
 
 @inproceedings{LavillesSison2017,
@@ -98,6 +106,7 @@
                                     booktitle:ais.txt/pacis2017/260|rename-from:journal|prep_ais_source;;},
    colrev_data_provenance        = {abstract:ais.txt/pacis2017/260;;
                                     colrev.ais_library.date:ais.txt/pacis2017/260;;
+                                    colrev.ais_library.type:ais.txt/pacis2017/260;;
                                     url:ais.txt/pacis2017/260;;},
    author                        = {Lavilles, Rabby Q. and Sison, Raymund C.},
    booktitle                     = {Pacific-Asia Conference on Information Systems},
@@ -106,6 +115,7 @@
    url                           = {https://aisel.aisnet.org/pacis2017/260},
    abstract                      = {Online sourcing marketplaces (OSMs) enable the hiring of skilled workers around the globe. It becomes a significant factor for the increasing recognition of online sourcing as an alternative outsourcing option. Despite the adoption of individuals and small and medium enterprises, there is a dearth of study that looks into the service providers (workers) in OSM. This paper addresses this gap by exploring the experiences of online workers from the Philippines, particularly software developers engaged in independent online work. Findings found at least six themes prevalent to online software developers (OSDs) including uncertainty and transitions, trust and work agreements, reputation and client relationships, accomplishing tasks, platforms and software support, and work practices. The study suggests that by looking at the experiences of software developers, current and future clients (employers) can gain insights in considering this outsourcing option. Moreover, OSMs can consider the needs of OSDs presented in this study as inputs in customizing their services.},
    colrev.ais_library.date       = {July 1, 2017},
+   colrev.ais_library.type       = {Journal Article},
 }
 
 @inproceedings{ElGazzarHenriksenWahid2017,
@@ -118,6 +128,7 @@
                                     booktitle:ais.txt/ecis2017_rp/68|rename-from:journal|prep_ais_source|prep_ais_source;;},
    colrev_data_provenance        = {abstract:ais.txt/ecis2017_rp/68;;
                                     colrev.ais_library.date:ais.txt/ecis2017_rp/68;;
+                                    colrev.ais_library.type:ais.txt/ecis2017_rp/68;;
                                     url:ais.txt/ecis2017_rp/68;;},
    author                        = {El-Gazzar, Rania and Henriksen, Helle and Wahid, Fathul},
    booktitle                     = {European Conference on Information Systems},
@@ -127,5 +138,6 @@
    url                           = {https://aisel.aisnet.org/ecis2017_rp/68},
    abstract                      = {Using the concept of affordances as an analytical lens, this study aims to understand the use of Cloud Computing (CC) by Egyptian entrepreneurs. The study analyses impact of CC on their businesses and its inhibiting and enabling factors. In general, Egyptian entrepreneurs have positive perceptions of CC and note its various actualized affordances: accessing information technology (IT) resources rapidly, broadening reach and transferring responsibility. The use of CC has yielded diverse effects: shortened time to market, reduced costs, a diversified audience and more useful feedback. We also identify what inhibits the use of CC, including transparency and corruption problems, limited support for online transactions, unsupportive government policies, low appreciation from the domestic market, cumbersome bureaucracy, account hacking and unreliable infrastructure. Finally, we also reveal some enabling factors, including institutional support, overseas market potential and CC uptake (i.e., growing use).},
    colrev.ais_library.date       = {June 10, 2017},
+   colrev.ais_library.type       = {Inproceedings},
 }
 

--- a/tests/data/load_utils/ais_expected.bib
+++ b/tests/data/load_utils/ais_expected.bib
@@ -1,4 +1,4 @@
-@article{00001,
+@article{000001,
    author                        = {Guo, Wenbo and Straub, Detmar W. and Zhang, Pengzhu and Cai, Zhao},
    journal                       = {Management Information Systems Quarterly},
    title                         = {How Trust Leads to Commitment on Microsourcing Platforms: Unraveling the Effects of Governance and Third-Party Mechanisms on Triadic Microsourcing Relationships},
@@ -9,9 +9,10 @@
    url                           = {https://aisel.aisnet.org/misq/vol45/iss3/13},
    abstract                      = {IS research has extensively examined the role of trust in client-vendor relationships, as well as the role of governance in information technology (IT) outsourcing, but little research has been carried out on the latest manifestation of outsourcing—namely, microsourcing, i.e., the sourcing of smaller scale projects. To extend the literature on the traditional IT outsourcing literature—a stream that largely focuses on medium-to-large scale offline projects—we investigate how to develop trust and commitment in a triadic microsourcing relationship which includes the microsourcer, the microsourcee, and the microsourcing platform (MP). We draw on transaction cost economics (TCE) to theorize a model specifically adapted to the microsourcing phenomenon to scrutinize the influences of formal contractual mechanisms, relational mechanisms, and third-party mechanisms. Combining data from a matched sample of microsourcers and microsourcees on the leading Chinese MP, Zbj.com, the paper deploys degree-symmetric modeling (DSM) for construct conceptualization, measurement, and data analysis. DSM is consistent with the holistic view used to develop the research model for triadic relationships. Findings confirm that the MP is critical in delivering governance mechanisms to ensure the development of triadic trust and commitment. The results suggest that researchers and practitioners should pay closer attention to triadic trust and commitment building through proper governance mechanisms in the online microsourcing marketplace. We argue that this work could be extended to other online digital platforms that involve multiple transacting parties.},
    date                          = {September  1, 2021},
+   type                          = {Journal Article},
 }
 
-@article{00002,
+@article{000002,
    author                        = {Obal, Lorie},
    journal                       = {Communications of the Association for Information Systems},
    title                         = {Microsourcing - Using Information Technology to Create Unexpected Work Relationships and Entrepreneurial Opportunities},
@@ -21,9 +22,10 @@
    url                           = {https://aisel.aisnet.org/cais/vol24/iss1/11},
    abstract                      = {Offshore outsourcing has increased to the point where it is now part of the mainstream consciousness.  The same tools that enable remote work sharing in corporations also allow individuals to outsource their own work (microsourcing)—either with company approval or covertly. As an innovative work practice, microsourcing can bring greater flexibility to the workforce. It also has the potential to undermine control of the work process as well as introducing new risks and ethical issues to the workplace.  The appearance of brokers to facilitate microsourcing suggests that entrepreneurs perceive there is a demand for these arrangements. Due to the potential threats to intellectual property, even employers and managers who do not use or approve of the practice should take some steps to educate themselves about microsourcing. This research is the first known attempt to use a theoretical framework to understand microsourcing as an individual level work strategy as well as its context and drivers. This study uses Structuration Theory as a guideline in the investigation of different microsourcing implementations.},
    date                          = {January  1, 2009},
+   type                          = {Journal Article},
 }
 
-@misc{00003,
+@article{000003,
    journal                       = {Management Information Systems Quarterly},
    title                         = {MISQ Volume 45, Issue 3 Table of Contents},
    year                          = {2021},
@@ -32,4 +34,5 @@
    pages                         = {i-ii},
    url                           = {https://aisel.aisnet.org/misq/vol45/iss3/1},
    date                          = {September  1, 2021},
+   type                          = {Journal Article},
 }


### PR DESCRIPTION
Updated ENLLoader to match new API

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Refactored ENLoader to return dict object, the conversion to record is handled. tests are updated accordingly

## What is the current behavior?
Converts ENL formats to records directly.

## What is the new behavior?

Loads ENL format as dict object, instead of records, conversion is handled by source

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
