### PR TITLE
Replace pybtex

### DIFF
--- a/colrev/dataset.py
+++ b/colrev/dataset.py
@@ -280,7 +280,8 @@ class Dataset:
 
     def save_records_dict(self, records: dict, *, partial: bool = False) -> None:
         """Save the records dict in RECORDS_FILE"""
-
+        if not records:
+            return
         if partial:
             self._save_record_list_by_id(records)
             return

--- a/colrev/loader/bib.py
+++ b/colrev/loader/bib.py
@@ -28,7 +28,7 @@ def extract_content(text: str) -> str:
     return match.group(1).strip() if match else text
 
 
-def fix_bib_file(filename: Path, logger: logging.Logger) -> None:
+def run_fix_bib_file(filename: Path, logger: logging.Logger) -> None:
     # pylint: disable=too-many-statements
 
     def fix_key(
@@ -168,7 +168,11 @@ class BIBLoader(colrev.loader.loader.Loader):
         field_mapper: typing.Callable = lambda x: x,
         id_labeler: typing.Callable = lambda x: x,
         logger: logging.Logger = logging.getLogger(__name__),
+        format_names: bool = False,
+        fix_bib_file: bool = False,
     ):
+        self.format_names = format_names
+        self.fix_bib_file = fix_bib_file
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,
@@ -393,7 +397,7 @@ class BIBLoader(colrev.loader.loader.Loader):
                     }
             return parsed_dict
 
-        def format_names(records: dict) -> None:
+        def run_format_names(records: dict) -> None:
             for record in records.values():
                 if Fields.AUTHOR in record:
                     record[Fields.AUTHOR] = parse_names(record[Fields.AUTHOR])
@@ -401,7 +405,8 @@ class BIBLoader(colrev.loader.loader.Loader):
                     record[Fields.EDITOR] = parse_names(record[Fields.EDITOR])
 
         # TODO : add flag to switch off
-        fix_bib_file(self.filename, self.logger)
+        if self.fix_bib_file:
+            run_fix_bib_file(self.filename, self.logger)
 
         records = {}
 
@@ -518,7 +523,8 @@ class BIBLoader(colrev.loader.loader.Loader):
 
         # Parse names (optional/flag to switch off - off per default, on only for initial load)
         # TODO : if self.parse_names:
-        format_names(records=records)
+        if self.format_names:
+            run_format_names(records=records)
 
         drop_empty_fields(records=records)
         resolve_crossref(records=records)

--- a/colrev/loader/enl.py
+++ b/colrev/loader/enl.py
@@ -32,11 +32,12 @@ class ENLLoader(colrev.loader.loader.Loader):
         self,
         *,
         filename: Path,
-        entrytype_setter: typing.Callable,
-        field_mapper: typing.Callable,
-        id_labeler: typing.Callable,
+        entrytype_setter: typing.Callable = lambda x: x,
+        field_mapper: typing.Callable = lambda x: x,
+        id_labeler: typing.Callable = lambda x: x,
         unique_id_field: str = "",
         logger: logging.Logger = logging.getLogger(__name__),
+        format_names: bool = False,
     ):
 
         super().__init__(
@@ -46,6 +47,7 @@ class ENLLoader(colrev.loader.loader.Loader):
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=logger,
+            format_names=format_names,
         )
 
         self.current: dict = {}

--- a/colrev/loader/json.py
+++ b/colrev/loader/json.py
@@ -23,11 +23,12 @@ class JSONLoader(colrev.loader.loader.Loader):
         self,
         *,
         filename: Path,
-        entrytype_setter: typing.Callable,
-        field_mapper: typing.Callable,
-        id_labeler: typing.Callable,
+        entrytype_setter: typing.Callable = lambda x: x,
+        field_mapper: typing.Callable = lambda x: x,
+        id_labeler: typing.Callable = lambda x: x,
         unique_id_field: str = "",
         logger: logging.Logger = logging.getLogger(__name__),
+        format_names: bool = False,
     ):
         super().__init__(
             filename=filename,
@@ -36,6 +37,7 @@ class JSONLoader(colrev.loader.loader.Loader):
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=logger,
+            format_names=format_names,
         )
 
     @classmethod

--- a/colrev/loader/load_utils.py
+++ b/colrev/loader/load_utils.py
@@ -156,6 +156,7 @@ def load(  # type: ignore
     unique_id_field: str = "",
     logger: logging.Logger = logging.getLogger(__name__),
     empty_if_file_not_exists: bool = True,
+    format_names: bool = False,
 ) -> dict:
     """Load a file and return records as a dictionary"""
 
@@ -188,6 +189,7 @@ def load(  # type: ignore
         id_labeler=id_labeler,
         unique_id_field=unique_id_field,
         logger=logger,
+        format_names=format_names,
     ).load()
 
 

