### PR TITLE
Fix typos across documentation and code

### DIFF
--- a/colrev/exceptions.py
+++ b/colrev/exceptions.py
@@ -384,7 +384,7 @@ class RecordNotFoundException(CoLRevException):
 
 
 class ImportException(CoLRevException):
-    """An error occured in the import functions."""
+    """An error occurred in the import functions."""
 
     def __init__(
         self,

--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -69,7 +69,7 @@ class Checker:
             raise colrev_exceptions.RepoSetupError(
                 "No colrev repository."
                 + "To retrieve a shared repository, use colrev init."
-                + "To initalize a new repository, "
+                + "To initialize a new repository, "
                 + "execute the command in an empty directory."
             )
 

--- a/colrev/ops/validate.py
+++ b/colrev/ops/validate.py
@@ -32,7 +32,7 @@ class Validate(colrev.process.operation.Operation):
         self.cpus = 4
 
     def _load_prior_records_dict(self, *, commit_sha: str) -> dict:
-        """If commit is "": return the last commited version of records"""
+        """If commit is "": return the last committed version of records"""
         git_repo = self.review_manager.dataset.get_repo()
         # Ensure the path uses forward slashes, which is compatible with Git's path handling
         records_file_path = self.review_manager.paths.RECORDS_FILE_GIT

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -247,7 +247,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
 
         if self.review_manager.dataset.has_record_changes():
             self.review_manager.logger.error(
-                "Cannot update github pages because there are uncommited changes."
+                "Cannot update github pages because there are uncommitted changes."
             )
             return
 

--- a/colrev/packages/semanticscholar/README.md
+++ b/colrev/packages/semanticscholar/README.md
@@ -25,7 +25,7 @@ Upon entering the command above with no additional parameters, a console interfa
 
 In the main menu, the user can decide whether they want to search for a single paper or author, or conduct a full keyword search. Authors can be searched for via their distinct SemanticScholar-ID, which the user is asked to enter into the console. Papers can be searched for by different IDs - SemanticScholarID, DOI, ArXiv etc.
 
-If the user opted for a full keyword search, they are asked to enter a series of search parameters: A query, a yearspan, fields of study, publication types etc. These parameters restrict the search within the SemanticScholar library to recieve more precise results.
+If the user opted for a full keyword search, they are asked to enter a series of search parameters: A query, a yearspan, fields of study, publication types etc. These parameters restrict the search within the SemanticScholar library to receive more precise results.
 
 For all search parameters except the query, the user can press the `enter` key to leave them blank. The query then will not restrict the search in the respective parameters, resulting in an increasingly broad search and more returned papers.
 

--- a/colrev/packages/springer_link/README.md
+++ b/colrev/packages/springer_link/README.md
@@ -64,7 +64,7 @@ The user can type the individual search constraints that can also use the boolea
 
 For additional contraints visit the SpringerLink API Documentation (Link below).
 
-#### API search: entering the search paramters
+#### API search: entering the search parameters
 
 In this step the user can enter the search parameters into the console.
 The user can provide values for the following parameters: keyword, subject, language, year and type. Pressing `enter` will confirm the choice. If the field is blank, this parameter will be skipped. The parameters should be entered as followed:

--- a/docs/source/manual/packages/colrev.semanticscholar.rst
+++ b/docs/source/manual/packages/colrev.semanticscholar.rst
@@ -85,7 +85,7 @@ API search: The user interface
 
 In the main menu, the user can decide whether they want to search for a single paper or author, or conduct a full keyword search. Authors can be searched for via their distinct SemanticScholar-ID, which the user is asked to enter into the console. Papers can be searched for by different IDs - SemanticScholarID, DOI, ArXiv etc.
 
-If the user opted for a full keyword search, they are asked to enter a series of search parameters: A query, a yearspan, fields of study, publication types etc. These parameters restrict the search within the SemanticScholar library to recieve more precise results.
+If the user opted for a full keyword search, they are asked to enter a series of search parameters: A query, a yearspan, fields of study, publication types etc. These parameters restrict the search within the SemanticScholar library to receive more precise results.
 
 For all search parameters except the query, the user can press the ``enter`` key to leave them blank. The query then will not restrict the search in the respective parameters, resulting in an increasingly broad search and more returned papers.
 

--- a/docs/source/manual/packages/colrev.springer_link.rst
+++ b/docs/source/manual/packages/colrev.springer_link.rst
@@ -128,7 +128,7 @@ Other Constraints supported by the Springers Nature API
 
 For additional contraints visit the SpringerLink API Documentation (Link below).
 
-API search: entering the search paramters
+API search: entering the search parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this step the user can enter the search parameters into the console.


### PR DESCRIPTION
## Summary
- correct spelling in import exception message
- fix typographical errors in command line docs
- fix typos in GitHub pages error message and validation function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'git')*

------
https://chatgpt.com/codex/tasks/task_e_686cdb41d2c8832a9dcde1024eeb1a68