### PR TITLE
Add optional logger parameter to package base class constructors

### DIFF
--- a/colrev/package_manager/init.py
+++ b/colrev/package_manager/init.py
@@ -365,7 +365,6 @@ def _get_package_imports(plugin: str) -> str:
         return "import colrev.ops.data"
     if plugin == "search_source":
         return """from pathlib import Path
-import logging
 import colrev.process.operation"""
     if plugin == "prep":
         return "import colrev.ops.prep"
@@ -418,6 +417,8 @@ def generate_module_content(
 
     module_content = f'''#! /usr/bin/env python
 """{class_name}"""
+import logging
+
 {package_imports}
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import {baseclass}

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python
 """Package interfaces."""
 from __future__ import annotations
-import logging
 
 import abc
+import logging
 import typing
 from abc import ABC
 from abc import abstractmethod

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import abc
-import logging
 import typing
 from abc import ABC
 from abc import abstractmethod

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -41,7 +41,7 @@ class ReviewTypePackageBaseClass(abc.ABC):
         *,
         operation: colrev.process.operation.Operation,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -78,7 +78,7 @@ class SearchSourcePackageBaseClass(ABC):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -148,7 +148,7 @@ class PrepPackageBaseClass(ABC):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -178,7 +178,7 @@ class PrepManPackageBaseClass(ABC):
         *,
         prep_man_operation: colrev.ops.prep_man.PrepMan,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -205,7 +205,7 @@ class DedupePackageBaseClass(ABC):
         *,
         dedupe_operation: colrev.ops.dedupe.Dedupe,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ):
         pass
 
@@ -232,7 +232,7 @@ class PrescreenPackageBaseClass(ABC):
         *,
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -259,7 +259,7 @@ class PDFGetPackageBaseClass(ABC):
         *,
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -287,7 +287,7 @@ class PDFGetManPackageBaseClass(ABC):
         *,
         pdf_get_man_operation: colrev.ops.pdf_get_man.PDFGetMan,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -314,7 +314,7 @@ class PDFPrepPackageBaseClass(ABC):
         *,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -343,7 +343,7 @@ class PDFPrepManPackageBaseClass(ABC):
         *,
         pdf_prep_man_operation: colrev.ops.pdf_prep_man.PDFPrepMan,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -371,7 +371,7 @@ class ScreenPackageBaseClass(ABC):
         *,
         screen_operation: colrev.ops.screen.Screen,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 
@@ -398,7 +398,7 @@ class DataPackageBaseClass(ABC):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
-        logger: logging.Logger = logging.getLogger(__name__),
+        logger: logging.Logger = None,
     ) -> None:
         pass
 

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import abc
+import logging
 import typing
 from abc import ABC
 from abc import abstractmethod
-import logging
 from pathlib import Path
 from typing import Type
 

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -6,6 +6,7 @@ import abc
 import typing
 from abc import ABC
 from abc import abstractmethod
+import logging
 from pathlib import Path
 from typing import Type
 
@@ -37,7 +38,11 @@ class ReviewTypePackageBaseClass(abc.ABC):
 
     @abstractmethod
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -74,6 +79,7 @@ class SearchSourcePackageBaseClass(ABC):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -143,6 +149,7 @@ class PrepPackageBaseClass(ABC):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -168,7 +175,11 @@ class PrepManPackageBaseClass(ABC):
 
     @abstractmethod
     def __init__(
-        self, *, prep_man_operation: colrev.ops.prep_man.PrepMan, settings: dict
+        self,
+        *,
+        prep_man_operation: colrev.ops.prep_man.PrepMan,
+        settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -195,6 +206,7 @@ class DedupePackageBaseClass(ABC):
         *,
         dedupe_operation: colrev.ops.dedupe.Dedupe,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ):
         pass
 
@@ -221,6 +233,7 @@ class PrescreenPackageBaseClass(ABC):
         *,
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -247,6 +260,7 @@ class PDFGetPackageBaseClass(ABC):
         *,
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -274,6 +288,7 @@ class PDFGetManPackageBaseClass(ABC):
         *,
         pdf_get_man_operation: colrev.ops.pdf_get_man.PDFGetMan,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -300,6 +315,7 @@ class PDFPrepPackageBaseClass(ABC):
         *,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -328,6 +344,7 @@ class PDFPrepManPackageBaseClass(ABC):
         *,
         pdf_prep_man_operation: colrev.ops.pdf_prep_man.PDFPrepMan,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -355,6 +372,7 @@ class ScreenPackageBaseClass(ABC):
         *,
         screen_operation: colrev.ops.screen.Screen,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 
@@ -381,6 +399,7 @@ class DataPackageBaseClass(ABC):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         pass
 

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Package interfaces."""
 from __future__ import annotations
+import logging
 
 import abc
 import typing
@@ -15,7 +16,6 @@ from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    import logging
     import colrev.record.record
     import colrev.settings
     import colrev.ops

--- a/tests/data/package_init/data.py
+++ b/tests/data/package_init/data.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.data
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import DataPackageBaseClass

--- a/tests/data/package_init/data.py
+++ b/tests/data/package_init/data.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import DataPackageBaseClass
 
 class CustomName(DataPackageBaseClass):
 
-    def __init__(self, *, data_operation: 'colrev.ops.data.Data', settings: 'dict') -> 'None':
+    def __init__(self, *, data_operation: 'colrev.ops.data.Data', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def get_advice(self) -> 'dict':

--- a/tests/data/package_init/data.py
+++ b/tests/data/package_init/data.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import DataPackageBaseClass
 
 class CustomName(DataPackageBaseClass):
 
-    def __init__(self, *, data_operation: 'colrev.ops.data.Data', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, data_operation: 'colrev.ops.data.Data', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def get_advice(self) -> 'dict':

--- a/tests/data/package_init/dedupe.py
+++ b/tests/data/package_init/dedupe.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import DedupePackageBaseClass
 
 class CustomName(DedupePackageBaseClass):
 
-    def __init__(self, *, dedupe_operation: 'colrev.ops.dedupe.Dedupe', settings: 'dict'):
+    def __init__(self, *, dedupe_operation: 'colrev.ops.dedupe.Dedupe', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)):
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def run_dedupe(self) -> 'None':

--- a/tests/data/package_init/dedupe.py
+++ b/tests/data/package_init/dedupe.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.dedupe
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import DedupePackageBaseClass

--- a/tests/data/package_init/dedupe.py
+++ b/tests/data/package_init/dedupe.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import DedupePackageBaseClass
 
 class CustomName(DedupePackageBaseClass):
 
-    def __init__(self, *, dedupe_operation: 'colrev.ops.dedupe.Dedupe', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)):
+    def __init__(self, *, dedupe_operation: 'colrev.ops.dedupe.Dedupe', settings: 'dict', logger: 'logging.Logger' = None):
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def run_dedupe(self) -> 'None':

--- a/tests/data/package_init/pdf_get.py
+++ b/tests/data/package_init/pdf_get.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.pdf_get
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import PDFGetPackageBaseClass

--- a/tests/data/package_init/pdf_get.py
+++ b/tests/data/package_init/pdf_get.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import PDFGetPackageBaseClass
 
 class CustomName(PDFGetPackageBaseClass):
 
-    def __init__(self, *, pdf_get_operation: 'colrev.ops.pdf_get.PDFGet', settings: 'dict') -> 'None':
+    def __init__(self, *, pdf_get_operation: 'colrev.ops.pdf_get.PDFGet', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def get_pdf(self, record: 'colrev.record.record.Record') -> 'colrev.record.record.Record':

--- a/tests/data/package_init/pdf_get.py
+++ b/tests/data/package_init/pdf_get.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import PDFGetPackageBaseClass
 
 class CustomName(PDFGetPackageBaseClass):
 
-    def __init__(self, *, pdf_get_operation: 'colrev.ops.pdf_get.PDFGet', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, pdf_get_operation: 'colrev.ops.pdf_get.PDFGet', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def get_pdf(self, record: 'colrev.record.record.Record') -> 'colrev.record.record.Record':

--- a/tests/data/package_init/pdf_get_man.py
+++ b/tests/data/package_init/pdf_get_man.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.pdf_get_man
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import PDFGetManPackageBaseClass

--- a/tests/data/package_init/pdf_get_man.py
+++ b/tests/data/package_init/pdf_get_man.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import PDFGetManPackageBaseClas
 
 class CustomName(PDFGetManPackageBaseClass):
 
-    def __init__(self, *, pdf_get_man_operation: 'colrev.ops.pdf_get_man.PDFGetMan', settings: 'dict') -> 'None':
+    def __init__(self, *, pdf_get_man_operation: 'colrev.ops.pdf_get_man.PDFGetMan', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def pdf_get_man(self, records: 'dict') -> 'dict':

--- a/tests/data/package_init/pdf_get_man.py
+++ b/tests/data/package_init/pdf_get_man.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import PDFGetManPackageBaseClas
 
 class CustomName(PDFGetManPackageBaseClass):
 
-    def __init__(self, *, pdf_get_man_operation: 'colrev.ops.pdf_get_man.PDFGetMan', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, pdf_get_man_operation: 'colrev.ops.pdf_get_man.PDFGetMan', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def pdf_get_man(self, records: 'dict') -> 'dict':

--- a/tests/data/package_init/pdf_prep.py
+++ b/tests/data/package_init/pdf_prep.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import PDFPrepPackageBaseClass
 
 class CustomName(PDFPrepPackageBaseClass):
 
-    def __init__(self, *, pdf_prep_operation: 'colrev.ops.pdf_prep.PDFPrep', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, pdf_prep_operation: 'colrev.ops.pdf_prep.PDFPrep', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prep_pdf(self, record: 'colrev.record.record_pdf.PDFRecord', pad: 'int') -> 'colrev.record.record.Record':

--- a/tests/data/package_init/pdf_prep.py
+++ b/tests/data/package_init/pdf_prep.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import PDFPrepPackageBaseClass
 
 class CustomName(PDFPrepPackageBaseClass):
 
-    def __init__(self, *, pdf_prep_operation: 'colrev.ops.pdf_prep.PDFPrep', settings: 'dict') -> 'None':
+    def __init__(self, *, pdf_prep_operation: 'colrev.ops.pdf_prep.PDFPrep', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prep_pdf(self, record: 'colrev.record.record_pdf.PDFRecord', pad: 'int') -> 'colrev.record.record.Record':

--- a/tests/data/package_init/pdf_prep.py
+++ b/tests/data/package_init/pdf_prep.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.pdf_prep
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import PDFPrepPackageBaseClass

--- a/tests/data/package_init/pdf_prep_man.py
+++ b/tests/data/package_init/pdf_prep_man.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import PDFPrepManPackageBaseCla
 
 class CustomName(PDFPrepManPackageBaseClass):
 
-    def __init__(self, *, pdf_prep_man_operation: 'colrev.ops.pdf_prep_man.PDFPrepMan', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, pdf_prep_man_operation: 'colrev.ops.pdf_prep_man.PDFPrepMan', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def pdf_prep_man(self, records: 'dict') -> 'dict':

--- a/tests/data/package_init/pdf_prep_man.py
+++ b/tests/data/package_init/pdf_prep_man.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.pdf_prep_man
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import PDFPrepManPackageBaseClass

--- a/tests/data/package_init/pdf_prep_man.py
+++ b/tests/data/package_init/pdf_prep_man.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import PDFPrepManPackageBaseCla
 
 class CustomName(PDFPrepManPackageBaseClass):
 
-    def __init__(self, *, pdf_prep_man_operation: 'colrev.ops.pdf_prep_man.PDFPrepMan', settings: 'dict') -> 'None':
+    def __init__(self, *, pdf_prep_man_operation: 'colrev.ops.pdf_prep_man.PDFPrepMan', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def pdf_prep_man(self, records: 'dict') -> 'dict':

--- a/tests/data/package_init/prep.py
+++ b/tests/data/package_init/prep.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import PrepPackageBaseClass
 
 class CustomName(PrepPackageBaseClass):
 
-    def __init__(self, *, prep_operation: 'colrev.ops.prep.Prep', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, prep_operation: 'colrev.ops.prep.Prep', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prepare(self, record: 'colrev.record.record_prep.PrepRecord') -> 'colrev.record.record.Record':

--- a/tests/data/package_init/prep.py
+++ b/tests/data/package_init/prep.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import PrepPackageBaseClass
 
 class CustomName(PrepPackageBaseClass):
 
-    def __init__(self, *, prep_operation: 'colrev.ops.prep.Prep', settings: 'dict') -> 'None':
+    def __init__(self, *, prep_operation: 'colrev.ops.prep.Prep', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prepare(self, record: 'colrev.record.record_prep.PrepRecord') -> 'colrev.record.record.Record':

--- a/tests/data/package_init/prep.py
+++ b/tests/data/package_init/prep.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.prep
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import PrepPackageBaseClass

--- a/tests/data/package_init/prep_man.py
+++ b/tests/data/package_init/prep_man.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.prep_man
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import PrepManPackageBaseClass

--- a/tests/data/package_init/prep_man.py
+++ b/tests/data/package_init/prep_man.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import PrepManPackageBaseClass
 
 class CustomName(PrepManPackageBaseClass):
 
-    def __init__(self, *, prep_man_operation: 'colrev.ops.prep_man.PrepMan', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, prep_man_operation: 'colrev.ops.prep_man.PrepMan', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prepare_manual(self, records: 'dict') -> 'dict':

--- a/tests/data/package_init/prep_man.py
+++ b/tests/data/package_init/prep_man.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import PrepManPackageBaseClass
 
 class CustomName(PrepManPackageBaseClass):
 
-    def __init__(self, *, prep_man_operation: 'colrev.ops.prep_man.PrepMan', settings: 'dict') -> 'None':
+    def __init__(self, *, prep_man_operation: 'colrev.ops.prep_man.PrepMan', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prepare_manual(self, records: 'dict') -> 'dict':

--- a/tests/data/package_init/prescreen.py
+++ b/tests/data/package_init/prescreen.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import PrescreenPackageBaseClas
 
 class CustomName(PrescreenPackageBaseClass):
 
-    def __init__(self, *, prescreen_operation: 'colrev.ops.prescreen.Prescreen', settings: 'dict') -> 'None':
+    def __init__(self, *, prescreen_operation: 'colrev.ops.prescreen.Prescreen', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def run_prescreen(self, records: 'dict', split: 'list') -> 'dict':

--- a/tests/data/package_init/prescreen.py
+++ b/tests/data/package_init/prescreen.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.prescreen
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import PrescreenPackageBaseClass

--- a/tests/data/package_init/prescreen.py
+++ b/tests/data/package_init/prescreen.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import PrescreenPackageBaseClas
 
 class CustomName(PrescreenPackageBaseClass):
 
-    def __init__(self, *, prescreen_operation: 'colrev.ops.prescreen.Prescreen', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, prescreen_operation: 'colrev.ops.prescreen.Prescreen', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def run_prescreen(self, records: 'dict', split: 'list') -> 'dict':

--- a/tests/data/package_init/review_type.py
+++ b/tests/data/package_init/review_type.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import ReviewTypePackageBaseCla
 
 class CustomName(ReviewTypePackageBaseClass):
 
-    def __init__(self, *, operation: 'colrev.process.operation.Operation', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, operation: 'colrev.process.operation.Operation', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def initialize(self, settings: 'colrev.settings.Settings') -> 'dict':

--- a/tests/data/package_init/review_type.py
+++ b/tests/data/package_init/review_type.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.data
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import ReviewTypePackageBaseClass

--- a/tests/data/package_init/review_type.py
+++ b/tests/data/package_init/review_type.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import ReviewTypePackageBaseCla
 
 class CustomName(ReviewTypePackageBaseClass):
 
-    def __init__(self, *, operation: 'colrev.process.operation.Operation', settings: 'dict') -> 'None':
+    def __init__(self, *, operation: 'colrev.process.operation.Operation', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def initialize(self, settings: 'colrev.settings.Settings') -> 'dict':

--- a/tests/data/package_init/screen.py
+++ b/tests/data/package_init/screen.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
+
 import colrev.ops.screen
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import ScreenPackageBaseClass

--- a/tests/data/package_init/screen.py
+++ b/tests/data/package_init/screen.py
@@ -8,7 +8,7 @@ from colrev.package_manager.package_base_classes import ScreenPackageBaseClass
 
 class CustomName(ScreenPackageBaseClass):
 
-    def __init__(self, *, screen_operation: 'colrev.ops.screen.Screen', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, screen_operation: 'colrev.ops.screen.Screen', settings: 'dict', logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def run_screen(self, records: 'dict', split: 'list') -> 'dict':

--- a/tests/data/package_init/screen.py
+++ b/tests/data/package_init/screen.py
@@ -6,7 +6,7 @@ from colrev.package_manager.package_base_classes import ScreenPackageBaseClass
 
 class CustomName(ScreenPackageBaseClass):
 
-    def __init__(self, *, screen_operation: 'colrev.ops.screen.Screen', settings: 'dict') -> 'None':
+    def __init__(self, *, screen_operation: 'colrev.ops.screen.Screen', settings: 'dict', logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def run_screen(self, records: 'dict', split: 'list') -> 'dict':

--- a/tests/data/package_init/search_source.py
+++ b/tests/data/package_init/search_source.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python
 """CustomName"""
+import logging
 import typing
 
 from pathlib import Path
-import logging
 import colrev.process.operation
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import SearchSourcePackageBaseClass

--- a/tests/data/package_init/search_source.py
+++ b/tests/data/package_init/search_source.py
@@ -10,7 +10,7 @@ from colrev.package_manager.package_base_classes import SearchSourcePackageBaseC
 
 class CustomName(SearchSourcePackageBaseClass):
 
-    def __init__(self, *, source_operation: 'colrev.process.operation.Operation', settings: 'typing.Optional[dict]' = None) -> 'None':
+    def __init__(self, *, source_operation: 'colrev.process.operation.Operation', settings: 'typing.Optional[dict]' = None, logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prep_link_md(self, prep_operation: 'colrev.ops.prep.Prep', record: 'colrev.record.record.Record', save_feed: 'bool' = True, timeout: 'int' = 10) -> 'colrev.record.record.Record':

--- a/tests/data/package_init/search_source.py
+++ b/tests/data/package_init/search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """CustomName"""
 import logging
+
 import typing
 
 from pathlib import Path
@@ -10,7 +11,7 @@ from colrev.package_manager.package_base_classes import SearchSourcePackageBaseC
 
 class CustomName(SearchSourcePackageBaseClass):
 
-    def __init__(self, *, source_operation: 'colrev.process.operation.Operation', settings: 'typing.Optional[dict]' = None, logger: 'logging.Logger' = logging.getLogger(__name__)) -> 'None':
+    def __init__(self, *, source_operation: 'colrev.process.operation.Operation', settings: 'typing.Optional[dict]' = None, logger: 'logging.Logger' = None) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prep_link_md(self, prep_operation: 'colrev.ops.prep.Prep', record: 'colrev.record.record.Record', save_feed: 'bool' = True, timeout: 'int' = 10) -> 'colrev.record.record.Record':


### PR DESCRIPTION
## Summary
- accept optional `logger` parameter in all package base class constructors
- adapt generated package templates for new parameter

## Testing
- `pre-commit` *(fails: unable to access github.com)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'colrev')*

------
https://chatgpt.com/codex/tasks/task_e_688cd02a9d40832a8f114004cffaa118