--- a/colrev/loader/load_utils.py
+++ b/colrev/loader/load_utils.py
@@ -179,7 +179,7 @@ def load(  # type: ignore
     elif filename.suffix == ".json":
         parser = colrev.loader.json.JSONLoader  # type: ignore
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"Unsupported file type: {filename.suffix}")
 
     return parser(
         filename=filename,
@@ -255,6 +255,6 @@ def get_nr_records(  # type: ignore
     elif filename.suffix == ".json":
         parser = colrev.loader.json.JSONLoader  # type: ignore
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"Unsupported file type: {filename.suffix}")
 
     return parser.get_nr_records(filename)

--- a/colrev/loader/load_utils_name_formatter.py
+++ b/colrev/loader/load_utils_name_formatter.py
@@ -1,0 +1,120 @@
+#! /usr/bin/env python
+"""Convenience functions for name formatting"""
+from __future__ import annotations
+
+import re
+
+whitespace_re = re.compile(r"(\s)")
+
+
+def split_tex_string(string, sep=None, strip=True, filter_empty=False):
+    if sep is None:
+        sep = r"[\s~]+"
+        filter_empty = True
+    sep_re = re.compile(sep)
+    brace_level = 0
+    name_start = 0
+    result = []
+    string_len = len(string)
+
+    for pos, char in enumerate(string):
+        if char == "{":
+            brace_level += 1
+        elif char == "}":
+            brace_level -= 1
+        elif brace_level == 0 and pos > 0:
+            match = sep_re.match(string[pos:])
+            if match:
+                sep_len = len(match.group())
+                if pos + sep_len < string_len:
+                    result.append(string[name_start:pos])
+                    name_start = pos + sep_len
+    if name_start < string_len:
+        result.append(string[name_start:])
+    if strip:
+        result = [part.strip() for part in result]
+    if filter_empty:
+        result = [part for part in result if part]
+    return result
+
+
+class NameParser:
+    def __init__(self, name: str):
+        self._first = []
+        self._middle = []
+        self._prelast = []
+        self._last = []
+        self._lineage = []
+        self.parse_string(name)
+
+    def parse_string(self, name: str):
+        name = name.strip()
+        parts = split_tex_string(name, ",")
+
+        if len(parts) == 3:  # "von Last, Jr, First"
+            self._parse_von_last(split_tex_string(parts[0]))
+            self._lineage.extend(split_tex_string(parts[1]))
+            self._parse_first_middle(split_tex_string(parts[2]))
+        elif len(parts) == 2:  # "von Last, First"
+            self._parse_von_last(split_tex_string(parts[0]))
+            self._parse_first_middle(split_tex_string(parts[1]))
+        elif len(parts) == 1:  # "First von Last"
+            parts = split_tex_string(name)
+            first_middle, von_last = self._split_at(parts, lambda part: part.islower())
+            if not von_last and first_middle:
+                last = first_middle.pop()
+                von_last.append(last)
+            self._parse_first_middle(first_middle)
+            self._parse_von_last(von_last)
+        else:
+            raise ValueError(f"Invalid name format: {name}")
+
+    def _parse_first_middle(self, parts):
+        if parts:
+            self._first.append(parts[0])
+            self._middle.extend(parts[1:])
+
+    def _parse_von_last(self, parts):
+        von, last = self._rsplit_at(parts, lambda part: part.islower())
+        if von and not last:
+            last.append(von.pop())
+        self._prelast.extend(von)
+        self._last.extend(last)
+
+    def _split_at(self, lst, pred):
+        pos = next((i for i, item in enumerate(lst) if pred(item)), len(lst))
+        return lst[:pos], lst[pos:]
+
+    def _rsplit_at(self, lst, pred):
+        rpos = next((i for i, item in enumerate(reversed(lst)) if pred(item)), len(lst))
+        pos = len(lst) - rpos
+        return lst[:pos], lst[pos:]
+
+    def get_part_as_text(self, part_type: str) -> str:
+        return " ".join(getattr(self, f"_{part_type}", []))
+
+    def format_name(self) -> str:
+        def join(name_list):
+            return " ".join([name for name in name_list if name])
+
+        first = self.get_part_as_text("first")
+        middle = self.get_part_as_text("middle")
+        prelast = self.get_part_as_text("prelast")
+        last = self.get_part_as_text("last")
+        lineage = self.get_part_as_text("lineage")
+        name_string = ""
+        if last:
+            name_string += join([prelast, last])
+        if lineage:
+            name_string += f", {lineage}"
+        if first or middle:
+            name_string += ", " + join([first, middle])
+        return name_string
+
+
+def parse_names(names: str) -> str:
+    if "," in names:
+        return names
+    name_list = re.split(r"\s+and\s+|;", names)
+    formatted_names = [NameParser(name.strip()).format_name() for name in name_list]
+    return " and ".join(formatted_names)

--- a/colrev/loader/load_utils_name_formatter.py
+++ b/colrev/loader/load_utils_name_formatter.py
@@ -55,6 +55,7 @@ class NameParser:
         self.parse_string(name)
 
     def parse_string(self, name: str) -> None:
+        """Parse the name string"""
         name = name.strip()
         parts = split_tex_string(name, ",")
 
@@ -97,18 +98,20 @@ class NameParser:
         pos = len(lst) - rpos
         return lst[:pos], lst[pos:]
 
-    def get_part_as_text(self, part_type: str) -> str:
+    def _get_part_as_text(self, part_type: str) -> str:
         return " ".join(getattr(self, f"_{part_type}", []))
 
     def format_name(self) -> str:
+        """Format the name"""
+
         def join(name_list: list) -> str:
             return " ".join([name for name in name_list if name])
 
-        first = self.get_part_as_text("first")
-        middle = self.get_part_as_text("middle")
-        prelast = self.get_part_as_text("prelast")
-        last = self.get_part_as_text("last")
-        lineage = self.get_part_as_text("lineage")
+        first = self._get_part_as_text("first")
+        middle = self._get_part_as_text("middle")
+        prelast = self._get_part_as_text("prelast")
+        last = self._get_part_as_text("last")
+        lineage = self._get_part_as_text("lineage")
         name_string = ""
         if last:
             name_string += join([prelast, last])

--- a/colrev/loader/load_utils_name_formatter.py
+++ b/colrev/loader/load_utils_name_formatter.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import re
 import typing
 
-whitespace_re = re.compile(r"(\s)")
+from colrev.constants import Fields
 
 
 def split_tex_string(
     string: str, sep: str = "", strip: bool = True, filter_empty: bool = False
 ) -> list:
+    """Split a string by a separator"""
+
     if sep == "":
         sep = r"[\s~]+"
         filter_empty = True
@@ -42,6 +44,8 @@ def split_tex_string(
 
 
 class NameParser:
+    """Parse a name string"""
+
     def __init__(self, name: str) -> None:
         self._first: list[str] = []
         self._middle: list[str] = []
@@ -116,8 +120,23 @@ class NameParser:
 
 
 def parse_names(names: str) -> str:
+    """Parse names"""
     if "," in names:
         return names
     name_list = re.split(r"\s+and\s+|;", names)
     formatted_names = [NameParser(name.strip()).format_name() for name in name_list]
     return " and ".join(formatted_names)
+
+
+def parse_names_in_records(records_dict: dict) -> None:
+    """Parse names in records
+
+    Note: requires fields to be Fields.AUTHOR/Fields.EDITOR
+
+    """
+
+    for record in records_dict.values():
+        if Fields.AUTHOR in record:
+            record[Fields.AUTHOR] = parse_names(record[Fields.AUTHOR])
+        if Fields.EDITOR in record:
+            record[Fields.EDITOR] = parse_names(record[Fields.EDITOR])

--- a/colrev/loader/load_utils_name_formatter.py
+++ b/colrev/loader/load_utils_name_formatter.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import re
+import typing
 
 whitespace_re = re.compile(r"(\s)")
 
 
-def split_tex_string(string, sep=None, strip=True, filter_empty=False):
-    if sep is None:
+def split_tex_string(
+    string: str, sep: str = "", strip: bool = True, filter_empty: bool = False
+) -> list:
+    if sep == "":
         sep = r"[\s~]+"
         filter_empty = True
     sep_re = re.compile(sep)
@@ -39,15 +42,15 @@ def split_tex_string(string, sep=None, strip=True, filter_empty=False):
 
 
 class NameParser:
-    def __init__(self, name: str):
-        self._first = []
-        self._middle = []
-        self._prelast = []
-        self._last = []
-        self._lineage = []
+    def __init__(self, name: str) -> None:
+        self._first: list[str] = []
+        self._middle: list[str] = []
+        self._prelast: list[str] = []
+        self._last: list[str] = []
+        self._lineage: list[str] = []
         self.parse_string(name)
 
-    def parse_string(self, name: str):
+    def parse_string(self, name: str) -> None:
         name = name.strip()
         parts = split_tex_string(name, ",")
 
@@ -69,23 +72,23 @@ class NameParser:
         else:
             raise ValueError(f"Invalid name format: {name}")
 
-    def _parse_first_middle(self, parts):
+    def _parse_first_middle(self, parts: list) -> None:
         if parts:
             self._first.append(parts[0])
             self._middle.extend(parts[1:])
 
-    def _parse_von_last(self, parts):
+    def _parse_von_last(self, parts: list) -> None:
         von, last = self._rsplit_at(parts, lambda part: part.islower())
         if von and not last:
             last.append(von.pop())
         self._prelast.extend(von)
         self._last.extend(last)
 
-    def _split_at(self, lst, pred):
+    def _split_at(self, lst: list, pred: typing.Callable) -> tuple:
         pos = next((i for i, item in enumerate(lst) if pred(item)), len(lst))
         return lst[:pos], lst[pos:]
 
-    def _rsplit_at(self, lst, pred):
+    def _rsplit_at(self, lst: list, pred: typing.Callable) -> tuple:
         rpos = next((i for i, item in enumerate(reversed(lst)) if pred(item)), len(lst))
         pos = len(lst) - rpos
         return lst[:pos], lst[pos:]
@@ -94,7 +97,7 @@ class NameParser:
         return " ".join(getattr(self, f"_{part_type}", []))
 
     def format_name(self) -> str:
-        def join(name_list):
+        def join(name_list: list) -> str:
             return " ".join([name for name in name_list if name])
 
         first = self.get_part_as_text("first")

--- a/colrev/loader/loader.py
+++ b/colrev/loader/loader.py
@@ -50,7 +50,12 @@ class Loader:
             Fields.ID in record_dict for record_dict in records_list
         ), "ID not set in all records"
         unique_ids = {record_dict[Fields.ID] for record_dict in records_list}
-        assert len(unique_ids) == len(records_list), "ID is not unique in records"
+        non_unique_ids = [
+            id
+            for id in unique_ids
+            if sum(1 for r in records_list if r[Fields.ID] == id) > 1
+        ]
+        assert not non_unique_ids, f"ID is not unique in records: {non_unique_ids}"
 
     def _set_entrytypes(self, records_dict: dict) -> None:
         for r_dict_val in records_dict.values():

--- a/colrev/loader/loader.py
+++ b/colrev/loader/loader.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
-
+from colrev.loader.load_utils_name_formatter import parse_names_in_records
 
 # pylint: disable=too-many-arguments
 
@@ -23,6 +23,7 @@ class Loader:
         id_labeler: typing.Callable,
         unique_id_field: str,
         logger: logging.Logger,
+        format_names: bool = False,
     ):
         self.filename = filename
         self.unique_id_field = unique_id_field
