### PR TITLE
Use posix paths for platform independence

### DIFF
--- a/colrev/packages/ocrmypdf/src/ocrmypdf.py
+++ b/colrev/packages/ocrmypdf/src/ocrmypdf.py
@@ -67,9 +67,11 @@ class OCRMyPDF(JsonSchemaMixin):
         #     options = options + '--deskew '
         docker_home_path = Path("/home/docker")
 
+        non_ocr_fname = docker_home_path / non_ocred_filename.name
+        docker_output_fname = docker_home_path / pdf_path.name
         args = (
-            f"--force-ocr --jobs 4 -l eng {str(docker_home_path / non_ocred_filename.name)} "
-            f"{str(docker_home_path / pdf_path.name)}"
+            f"--force-ocr --jobs 4 -l eng {non_ocr_fname.as_posix()} "
+            f"{docker_output_fname.as_posix()}"
         )
 
         client = docker.from_env(timeout=120)

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -682,7 +682,7 @@ class PaperMarkdown(JsonSchemaMixin):
                 image=self.pandoc_image,
                 command=script,
                 user=user,
-                volumes=[str(self.review_manager.path) + ":/data"],
+                volumes=[self.review_manager.path.as_posix() + ":/data"],
             )
 
         except docker.errors.ImageNotFound:
@@ -736,9 +736,9 @@ class PaperMarkdown(JsonSchemaMixin):
             self.review_manager.logger.info("Build paper")
 
         script = (
-            f"{self.paper_relative_path} --filter pandoc-crossref --citeproc "
-            + f"--reference-doc {word_template.relative_to(self.review_manager.path)} "
-            + f"--output {output_relative_path}"
+            f"{self.paper_relative_path.as_posix()} --filter pandoc-crossref --citeproc "
+            + f"--reference-doc {word_template.relative_to(self.review_manager.path).as_posix()} "
+            + f"--output {output_relative_path.as_posix()}"
         )
 
         Timer(

--- a/colrev/packages/prisma/src/prisma.py
+++ b/colrev/packages/prisma/src/prisma.py
@@ -146,13 +146,13 @@ class PRISMA(JsonSchemaMixin):
             self.review_manager.logger.info("Complete processing and use colrev data")
             return
 
-        csv_relative_path = self.csv_path.relative_to(self.review_manager.path)
+        csv_relative_path = self.csv_path.relative_to(self.review_manager.path).as_posix()
 
         if not silent_mode:
             self.review_manager.logger.info("Create PRISMA diagram")
 
         for diagram_path in self.settings.diagram_path:
-            diagram_relative_path = diagram_path.relative_to(self.review_manager.path)
+            diagram_relative_path = diagram_path.relative_to(self.review_manager.path).as_posix()
 
             script = (
                 "Rscript "

--- a/colrev/packages/prisma/src/prisma.py
+++ b/colrev/packages/prisma/src/prisma.py
@@ -174,7 +174,7 @@ class PRISMA(JsonSchemaMixin):
                 )
 
             self._call_docker_build_process(script=script)
-            csv_relative_path.unlink()
+            self.csv_path.unlink()
 
     def _call_docker_build_process(self, *, script: str) -> None:
         try:

--- a/colrev/packages/prisma/src/prisma.py
+++ b/colrev/packages/prisma/src/prisma.py
@@ -146,13 +146,17 @@ class PRISMA(JsonSchemaMixin):
             self.review_manager.logger.info("Complete processing and use colrev data")
             return
 
-        csv_relative_path = self.csv_path.relative_to(self.review_manager.path).as_posix()
+        csv_relative_path = self.csv_path.relative_to(
+            self.review_manager.path
+        ).as_posix()
 
         if not silent_mode:
             self.review_manager.logger.info("Create PRISMA diagram")
 
         for diagram_path in self.settings.diagram_path:
-            diagram_relative_path = diagram_path.relative_to(self.review_manager.path).as_posix()
+            diagram_relative_path = diagram_path.relative_to(
+                self.review_manager.path
+            ).as_posix()
 
             script = (
                 "Rscript "


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We're using regular pathlib paths which can cause issues on Windows when using win paths together with posix paths inside docker (e.g., for paper.md)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- convert pathlib paths that are used in docker to posix paths

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