@@ -30,6 +31,7 @@ class Loader:
         self.id_labeler = id_labeler
         self.entrytype_setter = entrytype_setter
         self.field_mapper = field_mapper
+        self.format_names = format_names
 
         self.logger = logger
 
@@ -106,5 +108,8 @@ class Loader:
         records_dict = {str(r[Fields.ID]): r for r in records_list}
         self._set_entrytypes(records_dict)
         self._set_fields(records_dict)
+
+        if self.format_names:
+            parse_names_in_records(records_dict)
 
         return records_dict

--- a/colrev/loader/md.py
+++ b/colrev/loader/md.py
@@ -25,11 +25,12 @@ class MarkdownLoader(colrev.loader.loader.Loader):
         self,
         *,
         filename: Path,
-        entrytype_setter: typing.Callable,
-        field_mapper: typing.Callable,
-        id_labeler: typing.Callable,
+        entrytype_setter: typing.Callable = lambda x: x,
+        field_mapper: typing.Callable = lambda x: x,
+        id_labeler: typing.Callable = lambda x: x,
         unique_id_field: str = "",
         logger: logging.Logger = logging.getLogger(__name__),
+        format_names: bool = False,
     ):
 
         super().__init__(
@@ -39,6 +40,7 @@ class MarkdownLoader(colrev.loader.loader.Loader):
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=logger,
+            format_names=format_names,
         )
 
     @classmethod

--- a/colrev/loader/nbib.py
+++ b/colrev/loader/nbib.py
@@ -33,12 +33,14 @@ class NBIBLoader(colrev.loader.loader.Loader):
         self,
         *,
         filename: Path,
-        entrytype_setter: typing.Callable,
-        field_mapper: typing.Callable,
-        id_labeler: typing.Callable,
+        entrytype_setter: typing.Callable = lambda x: x,
+        field_mapper: typing.Callable = lambda x: x,
+        id_labeler: typing.Callable = lambda x: x,
         unique_id_field: str = "",
         logger: logging.Logger = logging.getLogger(__name__),
+        format_names: bool = False,
     ):
+
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,
@@ -46,6 +48,7 @@ class NBIBLoader(colrev.loader.loader.Loader):
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=logger,
+            format_names=format_names,
         )
 
         self.current: dict = {}

--- a/colrev/loader/ris.py
+++ b/colrev/loader/ris.py
@@ -33,11 +33,12 @@ class RISLoader(colrev.loader.loader.Loader):
         self,
         *,
         filename: Path,
-        entrytype_setter: typing.Callable,
-        field_mapper: typing.Callable,
-        id_labeler: typing.Callable,
+        entrytype_setter: typing.Callable = lambda x: x,
+        field_mapper: typing.Callable = lambda x: x,
+        id_labeler: typing.Callable = lambda x: x,
         unique_id_field: str = "",
         logger: logging.Logger = logging.getLogger(__name__),
+        format_names: bool = False,
     ):
         super().__init__(
             filename=filename,
@@ -46,6 +47,7 @@ class RISLoader(colrev.loader.loader.Loader):
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=logger,
+            format_names=format_names,
         )
 
         self.current: dict = {}

--- a/colrev/loader/table.py
+++ b/colrev/loader/table.py
@@ -23,12 +23,14 @@ class TableLoader(colrev.loader.loader.Loader):
         self,
         *,
         filename: Path,
-        entrytype_setter: typing.Callable,
-        field_mapper: typing.Callable,
-        id_labeler: typing.Callable,
+        entrytype_setter: typing.Callable = lambda x: x,
+        field_mapper: typing.Callable = lambda x: x,
+        id_labeler: typing.Callable = lambda x: x,
         unique_id_field: str = "",
         logger: logging.Logger = logging.getLogger(__name__),
+        format_names: bool = False,
     ):
+
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,
@@ -36,6 +38,7 @@ class TableLoader(colrev.loader.loader.Loader):
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=logger,
+            format_names=format_names,
         )
 
     @classmethod

--- a/colrev/ops/pdf_prep.py
+++ b/colrev/ops/pdf_prep.py
@@ -471,9 +471,6 @@ class PDFPrep(colrev.process.operation.Operation):
 
             self._print_stats(pdf_prep_record_list=pdf_prep_record_list)
 
-        # Note: for formatting...
-        records = self.review_manager.dataset.load_records_dict()
-        self.review_manager.dataset.save_records_dict(records)
         self.review_manager.dataset.create_commit(msg="PDFs: prepare")
         self.review_manager.logger.info(
             f"{Colors.GREEN}Completed pdf-prep operation{Colors.END}"

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -106,6 +106,7 @@ class EbscoHostSearchSource:
             logger=self.review_manager.logger,
             unique_id_field="ID",
             field_mapper=field_mapper,
+            format_names=True,
         )
         return records
 

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -298,6 +298,7 @@ class IEEEXploreSearchSource:
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=self.review_manager.logger,
+            format_names=True,
         )
 
         return records

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import zope.interface
 from pydantic import Field
 
+import colrev.loader.bib
 import colrev.package_manager.interfaces
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
@@ -151,6 +152,9 @@ class ScopusSearchSource:
                     del record_dict["Start_Page"]
                     del record_dict["End_Page"]
 
+        colrev.loader.bib.run_fix_bib_file(
+            self.search_source.filename, logger=self.review_manager.logger
+        )
         records = colrev.loader.load_utils.load(
             filename=self.search_source.filename,
             unique_id_field="ID",

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -436,6 +436,7 @@ class SpringerLinkSearchSource:
             entrytype_setter=entrytype_setter,
             field_mapper=field_mapper,
             logger=self.review_manager.logger,
+            format_names=True,
         )
         return records
 
@@ -520,6 +521,7 @@ class SpringerLinkSearchSource:
             filename=self.search_source.filename,
             logger=self.review_manager.logger,
             unique_id_field="ID",
+            format_names=True,
         )
         return records
 

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -103,6 +103,7 @@ class TaylorAndFrancisSearchSource:
             logger=self.review_manager.logger,
             unique_id_field="ID",
             field_mapper=field_mapper,
+            format_names=True,
         )
         return records
 

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.check_valid_bib.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.check_valid_bib.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.check\_valid\_bib
+===================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: check_valid_bib

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.extract_content.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.extract_content.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.extract\_content
+==================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: extract_content

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.handle_new_entry.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.handle_new_entry.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.handle\_new\_entry
+====================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: handle_new_entry

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.parse_provenance.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.parse_provenance.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.parse\_provenance
+===================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: parse_provenance

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.process_key_value.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.process_key_value.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.process\_key\_value
+=====================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: process_key_value

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.process_lines.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.process_lines.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.process\_lines
+================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: process_lines

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.rst
@@ -9,6 +9,22 @@ colrev.loader.bib
 
 
 
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+
+      check_valid_bib
+      extract_content
+      handle_new_entry
+      parse_provenance
+      process_key_value
+      process_lines
+      run_fix_bib_file
+      run_resolve_crossref
+      store_current_key_value
+
 
 
 

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.run_fix_bib_file.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.run_fix_bib_file.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.run\_fix\_bib\_file
+=====================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: run_fix_bib_file

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.run_resolve_crossref.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.run_resolve_crossref.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.run\_resolve\_crossref
+========================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: run_resolve_crossref

--- a/docs/source/dev_docs/_autosummary/colrev.loader.bib.store_current_key_value.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.bib.store_current_key_value.rst
@@ -1,0 +1,6 @@
+colrev.loader.bib.store\_current\_key\_value
+============================================
+
+.. currentmodule:: colrev.loader.bib
+
+.. autofunction:: store_current_key_value

--- a/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.NameParser.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.NameParser.rst
@@ -1,0 +1,20 @@
+colrev.loader.load\_utils\_name\_formatter.NameParser
+=====================================================
+
+.. currentmodule:: colrev.loader.load_utils_name_formatter
+
+.. autoclass:: NameParser
+   :members:
+   :show-inheritance:
+   :inherited-members:
+   :special-members: __call__, __add__, __mul__
+
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :nosignatures:
+
+      ~NameParser.format_name
+      ~NameParser.parse_string

--- a/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.parse_names.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.parse_names.rst
@@ -1,0 +1,6 @@
+colrev.loader.load\_utils\_name\_formatter.parse\_names
+=======================================================
+
+.. currentmodule:: colrev.loader.load_utils_name_formatter
+
+.. autofunction:: parse_names

--- a/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.parse_names_in_records.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.parse_names_in_records.rst
@@ -1,0 +1,6 @@
+colrev.loader.load\_utils\_name\_formatter.parse\_names\_in\_records
+====================================================================
+
+.. currentmodule:: colrev.loader.load_utils_name_formatter
+
+.. autofunction:: parse_names_in_records

--- a/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.rst
@@ -1,0 +1,33 @@
+colrev.loader.load\_utils\_name\_formatter
+==========================================
+
+.. automodule:: colrev.loader.load_utils_name_formatter
+
+
+
+
+
+
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+
+      parse_names
+      parse_names_in_records
+      split_tex_string
+
+
+
+
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+      :nosignatures:
+
+      NameParser

--- a/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.split_tex_string.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.load_utils_name_formatter.split_tex_string.rst
@@ -1,0 +1,6 @@
+colrev.loader.load\_utils\_name\_formatter.split\_tex\_string
+=============================================================
+
+.. currentmodule:: colrev.loader.load_utils_name_formatter
+
+.. autofunction:: split_tex_string

--- a/docs/source/dev_docs/_autosummary/colrev.loader.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.loader.rst
@@ -31,6 +31,7 @@ colrev.loader
    colrev.loader.json
    colrev.loader.load_utils
    colrev.loader.load_utils_formatter
+   colrev.loader.load_utils_name_formatter
    colrev.loader.loader
    colrev.loader.md
    colrev.loader.nbib

--- a/poetry.lock
+++ b/poetry.lock
@@ -787,17 +787,6 @@ files = [
 ansicon = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
-name = "latexcodec"
-version = "3.0.0"
-description = "A lexer and codec to work with LaTeX code in Python."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "latexcodec-3.0.0-py3-none-any.whl", hash = "sha256:6f3477ad5e61a0a99bd31a6a370c34e88733a6bad9c921a3ffcfacada12f41a7"},
-    {file = "latexcodec-3.0.0.tar.gz", hash = "sha256:917dc5fe242762cc19d963e6548b42d63a118028cdd3361d62397e3b638b6bc5"},
-]
-
-[[package]]
 name = "lingua-language-detector"
 version = "2.0.2"
 description = "An accurate natural language detection library, suitable for short text and mixed-language text"
@@ -1581,25 +1570,6 @@ files = [
 
 [package.dependencies]
 wcwidth = "*"
-
-[[package]]
-name = "pybtex"
-version = "0.24.0"
-description = "A BibTeX-compatible bibliography processor in Python"
-optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*"
-files = [
-    {file = "pybtex-0.24.0-py2.py3-none-any.whl", hash = "sha256:e1e0c8c69998452fea90e9179aa2a98ab103f3eed894405b7264e517cc2fcc0f"},
-    {file = "pybtex-0.24.0.tar.gz", hash = "sha256:818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755"},
-]
-
-[package.dependencies]
-latexcodec = ">=1.0.4"
-PyYAML = ">=3.01"
-six = "*"
-
-[package.extras]
-test = ["pytest"]
 
 [[package]]
 name = "pycountry"
@@ -2924,4 +2894,4 @@ docs = ["Sphinx", "beautifulsoup4", "docutils", "m2r", "repoze-sphinx-autointerf
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "d249366f10c33bf4124d5ae753d1b3212646e833b756acdaa4821a01e7f4c8fc"
+content-hash = "7bb2367e7b1aad7287f753d24c0e9de30b8917db9a1111fb34eab90a67e1d1cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ lxml = "^5.2.0"                         # required by tei_parser
 pandas = "^2.2"
 openpyxl = "^3.1.2"                     # required by pandas for Excel
 PyYAML = "^6.0.0"
-pybtex = "^0.24.0"                      # internally?
 requests = "^2.32.0"
 requests-cache = "^0.9.6"
 lingua-language-detector = "^2.0.2"

--- a/tests/2_loader/bib_test.py
+++ b/tests/2_loader/bib_test.py
@@ -47,9 +47,14 @@ def test_load(tmp_path, helpers) -> None:  # type: ignore
         target=Path("data/search/bib_data.bib"),
     )
 
+    colrev.loader.bib.run_fix_bib_file(
+        Path("data/search/bib_data.bib"), logger=logging.getLogger(__name__)
+    )
+
     records = colrev.loader.load_utils.load(
         filename=Path("data/search/bib_data.bib"),
     )
+    colrev.loader.bib.run_resolve_crossref(records, logger=logging.getLogger(__name__))
 
     assert records == {
         "articlewriter_firstrandomword_2020": {

--- a/tests/2_loader/bib_test.py
+++ b/tests/2_loader/bib_test.py
@@ -75,8 +75,8 @@ def test_load(tmp_path, helpers) -> None:  # type: ignore
             "ID": "articlewriter_firstrandomword_2020a",
             "abstract": "This is a nice abstract.",
             "author": "Articlewriter, Laura",
-            "doi": "10.3333/XYZ.V4444.04",
-            "issn": "07654321",
+            "doi": "10.3333/XYZ.V4444.04A",
+            "issn": "07654321a",
             "journal": "Dummy Relations",
             "key_words": "Dummy, Template, Void, Example",
             "language": "German",
@@ -100,8 +100,8 @@ def test_load(tmp_path, helpers) -> None:  # type: ignore
             "ENTRYTYPE": "inproceedings",
             "ID": "mouse2016",
             "author": "Mouse, M.",
-            "crossref": "ICRC2016",
             "title": "Mouse stories two",
+            "crossref": "ICRC2016",
         },
     }
 

--- a/tests/2_loader/data/bib_data.bib
+++ b/tests/2_loader/data/bib_data.bib
@@ -17,7 +17,7 @@
 }
 
 @article{articlewriter_firstrandomword_2020,
-   doi                           = {10.3333/XYZ.V4444.04},
+   doi                           = {10.3333/XYZ.V4444.04a},
    author                        = {Articlewriter, Laura},
    journal                       = {Dummy Relations},
    title                         = {This is a dummy title},
@@ -26,7 +26,7 @@
    number                        = {299},
    pages                         = {99--123},
    abstract                      = {This is a nice abstract.},
-   issn                          = {07654321},
+   issn                          = {07654321a},
    key words                     = {Dummy, Template, Void, Example},
    language                      = {German},
    month                         = {April},

--- a/tests/2_loader/loader_test.py
+++ b/tests/2_loader/loader_test.py
@@ -41,6 +41,10 @@ def test_load(tmp_path, helpers) -> None:  # type: ignore
         target=Path("data/search/bib_data.bib"),
     )
 
+    colrev.loader.bib.run_fix_bib_file(
+        Path("data/search/bib_data.bib"), logger=logging.getLogger(__name__)
+    )
+
     colrev.loader.load_utils.load(
         filename=Path("data/search/bib_data.bib"), logger=logging.getLogger(__name__)
     )

--- a/tests/3_packages_search/data/ais_enl_result.bib
+++ b/tests/3_packages_search/data/ais_enl_result.bib
@@ -41,7 +41,7 @@
    pages                         = {1309--1348},
    url                           = {https://aisel.aisnet.org/misq/vol45/iss3/13},
    abstract                      = {IS research has extensively examined the role of trust in client-vendor relationships, as well as the role of governance in information technology (IT) outsourcing, but little research has been carried out on the latest manifestation of outsourcing—namely, microsourcing, i.e., the sourcing of smaller scale projects. To extend the literature on the traditional IT outsourcing literature—a stream that largely focuses on medium-to-large scale offline projects—we investigate how to develop trust and commitment in a triadic microsourcing relationship which includes the microsourcer, the microsourcee, and the microsourcing platform (MP). We draw on transaction cost economics (TCE) to theorize a model specifically adapted to the microsourcing phenomenon to scrutinize the influences of formal contractual mechanisms, relational mechanisms, and third-party mechanisms. Combining data from a matched sample of microsourcers and microsourcees on the leading Chinese MP, Zbj.com, the paper deploys degree-symmetric modeling (DSM) for construct conceptualization, measurement, and data analysis. DSM is consistent with the holistic view used to develop the research model for triadic relationships. Findings confirm that the MP is critical in delivering governance mechanisms to ensure the development of triadic trust and commitment. The results suggest that researchers and practitioners should pay closer attention to triadic trust and commitment building through proper governance mechanisms in the online microsourcing marketplace. We argue that this work could be extended to other online digital platforms that involve multiple transacting parties.},
-   date                          = {September 1, 2021},
+   date                          = {September  1, 2021},
 }
 
 @inproceedings{LavillesSison2017,
@@ -60,7 +60,7 @@
    year                          = {2017},
    url                           = {https://aisel.aisnet.org/pacis2017/260},
    abstract                      = {Online sourcing marketplaces (OSMs) enable the hiring of skilled workers around the globe. It becomes a significant factor for the increasing recognition of online sourcing as an alternative outsourcing option. Despite the adoption of individuals and small and medium enterprises, there is a dearth of study that looks into the service providers (workers) in OSM. This paper addresses this gap by exploring the experiences of online workers from the Philippines, particularly software developers engaged in independent online work. Findings found at least six themes prevalent to online software developers (OSDs) including uncertainty and transitions, trust and work agreements, reputation and client relationships, accomplishing tasks, platforms and software support, and work practices. The study suggests that by looking at the experiences of software developers, current and future clients (employers) can gain insights in considering this outsourcing option. Moreover, OSMs can consider the needs of OSDs presented in this study as inputs in customizing their services.},
-   date                          = {July 1, 2017},
+   date                          = {July  1, 2017},
 }
 
 @inproceedings{RokrokShafiekhahOsorioEtAl2019,
@@ -79,7 +79,7 @@
    year                          = {2019},
    url                           = {https://aisel.aisnet.org/hicss-52/da/sustainability/2},
    abstract                      = {A significant procedure to ensure the consumer supply is Power System Restoration (PSR). Due to the increase of the number of distributed generators in the grid, it is possible to shift from the conventional PSR to a new strategy involving the use of distributed energy resources (DER). In this paper, a decentralized multi-agent system (MAS) is proposed to cope with the restoration procedure in a microgrid (MG). Each agent is assigned to a specific consumer or microsource (MS), communicating with other agents at every stage of the restoration procedure so that a common decision is reached. The 0/1 knapsack problem is the problem that every agent solves to determine the best load connection sequence during the restoration of the MG. Two different case studies are used to test the MAS on a dynamically modeled benchmark MG: a total blackout and a partial blackout. Regarding the partial blackout case, demand response emergency programs are considered to manage the loads in the MG. The MAS is developed in Matlab/Simulink environment and by performing the corresponding dynamic simulations it is possible to validate this system towards sustainability.},
-   date                          = {January 8, 2019},
+   date                          = {January  8, 2019},
 }
 
 @article{Unknown2021,
@@ -103,7 +103,7 @@
    number                        = {3},
    pages                         = {i--ii},
    url                           = {https://aisel.aisnet.org/misq/vol45/iss3/1},
-   date                          = {September 1, 2021},
+   date                          = {September  1, 2021},
 }
 
 @article{Unknown2021a,
@@ -126,6 +126,6 @@
    number                        = {4},
    pages                         = {2281--2284},
    url                           = {https://aisel.aisnet.org/misq/vol45/iss4/25},
-   date                          = {December 2, 2021},
+   date                          = {December  2, 2021},
 }
 

--- a/tests/3_packages_search/data/ebsco_bib_result.bib
+++ b/tests/3_packages_search/data/ebsco_bib_result.bib
@@ -3,7 +3,7 @@
    colrev_status                 = {md_needs_manual_preparation},
    colrev_masterdata_provenance  = {author:ebsco_bib.bib/13362467620181001;;
                                     journal:ebsco_bib.bib/13362467620181001;;
-                                    title:generic_field_requirements;missing;
+                                    title:ebsco_bib.bib/13362467620181001;;
                                     year:generic_field_requirements;missing;
                                     volume:generic_field_requirements;missing;
                                     number:generic_field_requirements;missing;},
@@ -11,12 +11,12 @@
                                     keywords:ebsco_bib.bib/13362467620181001;;},
    author                        = {Cruise, Tom},
    journal                       = {Journal of Technology},
-   title                         = {UNKNOWN},
+   title                         = {When sharing fixes prices},
    year                          = {UNKNOWN},
    volume                        = {UNKNOWN},
    number                        = {UNKNOWN},
    abstract                      = {While price-fixing},
-   keywords                      = {Price fixing, Sharing economy, Antitrust law, ). addSize(768, 0, 160, 250, 300, 320, 50).build(), 600, 600).build(), 728, 90, 90). addSize(0, 90). addSize(768, 90).build(), 970, @type:Person},
+   keywords                      = {Price fixing, Sharing economy, Antitrust law, ). addSize(768, 0, 160, 250, 300, 320, 50).build(), 600, 600).build(), 728, 90, 90). addSize(0, 90). addSize(768, 90).build(), 970, @type:Person}, @type:Person}, a more nuanced picture emerges regarding t, affiliation:Faculty of Law, agency, as shown by the Amazon poster case, author:{name:Nowag, author:{name:Nowag, copyrightHolder:Oxford University Press, copyrightYear:2018, description:Abstract. While price-fixing on platforms can attract severe enforcement action, employee, enforcement, googletag.cmd = googletag.cmd ||, googletag.cmd = googletag.cmd ||, googletag.cmd.push(function() { var pathChar = '/', googletag.cmd.push(function() { var pathChar = '/', gptAdSlotsad1 = googletag.defineSlot(pathChar+'116097782'+pathChar+'antitrustBehindAd1', 970, 90, 728, 90, 320, 50, 'adBlockHeader'). defineSizeMapping(mappingad1). addService(googletag.pubads()), gptAdSlotsad2 = googletag.defineSlot(pathChar+'116097782'+pathChar+'antitrustBehindAd2', 0},
 }
 
 @article{SmithSteward2000,

--- a/tests/3_packages_search/data/jstor_ris_result.bib
+++ b/tests/3_packages_search/data/jstor_ris_result.bib
@@ -46,7 +46,7 @@
    volume                        = {4},
    number                        = {4},
    pages                         = {80--87},
-   publisher                     = {University Press},
+   publisher                     = {University  Press},
    url                           = {http://www.jstor.org/stable/10.1111/something.2014.3.4.56},
    abstract                      = {This is another abstract.},
    issn                          = {21111112, 2777777X},

--- a/tests/3_packages_search/data/trid_ris_result.bib
+++ b/tests/3_packages_search/data/trid_ris_result.bib
@@ -31,10 +31,10 @@
    keywords                      = {Keyword one, Keyword two, Keyword three},
 }
 
-@techreport{AuthorOneAuthorTwoofaResearchCenterEtAl2019,
+@techreport{AuthorOneAuthorTwoCenterEtAl2019,
    colrev_origin                 = {trid_ris.ris/01744444;},
    colrev_status                 = {md_prepared},
-   colrev_masterdata_provenance  = {author:trid_ris.ris/01744444;erroneous-term-in-field;
+   colrev_masterdata_provenance  = {author:trid_ris.ris/01744444;erroneous-term-in-field,name-format-separators;
                                     pages:trid_ris.ris/01744444;;
                                     title:trid_ris.ris/01744444;;
                                     year:trid_ris.ris/01744444;;
@@ -45,7 +45,7 @@
                                     fulltext:trid_ris.ris/01744444;;
                                     keywords:trid_ris.ris/01744444;;
                                     url:trid_ris.ris/01744444;;},
-   author                        = {Author-One, A and Author-Two, B and of a Research Center, Name and of a University, Name},
+   author                        = {Author-One, A and Author-Two, B and Name of a Research Center and Name of a University},
    title                         = {Title of this citation},
    year                          = {2019},
    pages                         = {146p},

--- a/tests/data/corrections/SrivastavaShainesh2015.json
+++ b/tests/data/corrections/SrivastavaShainesh2015.json
@@ -17,14 +17,14 @@
                 "note": ""
             }
         },
+        "author": "Srivastava, Shirish C. and Shainesh, G.",
         "journal": "MIS Quarterly",
         "title": "Bridging the service divide through digitally enabled service innovations: {E}vidence from {I}ndian healthcare service providers",
         "year": "2015",
         "volume": "39",
         "number": "1",
         "pages": "245--267",
-        "language": "eng",
-        "author": "Srivastava, Shirish C. and Shainesh, G."
+        "language": "eng"
     },
     "changes": [
         [


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Replace pybtex by an internal BibTeX-parser:

- Pybtex implements name parsing, which is only needed in the load operation. A downside is that name parsing cannot be switched off, i.e., it consumes time for all other operations and also introduces differences between bib-files (changes not related to the actual operations). The change also allows us to drop a dependency.
- With the `format_names`, `fix_bib_file`, `resolve_crossref` flags deactivated (per default), BibTeX files are parsed up to 10x faster.
- Per default, the bib-parser introduces fewer formatting changes, which is useful for consistent version histories.
- The code of `get_record_header_items()` is integrated with `load_records_list()`.
- `format_names` is now also available for other parsers (ris, csv, ...).

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
