### PR TITLE
Add optional logger support

### DIFF
--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: ABI/INFORM (ProQuest)"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -36,8 +37,10 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://search.proquest.com/abicomplete/advanced"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.search_source = self.settings_class(**settings)
         self.source_operation = source_operation

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: ABI/INFORM (ProQuest)"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -37,7 +37,10 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://search.proquest.com/abicomplete/advanced"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: ACM Digital Library"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 from pathlib import Path
@@ -34,8 +35,10 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://dl.acm.org/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
         self.operation = source_operation

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """SearchSource: ACM Digital Library"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -35,7 +35,10 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://dl.acm.org/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
+++ b/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Adding of journal rankings to metadata"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -27,7 +29,9 @@ class AddJournalRanking(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.local_index = colrev.env.local_index.LocalIndex()
 

--- a/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
+++ b/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Adding of journal rankings to metadata"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=too-few-public-methods
 

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: AIS electronic Library"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -67,8 +68,10 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     }
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
         self.quality_model = self.review_manager.get_qm()
@@ -208,14 +211,14 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         source = self.search_source
 
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         if source.search_type == SearchType.API:
             if "query" not in source.search_parameters:
                 # if "search_terms" not in source.search_parameters["query"]:
                 raise colrev_exceptions.InvalidQueryException("query parameter missing")
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def _get_ais_query_return(self) -> list:
         def query_from_params(params: dict) -> str:
@@ -260,7 +263,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
             id_labeler=ais_load_utils.enl_id_labeler,
             entrytype_setter=ais_load_utils.enl_entrytype_setter,
             field_mapper=ais_load_utils.enl_field_mapper,
-            logger=self.review_manager.logger,
+            logger=self.logger,
         )
 
         return list(records.values())
@@ -274,7 +277,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         # pylint: disable=too-many-branches
 
         if rerun:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Performing a search of the full history (may take time)"
             )
 

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: AIS electronic Library"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 import urllib.parse
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 import requests
@@ -68,7 +68,10 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     }
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
@@ -277,9 +280,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         # pylint: disable=too-many-branches
 
         if rerun:
-            self.logger.info(
-                "Performing a search of the full history (may take time)"
-            )
+            self.logger.info("Performing a search of the full history (may take time)")
 
         try:
             for record_dict in self._get_ais_query_return():

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: arXiv"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -46,7 +47,9 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # arXiv as a search_source
@@ -133,7 +136,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
     ) -> None:
         """Validate the SearchSource (parameters etc.)"""
 
-        search_operation.review_manager.logger.debug(
+        self.logger.debug(
             f"Validate SearchSource {source.filename}"
         )
 
@@ -146,7 +149,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
             # if "query_file" in source.search_parameters:
             # ...
 
-        search_operation.review_manager.logger.debug(
+        self.logger.debug(
             f"SearchSource {source.filename} validated"
         )
 
@@ -200,11 +203,11 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
     #         headers = {"user-agent": f"{__name__} (mailto:{self.email})"}
     #         session = self.review_manager.get_cached_session()
 
-    #         # review_manager.logger.debug(url)
+    #         # self.logger.debug(url)
     #         ret = session.request("GET", url, headers=headers, timeout=timeout)
     #         ret.raise_for_status()
     #         if ret.status_code != 200:
-    #             # review_manager.logger.debug(
+    #             # self.logger.debug(
     #             #     f"crossref_query failed with status {ret.status_code}"
     #             # )
     #             return {"arxiv_id": arxiv_id}
@@ -264,7 +267,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         rerun: bool,
     ) -> None:
         if rerun:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Performing a search of the full history (may take time)"
             )
 
@@ -275,7 +278,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
                     if "" == record_dict.get(
                         Fields.AUTHOR, ""
                     ) and "" == record_dict.get(Fields.TITLE, ""):
-                        self.review_manager.logger.warning(
+                        self.logger.warning(
                             f"Skipped record: {record_dict}"
                         )
                         continue

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: arXiv"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 import feedparser
@@ -136,9 +136,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
     ) -> None:
         """Validate the SearchSource (parameters etc.)"""
 
-        self.logger.debug(
-            f"Validate SearchSource {source.filename}"
-        )
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         if source.filename.name != self._arxiv_md_filename.name:
             if "query" not in source.search_parameters:
@@ -149,9 +147,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
             # if "query_file" in source.search_parameters:
             # ...
 
-        self.logger.debug(
-            f"SearchSource {source.filename} validated"
-        )
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def check_availability(
         self, *, source_operation: colrev.process.operation.Operation
@@ -267,9 +263,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         rerun: bool,
     ) -> None:
         if rerun:
-            self.logger.info(
-                "Performing a search of the full history (may take time)"
-            )
+            self.logger.info("Performing a search of the full history (may take time)")
 
         try:
             for record_dict in self._get_arxiv_query_return():
@@ -278,9 +272,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
                     if "" == record_dict.get(
                         Fields.AUTHOR, ""
                     ) and "" == record_dict.get(Fields.TITLE, ""):
-                        self.logger.warning(
-                            f"Skipped record: {record_dict}"
-                        )
+                        self.logger.warning(f"Skipped record: {record_dict}")
                         continue
 
                     prep_record = colrev.record.record_prep.PrepRecord(record_dict)

--- a/colrev/packages/bibliography_export/src/bibliography_export.py
+++ b/colrev/packages/bibliography_export/src/bibliography_export.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Export of references in different bibliographical formats as a data operation"""
 from __future__ import annotations
+from typing import Optional
 
 import copy
 from enum import Enum
@@ -20,6 +21,7 @@ from colrev.constants import Fields
 from colrev.constants import FieldSet
 from colrev.constants import RecordState
 from colrev.writer.write_utils import write_file
+import logging
 
 
 class BibFormats(Enum):
@@ -64,7 +66,9 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
 
         if "bib_format" not in settings:
@@ -77,7 +81,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
         self.endpoint_path = self.review_manager.paths.output
 
     def _export(self, *, selected_records: dict) -> None:
-        self.review_manager.logger.info(f"Export {self.settings.bib_format.name}")
+        self.logger.info(f"Export {self.settings.bib_format.name}")
 
         if self.settings.bib_format is BibFormats.zotero:
             export_filepath = self.endpoint_path / Path("zotero.bib")
@@ -189,7 +193,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
             self._export(selected_records=selected_records)
 
         except NotImplementedError:
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Not yet implemented ({self.settings.bib_format})"
             )
 

--- a/colrev/packages/bibliography_export/src/bibliography_export.py
+++ b/colrev/packages/bibliography_export/src/bibliography_export.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Export of references in different bibliographical formats as a data operation"""
 from __future__ import annotations
-from typing import Optional
 
 import copy
+import logging
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import inquirer
 from pydantic import BaseModel
@@ -21,7 +22,6 @@ from colrev.constants import Fields
 from colrev.constants import FieldSet
 from colrev.constants import RecordState
 from colrev.writer.write_utils import write_file
-import logging
 
 
 class BibFormats(Enum):
@@ -193,9 +193,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
             self._export(selected_records=selected_records)
 
         except NotImplementedError:
-            self.logger.info(
-                f"Not yet implemented ({self.settings.bib_format})"
-            )
+            self.logger.info(f"Not yet implemented ({self.settings.bib_format})")
 
     def update_record_status_matrix(
         self,

--- a/colrev/packages/blank/src/blank.py
+++ b/colrev/packages/blank/src/blank.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Blank literature review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -20,8 +22,10 @@ class BlankReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/blank/src/blank.py
+++ b/colrev/packages/blank/src/blank.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Blank literature review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,7 +23,10 @@ class BlankReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
+++ b/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 """CliPrepMan"""
-from typing import Optional
+import logging
 import typing
+from typing import Optional
 
 import inquirer
 
@@ -11,7 +12,6 @@ from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.package_manager.package_base_classes import PrepManPackageBaseClass
 from colrev.packages.crossref.src import crossref_api
-import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -20,7 +20,10 @@ class CliPrepMan(PrepManPackageBaseClass):
     """CLI for manual preparation of records"""
 
     def __init__(
-        self, *, prep_man_operation: colrev.ops.prep_man.PrepMan, settings: dict,
+        self,
+        *,
+        prep_man_operation: colrev.ops.prep_man.PrepMan,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> "None":
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
+++ b/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """CliPrepMan"""
+from typing import Optional
 import typing
 
 import inquirer
@@ -10,6 +11,7 @@ from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.package_manager.package_base_classes import PrepManPackageBaseClass
 from colrev.packages.crossref.src import crossref_api
+import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -18,8 +20,10 @@ class CliPrepMan(PrepManPackageBaseClass):
     """CLI for manual preparation of records"""
 
     def __init__(
-        self, *, prep_man_operation: colrev.ops.prep_man.PrepMan, settings: dict
+        self, *, prep_man_operation: colrev.ops.prep_man.PrepMan, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> "None":
+        self.logger = logger or logging.getLogger(__name__)
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def _get_choices(

--- a/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """CLI interface for manual retrieval of PDFs"""
 from __future__ import annotations
+from typing import Optional
 
 import shutil
 import urllib.parse
@@ -17,6 +18,7 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -34,7 +36,9 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
         *,
         pdf_get_man_operation: colrev.ops.pdf_get_man.PDFGetMan,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_man_operation.review_manager
         self.pdf_get_man_operation = pdf_get_man_operation
@@ -211,7 +215,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
         *,
         record: colrev.record.record.Record,
     ) -> None:
-        # self.review_manager.logger.debug(
+        # self.logger.debug(
         #     f"called pdf_get_man_cli for {record}"
         # )
 
@@ -229,7 +233,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
 
         filepath = self._get_filepath(record=record)
         for retrieval_script in retrieval_scripts.values():
-            # self.review_manager.logger.debug(
+            # self.logger.debug(
             #     f'{script_name}({record.data[Fields.ID]}) called'
             # )
             record = retrieval_script(record)
@@ -260,7 +264,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
     def pdf_get_man(self, records: dict) -> dict:
         """Get the PDF manually based on a cli"""
 
-        self.review_manager.logger.info("Retrieve PDFs manually")
+        self.logger.info("Retrieve PDFs manually")
         pdf_get_operation = self.review_manager.get_pdf_get_operation()
         pdf_dir = self.pdf_dir
 
@@ -278,7 +282,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
         self.pdf_get_man_operation.export_retrieval_table(records)
         pdf_get_man_data = self.pdf_get_man_operation.get_data()
         if pdf_get_man_data["nr_tasks"] == 0:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "No tasks for PDF retrieval (run colrev pdf-get )."
             )
             return records
@@ -304,7 +308,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
                     manual_author=True,
                 )
         else:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Retrieve PDFs manually and copy the files to "
                 f"the {pdf_dir}. Afterwards, use "
                 "colrev pdf-get-man"

--- a/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """CLI interface for manual retrieval of PDFs"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import shutil
 import urllib.parse
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -18,7 +19,6 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -282,9 +282,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
         self.pdf_get_man_operation.export_retrieval_table(records)
         pdf_get_man_data = self.pdf_get_man_operation.get_data()
         if pdf_get_man_data["nr_tasks"] == 0:
-            self.logger.info(
-                "No tasks for PDF retrieval (run colrev pdf-get )."
-            )
+            self.logger.info("No tasks for PDF retrieval (run colrev pdf-get ).")
             return records
         print(
             "\nInstructions\n\n      "

--- a/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """CLI interface for manual preparation of PDFs"""
 from __future__ import annotations
+from typing import Optional
 
 import os
 import platform
@@ -21,6 +22,7 @@ from colrev.constants import Colors
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -38,7 +40,9 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
         *,
         pdf_prep_man_operation: colrev.ops.pdf_prep_man.PDFPrepMan,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_man_operation.review_manager
         self.pdf_prep_man_operation = pdf_prep_man_operation
@@ -345,7 +349,7 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
     def pdf_prep_man(self, records: dict) -> dict:
         """Prepare PDF manually based on a cli"""
 
-        self.review_manager.logger.info("Loading data for pdf_prep_man")
+        self.logger.info("Loading data for pdf_prep_man")
         pdf_prep_man_data = self.pdf_prep_man_operation.get_data()
         records = self.review_manager.dataset.load_records_dict()
 
@@ -372,7 +376,7 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
                     manual_author=True,
                 )
         else:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Prepare PDFs manually. Afterwards, use colrev pdf-get-man"
             )
 

--- a/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
@@ -1,14 +1,15 @@
 #! /usr/bin/env python
 """CLI interface for manual preparation of PDFs"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import os
 import platform
 import re
 import subprocess
 import textwrap
 from pathlib import Path
+from typing import Optional
 
 import inquirer
 from pydantic import Field
@@ -22,7 +23,6 @@ from colrev.constants import Colors
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 # pylint: disable=too-few-public-methods
 

--- a/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
+++ b/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Prescreen based on CLI"""
 from __future__ import annotations
+from typing import Optional
 
 import textwrap
 
@@ -13,6 +14,7 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -30,7 +32,9 @@ class CoLRevCLIPrescreen(base_classes.PrescreenPackageBaseClass):
         *,
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prescreen_operation = prescreen_operation
         self.review_manager = prescreen_operation.review_manager
@@ -76,10 +80,10 @@ class CoLRevCLIPrescreen(base_classes.PrescreenPackageBaseClass):
         stat_len: int,
         padding: int,
     ) -> bool:
-        self.review_manager.logger.debug("Start prescreen")
+        self.logger.debug("Start prescreen")
 
         if 0 == stat_len:
-            self.review_manager.logger.info("No records to prescreen")
+            self.logger.info("No records to prescreen")
 
         i, quit_pressed = 0, False
         for record_dict in prescreen_data["items"]:
@@ -108,7 +112,7 @@ class CoLRevCLIPrescreen(base_classes.PrescreenPackageBaseClass):
                     inclusion_decision_str = ret.replace("y", "yes").replace("n", "no")
 
             if quit_pressed:
-                self.review_manager.logger.info("Stop prescreen")
+                self.logger.info("Stop prescreen")
                 break
 
             if ret == "s":

--- a/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
+++ b/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Prescreen based on CLI"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import textwrap
+from typing import Optional
 
 from pydantic import Field
 
@@ -14,7 +15,6 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/colrev_cli_screen/src/screen_cli.py
+++ b/colrev/packages/colrev_cli_screen/src/screen_cli.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Screen based on CLI"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from inquirer import Checkbox
@@ -16,7 +18,6 @@ import colrev.settings
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import ScreenCriterionType
-import logging
 
 
 class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):

--- a/colrev/packages/colrev_cli_screen/src/screen_cli.py
+++ b/colrev/packages/colrev_cli_screen/src/screen_cli.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Screen based on CLI"""
 from __future__ import annotations
+from typing import Optional
 
 from inquirer import Checkbox
 from inquirer import prompt
@@ -15,6 +16,7 @@ import colrev.settings
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import ScreenCriterionType
+import logging
 
 
 class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
@@ -32,7 +34,9 @@ class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
         *,
         screen_operation: colrev.ops.screen.Screen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = screen_operation.review_manager
         self.screen_operation = screen_operation
         self.settings = self.settings_class(**settings)
@@ -193,7 +197,7 @@ class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
                 decision = ret
 
         if quit_pressed:
-            self.review_manager.logger.info("Stop screen")
+            self.logger.info("Stop screen")
             return "quit"
 
         if decision == "y":
@@ -243,7 +247,7 @@ class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
         self._stat_len = screen_data["nr_tasks"]
 
         if 0 == self._stat_len:
-            self.review_manager.logger.info("No records to prescreen")
+            self.logger.info("No records to prescreen")
 
         records = self.review_manager.dataset.load_records_dict()
 
@@ -265,11 +269,11 @@ class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
             if ret == "skip":
                 continue
             if ret == "quit":
-                self.review_manager.logger.info("Stop screen")
+                self.logger.info("Stop screen")
                 break
 
         if self._stat_len == 0:
-            self.review_manager.logger.info("No records to screen")
+            self.logger.info("No records to screen")
             return records
 
         if self._i < self._stat_len and split:  # if records remain for screening

--- a/colrev/packages/colrev_curation/src/colrev_curation.py
+++ b/colrev/packages/colrev_curation/src/colrev_curation.py
@@ -1,12 +1,13 @@
 #! /usr/bin/env python
 """Colrev curated data as part of the data operations"""
 from __future__ import annotations
-from typing import Optional
 
 import collections
+import logging
 import os
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from pydantic import BaseModel
@@ -20,7 +21,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 class ColrevCurationSettings(

--- a/colrev/packages/colrev_curation/src/colrev_curation.py
+++ b/colrev/packages/colrev_curation/src/colrev_curation.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Colrev curated data as part of the data operations"""
 from __future__ import annotations
+from typing import Optional
 
 import collections
 import os
@@ -19,6 +20,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 class ColrevCurationSettings(
@@ -47,7 +49,9 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         # Set default values (if necessary)
         if "version" not in settings:
             settings["version"] = "0.1"
@@ -113,7 +117,7 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
             elif Fields.BOOKTITLE in record_dict:
                 key = record_dict.get(Fields.YEAR, "-")
             else:
-                self.review_manager.logger.error(f"TOC not supported: {record_dict}")
+                self.logger.error(f"TOC not supported: {record_dict}")
                 continue
             if not all(
                 source in [o.split("/")[0] for o in record_dict[Fields.ORIGIN]]
@@ -239,7 +243,7 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
         silent_mode: bool,
     ) -> None:
         if not silent_mode:
-            self.review_manager.logger.info("Calculate statistics for readme")
+            self.logger.info("Calculate statistics for readme")
 
         # alternatively: get sources from search_sources.filename (name/stem?)
         sources = []

--- a/colrev/packages/colrev_curation/src/curation_prep.py
+++ b/colrev/packages/colrev_curation/src/curation_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Preparation of curations"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -12,7 +14,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/colrev_curation/src/curation_prep.py
+++ b/colrev/packages/colrev_curation/src/curation_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Preparation of curations"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -11,6 +12,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -32,7 +34,9 @@ class CurationPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.quality_model = prep_operation.review_manager.get_qm()
         self.prep_operation = prep_operation

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: CoLRev project"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import shutil
 import tempfile
 from copy import deepcopy
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 import pandasql as ps
@@ -43,7 +43,10 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: CoLRev project"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import shutil
@@ -42,8 +43,10 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
 
@@ -52,7 +55,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Validate the SearchSource (parameters etc.)"""
         source = self.search_source
 
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         if "scope" not in source.search_parameters:
             raise colrev_exceptions.InvalidQueryException(
@@ -63,7 +66,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
                 "url field required in search_parameters"
             )
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     # pylint: disable=colrev-missed-constant-usage
     @classmethod
@@ -109,7 +112,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
             notify_state_transition_operation=False,
         )
         # pylint: disable=colrev-missed-constant-usage
-        self.review_manager.logger.info(
+        self.logger.info(
             f'Loading records from {self.search_source.search_parameters["scope"]["url"]}'
         )
         records = project_review_manager.dataset.load_records_dict()
@@ -192,7 +195,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
             Fields.GROBID_VERSION,
         ]
 
-        self.review_manager.logger.info("Importing selected records")
+        self.logger.info("Importing selected records")
         for record_to_import in tqdm(list(records_to_import.values())):
             if "condition" in self.search_source.search_parameters["scope"]:
                 res = []

--- a/colrev/packages/conceptual_review/src/conceptual_review.py
+++ b/colrev/packages/conceptual_review/src/conceptual_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Conceptual review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -23,7 +24,10 @@ class ConceptualReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/conceptual_review/src/conceptual_review.py
+++ b/colrev/packages/conceptual_review/src/conceptual_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Conceptual review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -21,8 +23,10 @@ class ConceptualReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
+++ b/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Conditional prescreen"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -27,7 +29,9 @@ class ConditionalPrescreen(base_classes.PrescreenPackageBaseClass):
         *,
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = prescreen_operation.review_manager
 

--- a/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
+++ b/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Conditional prescreen"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/critical_review/src/critical_review.py
+++ b/colrev/packages/critical_review/src/critical_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Critical review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -20,8 +22,10 @@ class CriticalReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/critical_review/src/critical_review.py
+++ b/colrev/packages/critical_review/src/critical_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Critical review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,7 +23,10 @@ class CriticalReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/crossref/src/crossref_prep.py
+++ b/colrev/packages/crossref/src/crossref_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on Crossref API as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.packages.crossref.src.crossref_search_source as crossref_connector
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/crossref/src/crossref_prep.py
+++ b/colrev/packages/crossref/src/crossref_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on Crossref API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.packages.crossref.src.crossref_search_source as crossref_connector
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -35,7 +37,9 @@ class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.crossref_source = crossref_connector.CrossrefSearchSource(

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: Crossref"""
 from __future__ import annotations
-from typing import Optional
 
 import datetime
 import logging
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 
 import inquirer
 import requests

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Crossref"""
 from __future__ import annotations
+from typing import Optional
 
 import datetime
 import logging
@@ -58,7 +59,9 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
 
         self.review_manager = source_operation.review_manager
         self.search_source = self._get_search_source(settings)
@@ -330,7 +333,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
     def _validate_source(self) -> None:
         """Validate the SearchSource (parameters etc.)"""
         source = self.search_source
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         if source.search_type not in self.search_types:
             raise colrev_exceptions.InvalidQueryException(
@@ -340,7 +343,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         if source.search_type == SearchType.API:
             self._validate_api_params()
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def _restore_url(
         self,
@@ -423,17 +426,17 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.api.last_updated = crossref_feed.get_last_updated()
 
         nrecs = self.api.get_len_total()
-        self.review_manager.logger.info(f"Total: {nrecs:,} records")
+        self.logger.info(f"Total: {nrecs:,} records")
         if not rerun:
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Retrieve papers indexed since {self.api.last_updated.split('T', maxsplit=1)[0]}"
             )
             nrecs = self.api.get_number_of_records()
 
-        self.review_manager.logger.info(f"Retrieve {nrecs:,} records")
+        self.logger.info(f"Retrieve {nrecs:,} records")
         estimated_time = nrecs * 0.5
         estimated_time_formatted = str(datetime.timedelta(seconds=int(estimated_time)))
-        self.review_manager.logger.info(f"Estimated time: {estimated_time_formatted}")
+        self.logger.info(f"Estimated time: {estimated_time_formatted}")
 
         try:
             for retrieved_record in self.api.get_records():

--- a/colrev/packages/curated_masterdata/src/curated_masterdata.py
+++ b/colrev/packages/curated_masterdata/src/curated_masterdata.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 """Curated metadata project"""
-from typing import Optional
+import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -12,7 +13,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code
@@ -25,7 +25,10 @@ class CuratedMasterdata(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/curated_masterdata/src/curated_masterdata.py
+++ b/colrev/packages/curated_masterdata/src/curated_masterdata.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Curated metadata project"""
+from typing import Optional
 from pathlib import Path
 
 from pydantic import Field
@@ -11,6 +12,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code
@@ -23,8 +25,10 @@ class CuratedMasterdata(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = operation.review_manager
 

--- a/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
+++ b/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Dedupe functionality dedicated to curated metadata repositories"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 import numpy as np
@@ -17,7 +19,6 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-many-arguments
@@ -285,9 +286,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
                 ),
             )
         else:
-            self.logger.info(
-                f"{Colors.GREEN}No duplicates found{Colors.END}"
-            )
+            self.logger.info(f"{Colors.GREEN}No duplicates found{Colors.END}")
 
     def _prep_records(self, *, records: dict) -> dict:
         required_fields = [
@@ -314,9 +313,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         return records
 
     def _dedupe_source(self, *, records: dict) -> list[list]:
-        self.logger.info(
-            "Processing as a non-pdf source (matching exact colrev_ids)"
-        )
+        self.logger.info("Processing as a non-pdf source (matching exact colrev_ids)")
 
         source_records = [
             r
@@ -561,9 +558,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
             )
             return
 
-        self.logger.info(
-            f"{Colors.GREEN}Duplicates identified{Colors.END}"
-        )
+        self.logger.info(f"{Colors.GREEN}Duplicates identified{Colors.END}")
 
         preferred_masterdata_sources = [
             s

--- a/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
+++ b/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Dedupe functionality dedicated to curated metadata repositories"""
 from __future__ import annotations
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -16,6 +17,7 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-many-arguments
@@ -44,7 +46,9 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         *,
         dedupe_operation: colrev.ops.dedupe.Dedupe,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ):
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.dedupe_operation = dedupe_operation
         self.review_manager = dedupe_operation.review_manager
@@ -167,7 +171,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
                 x for x in available_sources if x not in dedupe_sources
             ]
             if len(sources_missing_in_dedupe) > 0:
-                self.review_manager.logger.warning(
+                self.logger.warning(
                     f"{Colors.ORANGE}Sources missing in "
                     "dedupe.scripts.colrev.curation_full_outlet_dedupe: "
                     f"{','.join(sources_missing_in_dedupe)}{Colors.END}"
@@ -186,13 +190,13 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
                             penultimate_position, dedupe_script_to_add
                         )
                         self.review_manager.save_settings()
-                        self.review_manager.logger.info(
+                        self.logger.info(
                             f"{Colors.GREEN}Added {source_missing_in_dedupe} "
                             f"to dedupe.scripts{Colors.END}"
                         )
 
     def _add_first_source_if_deduplicated(self, *, records: dict) -> None:
-        self.review_manager.logger.info(
+        self.logger.info(
             f"Starting with records from {self.settings.selected_source}"
             " (setting to md_processed as the initial records)"
         )
@@ -272,7 +276,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         self.review_manager.dataset.save_records_dict(records)
 
         if self.review_manager.dataset.has_record_changes():
-            self.review_manager.logger.info(f"{Colors.GREEN}Commit changes{Colors.END}")
+            self.logger.info(f"{Colors.GREEN}Commit changes{Colors.END}")
             self.review_manager.dataset.create_commit(
                 msg=(
                     "Merge duplicate records (set unique records from "
@@ -281,7 +285,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
                 ),
             )
         else:
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"{Colors.GREEN}No duplicates found{Colors.END}"
             )
 
@@ -310,7 +314,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         return records
 
     def _dedupe_source(self, *, records: dict) -> list[list]:
-        self.review_manager.logger.info(
+        self.logger.info(
             "Processing as a non-pdf source (matching exact colrev_ids)"
         )
 
@@ -475,7 +479,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
             )
 
     def _dedupe_pdf_source(self, *, records: dict) -> list[list]:
-        self.review_manager.logger.info("Processing as a pdf source")
+        self.logger.info("Processing as a pdf source")
 
         source_records = [
             r
@@ -537,7 +541,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
             self._add_first_source_if_deduplicated(records=records)
             return
 
-        self.review_manager.logger.info(
+        self.logger.info(
             "Identify duplicates between "
             f"curated_records and {self.settings.selected_source} (within toc_items)"
         )
@@ -552,12 +556,12 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         # Note : dedupe.apply_merges reloads the records and
         # thereby discards previous changes
         if len(decision_list) == 0:
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"{Colors.GREEN}No merge-candidates identified between sets{Colors.END}"
             )
             return
 
-        self.review_manager.logger.info(
+        self.logger.info(
             f"{Colors.GREEN}Duplicates identified{Colors.END}"
         )
 

--- a/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
+++ b/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Deduplication of remaining records in curated metadata repositories"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from pydantic import Field
@@ -18,7 +19,6 @@ import colrev.record.record_prep
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-many-arguments
@@ -80,9 +80,7 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
                 self.logger.info(
                     f"{Colors.ORANGE}Source {source_origin} not fully merged{Colors.END}"
                 )
-                self.logger.info(
-                    f"Exporting details to dedupe/{source_origin}.xlsx"
-                )
+                self.logger.info(f"Exporting details to dedupe/{source_origin}.xlsx")
 
                 records_df = records_df[
                     records_df.columns.intersection(

--- a/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
+++ b/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Deduplication of remaining records in curated metadata repositories"""
 from __future__ import annotations
+from typing import Optional
 
 import typing
 from pathlib import Path
@@ -17,6 +18,7 @@ import colrev.record.record_prep
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-many-arguments
@@ -35,7 +37,9 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
         *,
         dedupe_operation: colrev.ops.dedupe.Dedupe,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ):
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = dedupe_operation.review_manager
         self.dedupe_operation = dedupe_operation
@@ -69,14 +73,14 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
             ]
             records_df = pd.DataFrame.from_records(list(selected_records))
             if records_df.shape[0] == 0:
-                self.review_manager.logger.info(
+                self.logger.info(
                     f"{Colors.GREEN}Source {source_origin} fully merged{Colors.END}"
                 )
             else:
-                self.review_manager.logger.info(
+                self.logger.info(
                     f"{Colors.ORANGE}Source {source_origin} not fully merged{Colors.END}"
                 )
-                self.review_manager.logger.info(
+                self.logger.info(
                     f"Exporting details to dedupe/{source_origin}.xlsx"
                 )
 
@@ -184,7 +188,7 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
 
     def _get_nr_recs_to_merge(self, *, records: dict) -> int:
         if self.review_manager.force_mode:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Scope: md_prepared, md_needs_manual_preparation, md_imported"
             )
             nr_recs_to_merge = len(
@@ -195,7 +199,7 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
                 ]
             )
         else:
-            self.review_manager.logger.info("Scope: md_prepared")
+            self.logger.info("Scope: md_prepared")
             nr_recs_to_merge = len(
                 [
                     x

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: DBLP"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -73,7 +74,9 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.search_source = self._get_search_source(settings)
         self.dblp_lock = Lock()
@@ -241,9 +244,9 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         total = api.total
-        self.review_manager.logger.info(f"Total: {total:,}")
+        self.logger.info(f"Total: {total:,}")
         if not rerun and len(dblp_feed.feed_records) > 0:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Retrieving latest results (no estimate available)"
             )
         elif total > 0 and rerun:
@@ -259,7 +262,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                 + str(int(seconds % 60)).zfill(2)
             )
 
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Estimated runtime [hh:mm:ss]: {formatted_time}"
             )
 
@@ -294,7 +297,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
     def _validate_source(self) -> None:
         """Validate the SearchSource (parameters etc.)"""
         source = self.search_source
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         assert source.search_type in self.search_types
 
@@ -319,7 +322,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                 "scope or query required in search_parameters"
             )
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def search(self, rerun: bool) -> None:
         """Run a search of DBLP"""
@@ -475,6 +478,6 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
             pass
         except colrev_exceptions.ServiceNotAvailableException:
             if self.review_manager.force_mode:
-                self.review_manager.logger.error("Service not available: DBLP")
+                self.logger.error("Service not available: DBLP")
 
         return record

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: DBLP"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 
 import requests
 from pydantic import BaseModel
@@ -246,9 +246,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         total = api.total
         self.logger.info(f"Total: {total:,}")
         if not rerun and len(dblp_feed.feed_records) > 0:
-            self.logger.info(
-                "Retrieving latest results (no estimate available)"
-            )
+            self.logger.info("Retrieving latest results (no estimate available)")
         elif total > 0 and rerun:
             seconds = 10 + (total / 10)
             if total > 1000:
@@ -262,9 +260,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                 + str(int(seconds % 60)).zfill(2)
             )
 
-            self.logger.info(
-                f"Estimated runtime [hh:mm:ss]: {formatted_time}"
-            )
+            self.logger.info(f"Estimated runtime [hh:mm:ss]: {formatted_time}")
 
         while True:
             api.set_next_url()

--- a/colrev/packages/dblp/src/dblp_metadata_prep.py
+++ b/colrev/packages/dblp/src/dblp_metadata_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on DBLP API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.packages.dblp.src.dblp as dblp_connector
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -33,7 +35,9 @@ class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.dblp_source = dblp_connector.DBLPSearchSource(

--- a/colrev/packages/dblp/src/dblp_metadata_prep.py
+++ b/colrev/packages/dblp/src/dblp_metadata_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on DBLP API as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.packages.dblp.src.dblp as dblp_connector
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/dedupe/src/dedupe.py
+++ b/colrev/packages/dedupe/src/dedupe.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Default deduplication module for CoLRev"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import shutil
 from pathlib import Path
+from typing import Optional
 
 import bib_dedupe.cluster
 import bib_dedupe.maybe_cases
@@ -21,7 +22,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 # pylint: disable=too-few-public-methods
 

--- a/colrev/packages/dedupe/src/dedupe.py
+++ b/colrev/packages/dedupe/src/dedupe.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Default deduplication module for CoLRev"""
 from __future__ import annotations
+from typing import Optional
 
 import shutil
 from pathlib import Path
@@ -20,6 +21,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -35,7 +37,9 @@ class Dedupe(base_classes.DedupePackageBaseClass):
         *,
         dedupe_operation: colrev.ops.dedupe.Dedupe,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ):
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.dedupe_operation = dedupe_operation
         self.review_manager = dedupe_operation.review_manager

--- a/colrev/packages/descriptive_review/src/descriptive_review.py
+++ b/colrev/packages/descriptive_review/src/descriptive_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Descriptive review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -20,8 +22,10 @@ class DescriptiveReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/descriptive_review/src/descriptive_review.py
+++ b/colrev/packages/descriptive_review/src/descriptive_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Descriptive review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,7 +23,10 @@ class DescriptiveReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/download_from_website/src/download_from_website.py
+++ b/colrev/packages/download_from_website/src/download_from_website.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Retrieval of PDFs from the website (URL)"""
 from __future__ import annotations
+from typing import Optional
 
 from pathlib import Path
 from urllib.parse import urljoin
@@ -14,6 +15,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods
@@ -40,7 +42,9 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
         *,
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_operation.review_manager
         self.pdf_get_operation = pdf_get_operation
@@ -66,21 +70,21 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                     if pdf_response.status_code == 200:
                         with open(pdf_filepath, "wb") as pdf_file:
                             pdf_file.write(pdf_response.content)
-                        self.review_manager.logger.debug(
+                        self.logger.debug(
                             f"PDF downloaded successfully as {pdf_filepath}"
                         )
                     else:
-                        self.review_manager.logger.debug(
+                        self.logger.debug(
                             f"Failed to download PDF. Status code: {pdf_response.status_code}"
                         )
                 else:
-                    self.review_manager.logger.debug(
+                    self.logger.debug(
                         "Paper title not found on the page."
                     )
             else:
-                self.review_manager.logger.debug("PDF link not found on the page.")
+                self.logger.debug("PDF link not found on the page.")
         else:
-            self.review_manager.logger.debug(
+            self.logger.debug(
                 f"Failed to retrieve the article page. Status code: {response.status_code}"
             )
 
@@ -108,19 +112,19 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                         with open(pdf_filepath, "wb") as pdf_file:
                             pdf_file.write(pdf_response.content)
 
-                        self.review_manager.logger.debug(
+                        self.logger.debug(
                             f"PDF downloaded successfully as {pdf_filepath}"
                         )
                     else:
-                        self.review_manager.logger.debug(
+                        self.logger.debug(
                             f"Failed to download PDF. Status code: {pdf_response.status_code}"
                         )
                 else:
-                    self.review_manager.logger.debug("PDF URL not found on the page.")
+                    self.logger.debug("PDF URL not found on the page.")
             else:
-                self.review_manager.logger.debug("PDF link not found on the page.")
+                self.logger.debug("PDF link not found on the page.")
         else:
-            self.review_manager.logger.debug(
+            self.logger.debug(
                 f"Failed to retrieve the article page. Status code: {response.status_code}"
             )
 
@@ -152,19 +156,19 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                         with open(pdf_filepath, "wb") as pdf_file:
                             pdf_file.write(pdf_response.content)
 
-                        self.review_manager.logger.debug(
+                        self.logger.debug(
                             f"PDF downloaded successfully as {pdf_filepath}"
                         )
                     else:
-                        self.review_manager.logger.debug(
+                        self.logger.debug(
                             f"Failed to download PDF. Status code: {pdf_response.status_code}"
                         )
                 else:
-                    self.review_manager.logger.debug("PDF URL not found on the page.")
+                    self.logger.debug("PDF URL not found on the page.")
             else:
-                self.review_manager.logger.debug("PDF link not found on the page.")
+                self.logger.debug("PDF link not found on the page.")
         else:
-            self.review_manager.logger.debug(
+            self.logger.debug(
                 f"Failed to retrieve the Minerva Medica page. Status code: {response.status_code}"
             )
 

--- a/colrev/packages/download_from_website/src/download_from_website.py
+++ b/colrev/packages/download_from_website/src/download_from_website.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Retrieval of PDFs from the website (URL)"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urljoin
 
 import requests
@@ -15,7 +16,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods
@@ -78,9 +78,7 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                             f"Failed to download PDF. Status code: {pdf_response.status_code}"
                         )
                 else:
-                    self.logger.debug(
-                        "Paper title not found on the page."
-                    )
+                    self.logger.debug("Paper title not found on the page.")
             else:
                 self.logger.debug("PDF link not found on the page.")
         else:

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: EBSCOHost"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -40,7 +40,10 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://search.ebscohost.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: EBSCOHost"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -39,8 +40,10 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://search.ebscohost.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
         self.source_operation = source_operation

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: ERIC"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -44,7 +45,9 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.source_operation = source_operation
         if settings:

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: ERIC"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 import urllib.parse
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: Europe PMC"""
 from __future__ import annotations
-from typing import Optional
 
 import json
 import logging
@@ -9,6 +8,7 @@ import typing
 from multiprocessing import Lock
 from pathlib import Path
 from sqlite3 import OperationalError
+from typing import Optional
 from urllib.parse import quote
 from urllib.parse import urlparse
 
@@ -328,9 +328,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
 
                 for retrieved_record in api.get_records():
                     if Fields.TITLE not in retrieved_record.data:
-                        self.logger.warning(
-                            f"Skipped record: {retrieved_record.data}"
-                        )
+                        self.logger.warning(f"Skipped record: {retrieved_record.data}")
                         continue
 
                     source = f"{self._SOURCE_URL}{retrieved_record.data[Fields.EUROPE_PMC_ID]}"

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Europe PMC"""
 from __future__ import annotations
+from typing import Optional
 
 import json
 import logging
@@ -78,7 +79,9 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # EuropePMC as a search_source
@@ -262,7 +265,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         source = self.search_source
 
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         assert source.search_type in self.search_types
 
@@ -271,7 +274,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                 "Query required in search_parameters"
             )
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def search(self, rerun: bool) -> None:
         """Run a search of Europe PMC"""
@@ -325,7 +328,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
 
                 for retrieved_record in api.get_records():
                     if Fields.TITLE not in retrieved_record.data:
-                        self.review_manager.logger.warning(
+                        self.logger.warning(
                             f"Skipped record: {retrieved_record.data}"
                         )
                         continue

--- a/colrev/packages/europe_pmc/src/europe_pmc_prep.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on Europe PMC API as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -10,7 +12,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.packages.europe_pmc.src.europe_pmc as europe_pmc_connector
 import colrev.record.record
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/europe_pmc/src/europe_pmc_prep.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on Europe PMC API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -9,6 +10,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.packages.europe_pmc.src.europe_pmc as europe_pmc_connector
 import colrev.record.record
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -30,7 +32,9 @@ class EuropePMCMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager

--- a/colrev/packages/exclude_collections/src/exclude_collections.py
+++ b/colrev/packages/exclude_collections/src/exclude_collections.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Exclude collections as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -9,6 +10,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -31,7 +33,9 @@ class ExcludeCollectionsPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def prepare(

--- a/colrev/packages/exclude_collections/src/exclude_collections.py
+++ b/colrev/packages/exclude_collections/src/exclude_collections.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Exclude collections as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -10,7 +12,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 

--- a/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
+++ b/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Exclude complementary materials as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -10,7 +12,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 

--- a/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
+++ b/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Exclude complementary materials as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -9,6 +10,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -32,7 +34,9 @@ class ExcludeComplementaryMaterialsPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
         self.complementary_materials_keywords = (

--- a/colrev/packages/exclude_languages/src/exclude_languages.py
+++ b/colrev/packages/exclude_languages/src/exclude_languages.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Exclude records based on language as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 import re
 import statistics
@@ -15,6 +16,7 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -30,7 +32,8 @@ class ExcludeLanguagesPrep(base_classes.PrepPackageBaseClass):
     source_correction_hint = "check with the developer"
     always_apply_changes = True
 
-    def __init__(self, *, prep_operation: colrev.ops.prep.Prep, settings: dict) -> None:
+    def __init__(self, *, prep_operation: colrev.ops.prep.Prep, settings: dict, logger: Optional[logging.Logger] = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
         # Note : the following objects have heavy memory footprints and should be

--- a/colrev/packages/exclude_languages/src/exclude_languages.py
+++ b/colrev/packages/exclude_languages/src/exclude_languages.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Exclude records based on language as a prep operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import re
 import statistics
+from typing import Optional
 
 from pydantic import Field
 
@@ -16,7 +17,6 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -32,7 +32,13 @@ class ExcludeLanguagesPrep(base_classes.PrepPackageBaseClass):
     source_correction_hint = "check with the developer"
     always_apply_changes = True
 
-    def __init__(self, *, prep_operation: colrev.ops.prep.Prep, settings: dict, logger: Optional[logging.Logger] = None) -> None:
+    def __init__(
+        self,
+        *,
+        prep_operation: colrev.ops.prep.Prep,
+        settings: dict,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
+++ b/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Exclude records with non-latin alphabets as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from alphabet_detector import AlphabetDetector
@@ -11,7 +13,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 

--- a/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
+++ b/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Exclude records with non-latin alphabets as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from alphabet_detector import AlphabetDetector
 from pydantic import Field
@@ -10,6 +11,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -34,7 +36,9 @@ class ExcludeNonLatinAlphabetsPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
 

--- a/colrev/packages/export_man_prep/src/prep_man_export.py
+++ b/colrev/packages/export_man_prep/src/prep_man_export.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Export of bib/pdfs as a prep-man operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import platform
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 import pymupdf
@@ -23,7 +24,6 @@ from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
 from colrev.writer.write_utils import write_file
-import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: directory containing PDF files (based on GROBID)"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pymupdf
 import requests
@@ -56,7 +56,10 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
     rerun: bool
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
@@ -82,9 +85,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             self.subdir_pattern = self.search_source.search_parameters["scope"][
                 "subdir_pattern"
             ]
-            self.logger.info(
-                f"Activate subdir_pattern: {self.subdir_pattern}"
-            )
+            self.logger.info(f"Activate subdir_pattern: {self.subdir_pattern}")
             if self.subdir_pattern == Fields.YEAR:
                 self.r_subdir_pattern = re.compile("([1-3][0-9]{3})")
             if self.subdir_pattern == "volume_number":
@@ -359,9 +360,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         file_path: Path,
     ) -> bool:
         if ";" in str(file_path):
-            self.logger.error(
-                f'skipping PDF with ";" in filepath: \n{file_path}'
-            )
+            self.logger.error(f'skipping PDF with ";" in filepath: \n{file_path}')
             return True
 
         if (
@@ -370,9 +369,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             or "_with_lp.pdf" == str(file_path)[-10:]
             or "_backup.pdf" == str(file_path)[-11:]
         ):
-            self.logger.info(
-                f"Skipping PDF with _ocr.pdf/_with_cp.pdf: {file_path}"
-            )
+            self.logger.info(f"Skipping PDF with _ocr.pdf/_with_cp.pdf: {file_path}")
             return True
 
         return False

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: directory containing PDF files (based on GROBID)"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -55,8 +56,10 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
     rerun: bool
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.source_operation = source_operation
 
@@ -79,7 +82,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             self.subdir_pattern = self.search_source.search_parameters["scope"][
                 "subdir_pattern"
             ]
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Activate subdir_pattern: {self.subdir_pattern}"
             )
             if self.subdir_pattern == Fields.YEAR:
@@ -131,7 +134,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         return not_updated
 
     def _remove_records_if_pdf_no_longer_exists(self) -> None:
-        # search_operation.review_manager.logger.debug(
+        # self.logger.debug(
         #     "Checking for PDFs that no longer exist"
         # )
 
@@ -140,7 +143,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         search_rd = colrev.loader.load_utils.load(
             filename=self.search_source.filename,
-            logger=self.review_manager.logger,
+            logger=self.logger,
             unique_id_field="ID",
         )
 
@@ -180,7 +183,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
                     if origin_to_remove in record_dict[Fields.ORIGIN]:
                         record_dict[Fields.ORIGIN].remove(origin_to_remove)
             if to_remove:
-                self.review_manager.logger.info(
+                self.logger.info(
                     f" {Colors.RED}Removed {len(to_remove)} records "
                     f"(PDFs no longer available){Colors.END}"
                 )
@@ -356,7 +359,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         file_path: Path,
     ) -> bool:
         if ";" in str(file_path):
-            self.review_manager.logger.error(
+            self.logger.error(
                 f'skipping PDF with ";" in filepath: \n{file_path}'
             )
             return True
@@ -367,7 +370,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             or "_with_lp.pdf" == str(file_path)[-10:]
             or "_backup.pdf" == str(file_path)[-11:]
         ):
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Skipping PDF with _ocr.pdf/_with_cp.pdf: {file_path}"
             )
             return True
@@ -379,7 +382,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         source = self.search_source
 
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         assert source.search_type == SearchType.FILES
 
@@ -407,7 +410,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             raise colrev_exceptions.InvalidQueryException(
                 "path required in search_parameters/scope"
             )
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def _add_md_string(self, *, record_dict: dict) -> dict:
         # To identify potential duplicates
@@ -541,7 +544,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
                 return new_record
         # otherwise: reindex all
 
-        self.review_manager.logger.info(f" extract metadata from {file_path}")
+        self.logger.info(f" extract metadata from {file_path}")
         try:
             if not self.review_manager.settings.is_curated_masterdata_repo():
                 # retrieve_based_on_colrev_pdf_id
@@ -558,7 +561,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             else:
                 new_record = self._get_grobid_metadata(file_path=file_path)
         except FileNotFoundError:
-            self.review_manager.logger.error(f"File not found: {file_path} (skipping)")
+            self.logger.error(f"File not found: {file_path} (skipping)")
             return {}
         except (
             colrev_exceptions.PDFHashError,
@@ -580,7 +583,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             and not r[Fields.FILE] == new_record[Fields.FILE]
         ]
         if potential_duplicates:
-            self.review_manager.logger.warning(
+            self.logger.warning(
                 f" {Colors.RED}skip record (PDF potential duplicate): "
                 f"{new_record['file']} {Colors.END} "
                 f"({','.join([r['file'] for r in potential_duplicates])})"
@@ -696,7 +699,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             raise colrev_exceptions.SearchNotAutomated("PDFs Dir Search not automated.")
 
         if self.review_manager.force_mode:  # i.e., reindex all
-            self.review_manager.logger.info("Reindex all")
+            self.logger.info("Reindex all")
 
         # Removing records/origins for which PDFs were removed makes sense for curated repositories
         # In regular repositories, it may be confusing (e.g., if PDFs are renamed)

--- a/colrev/packages/genai/src/genai_data.py
+++ b/colrev/packages/genai/src/genai_data.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Data based on GenAI"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import re
 import typing
 from pathlib import Path
+from typing import Optional
 
 from litellm import completion
 from pydantic import BaseModel
@@ -16,7 +17,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record_pdf
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/genai/src/genai_data.py
+++ b/colrev/packages/genai/src/genai_data.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Data based on GenAI"""
 from __future__ import annotations
+from typing import Optional
 
 import re
 import typing
@@ -15,6 +16,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record_pdf
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -44,7 +46,9 @@ class GenAIData(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
         self.data_operation = data_operation
 

--- a/colrev/packages/genai/src/genai_prescreen.py
+++ b/colrev/packages/genai/src/genai_prescreen.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Prescreen based on GenAI"""
 from __future__ import annotations
-from typing import Optional
 
 import csv
+import logging
 from pathlib import Path
 from typing import ClassVar
+from typing import Optional
 
 import pandas as pd
 from litellm import completion
@@ -17,7 +18,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/genai/src/genai_prescreen.py
+++ b/colrev/packages/genai/src/genai_prescreen.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Prescreen based on GenAI"""
 from __future__ import annotations
+from typing import Optional
 
 import csv
 from pathlib import Path
@@ -16,6 +17,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -64,7 +66,9 @@ class GenAIPrescreen(base_classes.PrescreenPackageBaseClass):
         *,
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = prescreen_operation.review_manager
         self.settings = self.settings_class(**settings)
         self.prescreen_decision_explanation_path = (
@@ -138,7 +142,7 @@ class GenAIPrescreen(base_classes.PrescreenPackageBaseClass):
         screening_decisions_df.to_csv(
             self.prescreen_decision_explanation_path, index=False, quoting=csv.QUOTE_ALL
         )
-        self.review_manager.logger.info(
+        self.logger.info(
             f"Exported prescreening decisions to {self.prescreen_decision_explanation_path}"
         )
 

--- a/colrev/packages/genai/src/genai_screen.py
+++ b/colrev/packages/genai/src/genai_screen.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Screen based on GenAI"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -9,7 +11,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import RecordState
-import logging
 
 # pylint: disable=too-few-public-methods
 

--- a/colrev/packages/genai/src/genai_screen.py
+++ b/colrev/packages/genai/src/genai_screen.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Screen based on GenAI"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -8,6 +9,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import RecordState
+import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -25,7 +27,9 @@ class GenAIScreen(base_classes.ScreenPackageBaseClass):
         *,
         screen_operation: colrev.ops.screen.Screen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = screen_operation.review_manager
         self.screen_operation = screen_operation
         self.settings = self.settings_class(**settings)

--- a/colrev/packages/general_polish/src/general_polish.py
+++ b/colrev/packages/general_polish/src/general_polish.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Genral polishing rules"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import re
+from typing import Optional
 
 from pydantic import Field
 
@@ -12,7 +13,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/general_polish/src/general_polish.py
+++ b/colrev/packages/general_polish/src/general_polish.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Genral polishing rules"""
 from __future__ import annotations
+from typing import Optional
 
 import re
 
@@ -11,6 +12,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -53,7 +55,9 @@ class GeneralPolishPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def prepare(

--- a/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
+++ b/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Retrieving DOIs from a papers website/url as a prep operation"""
 from __future__ import annotations
-from typing import Optional
 
 import collections
+import logging
 import re
 from sqlite3 import OperationalError
+from typing import Optional
 
 import requests
 from pydantic import Field
@@ -19,7 +20,6 @@ import colrev.record.record
 import colrev.record.record_prep
 import colrev.record.record_similarity
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code

--- a/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
+++ b/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Retrieving DOIs from a papers website/url as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 import collections
 import re
@@ -18,6 +19,7 @@ import colrev.record.record
 import colrev.record.record_prep
 import colrev.record.record_similarity
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code
@@ -41,7 +43,9 @@ class DOIFromURLsPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager

--- a/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
+++ b/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on CiteAs API as a prep operation"""
 from __future__ import annotations
-from typing import Optional
 
 import json
+import logging
+from typing import Optional
 
 import requests
 from pydantic import Field
@@ -15,7 +16,6 @@ import colrev.record.record
 import colrev.record.record_prep
 import colrev.record.record_similarity
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code

--- a/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
+++ b/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on CiteAs API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 import json
 
@@ -14,6 +15,7 @@ import colrev.record.record
 import colrev.record.record_prep
 import colrev.record.record_similarity
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code
@@ -38,7 +40,9 @@ class CiteAsPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager
@@ -115,7 +119,7 @@ class CiteAsPrep(base_classes.PrepPackageBaseClass):
         except requests.exceptions.RequestException:
             pass
         except UnicodeEncodeError:
-            self.review_manager.logger.error(
+            self.logger.error(
                 "UnicodeEncodeError - this needs to be fixed at some time"
             )
 

--- a/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
+++ b/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on DOI metadata as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.packages.doi_org.src.doi_org as doi_connector
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
+++ b/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on DOI metadata as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.packages.doi_org.src.doi_org as doi_connector
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -34,7 +36,9 @@ class DOIMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager

--- a/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
+++ b/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Completion of metadata based on year-volume-issue dependency as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 import requests
 from pydantic import Field
@@ -14,6 +15,7 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.packages.crossref.src import crossref_api
+import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods
@@ -38,7 +40,9 @@ class YearVolIssPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager

--- a/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
+++ b/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Completion of metadata based on year-volume-issue dependency as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 import requests
@@ -15,7 +17,6 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.packages.crossref.src import crossref_api
-import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/github/src/github_prep.py
+++ b/colrev/packages/github/src/github_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on GitHub REST API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -9,6 +10,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.packages.github.src.github_search_source as github_connector
 import colrev.record.record
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -31,7 +33,9 @@ class GithubMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager

--- a/colrev/packages/github/src/github_prep.py
+++ b/colrev/packages/github/src/github_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on GitHub REST API as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -10,7 +12,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.packages.github.src.github_search_source as github_connector
 import colrev.record.record
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: GitHub"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 
 import inquirer
 from github import Auth

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: GitHub"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -61,7 +62,9 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # GitHub as a search source

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Creation of a github-page for the review as part of the data operations"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 from pathlib import Path
+from typing import Optional
 
 import git
 from pydantic import BaseModel
@@ -18,7 +19,6 @@ from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.writer.write_utils import write_file
-import logging
 
 
 class GHPagesSettings(

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Creation of a github-page for the review as part of the data operations"""
 from __future__ import annotations
+from typing import Optional
 
 from pathlib import Path
 
@@ -17,6 +18,7 @@ from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.writer.write_utils import write_file
+import logging
 
 
 class GHPagesSettings(
@@ -53,7 +55,9 @@ class GithubPages(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         # Set default values (if necessary)
         if "version" not in settings:
             settings["version"] = "0.1.0"
@@ -79,7 +83,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
 
     def _setup_github_pages_branch(self) -> None:
         # if branch does not exist: create and add index.html
-        self.review_manager.logger.info("Setup gh-pages branch")
+        self.logger.info("Setup gh-pages branch")
         self.git_repo.git.checkout("--orphan", self.GH_PAGES_BRANCH_NAME)
         self.git_repo.git.rm("-rf", Path("."))
 
@@ -128,7 +132,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
         silent_mode: bool,
     ) -> None:
         if not silent_mode:
-            self.review_manager.logger.info("Update data on github pages")
+            self.logger.info("Update data on github pages")
 
         records = self.review_manager.dataset.load_records_dict()
 
@@ -177,7 +181,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
         silent_mode: bool,
     ) -> None:
         if not silent_mode:
-            self.review_manager.logger.info("Push to github pages")
+            self.logger.info("Push to github pages")
         if "origin" in self.git_repo.remotes:
             if "origin/gh-pages" in [r.name for r in self.git_repo.remotes.origin.refs]:
                 try:
@@ -185,7 +189,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
                         refspec=f"{self.GH_PAGES_BRANCH_NAME}:{self.GH_PAGES_BRANCH_NAME}"
                     )
                 except git.exc.GitCommandError:  # pylint: disable=no-member
-                    self.review_manager.logger.error(
+                    self.logger.error(
                         "Could not push branch gh-pages. Please resolve manually, i.e., run "
                         f"{Colors.ORANGE}git switch gh-pages && "
                         f"git pull --rebase && git push{Colors.END}"
@@ -204,12 +208,12 @@ class GithubPages(base_classes.DataPackageBaseClass):
                 .split("/")
             )
             if not silent_mode:
-                self.review_manager.logger.info(
+                self.logger.info(
                     f"Data available at: https://{username}.github.io/{project}/"
                 )
         else:
             if not silent_mode:
-                self.review_manager.logger.info("No remotes specified")
+                self.logger.info("No remotes specified")
 
     def _check_gh_pages_setup(self) -> None:
         username, project = (
@@ -240,13 +244,13 @@ class GithubPages(base_classes.DataPackageBaseClass):
         # pylint: disable=too-many-branches
 
         if self.review_manager.in_ci_environment():
-            self.review_manager.logger.error(
+            self.logger.error(
                 "Running in CI environment. Skipping github-pages generation."
             )
             return
 
         if self.review_manager.dataset.has_record_changes():
-            self.review_manager.logger.error(
+            self.logger.error(
                 "Cannot update github pages because there are uncommitted changes."
             )
             return
@@ -310,7 +314,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
             self.git_repo.git.checkout(active_branch)
             self._check_gh_pages_setup()
         else:
-            self.review_manager.logger.warning(
+            self.logger.warning(
                 "Cannot push github pages because there is no remote origin. "
                 "gh-pages branch will only be created locally."
             )

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: GoogleScholar"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 from pathlib import Path
@@ -35,8 +36,10 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://scholar.google.de/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.source_operation = source_operation
         self.review_manager = source_operation.review_manager

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """SearchSource: GoogleScholar"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -36,7 +36,10 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://scholar.google.de/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/grobid_tei/src/grobid_tei.py
+++ b/colrev/packages/grobid_tei/src/grobid_tei.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Creation of TEI as a PDF preparation operation"""
 from __future__ import annotations
+from typing import Optional
 
 import typing
 from pathlib import Path
@@ -11,6 +12,7 @@ import colrev.env.tei_parser
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
+import logging
 
 if typing.TYPE_CHECKING:
     import colrev.record.record_pdf
@@ -27,8 +29,10 @@ class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
     ci_supported: bool = Field(default=False)
 
     def __init__(
-        self, *, pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep, settings: dict
+        self, *, pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager
 
@@ -49,7 +53,7 @@ class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
             return record
 
         if not record.get_tei_filename().is_file():
-            self.review_manager.logger.debug(f" creating tei: {record.data['ID']}")
+            self.logger.debug(f" creating tei: {record.data['ID']}")
             _ = colrev.env.tei_parser.TEIParser(
                 pdf_path=Path(record.data[Fields.FILE]),
                 tei_path=record.get_tei_filename(),

--- a/colrev/packages/grobid_tei/src/grobid_tei.py
+++ b/colrev/packages/grobid_tei/src/grobid_tei.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Creation of TEI as a PDF preparation operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -12,7 +13,6 @@ import colrev.env.tei_parser
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
-import logging
 
 if typing.TYPE_CHECKING:
     import colrev.record.record_pdf
@@ -29,7 +29,10 @@ class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
     ci_supported: bool = Field(default=False)
 
     def __init__(
-        self, *, pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep, settings: dict,
+        self,
+        *,
+        pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: IEEEXplore"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from pydantic import Field

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: IEEEXplore"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -50,7 +51,9 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
 
         if settings:

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """SearchSource: JSTOR"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -36,7 +36,10 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "http://www.jstor.org"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: JSTOR"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 from pathlib import Path
@@ -35,8 +36,10 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "http://www.jstor.org"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.operation = source_operation
         self.review_manager = source_operation.review_manager

--- a/colrev/packages/literature_review/src/literature_review.py
+++ b/colrev/packages/literature_review/src/literature_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Simple literature review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,8 +24,10 @@ class LiteratureReview(base_classes.ReviewTypePackageBaseClass):
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/literature_review/src/literature_review.py
+++ b/colrev/packages/literature_review/src/literature_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Simple literature review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -24,7 +25,10 @@ class LiteratureReview(base_classes.ReviewTypePackageBaseClass):
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: LocalIndex"""
 from __future__ import annotations
-from typing import Optional
 
 import difflib
 import logging
@@ -9,6 +8,7 @@ import typing
 import webbrowser
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 import git
@@ -872,9 +872,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         if check_review_manager.dataset.behind_remote():
             git_repo = check_review_manager.dataset.get_repo()
             origin = git_repo.remotes.origin
-            self.logger.info(
-                f"Pull project changes from {git_repo.remotes.origin}"
-            )
+            self.logger.info(f"Pull project changes from {git_repo.remotes.origin}")
             res = origin.pull()
             self.logger.info(res)
 
@@ -887,9 +885,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
             print(exc)
             return
 
-        self.logger.info(
-            "Precondition for correction (pull-request) checked."
-        )
+        self.logger.info("Precondition for correction (pull-request) checked.")
 
         success = self._apply_change_item_correction(
             check_operation=check_operation,

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: LocalIndex"""
 from __future__ import annotations
+from typing import Optional
 
 import difflib
 import logging
@@ -66,7 +67,9 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # LocalIndex as a search_source
@@ -101,7 +104,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
     def _validate_source(self) -> None:
         """Validate the SearchSource (parameters etc.)"""
         source = self.search_source
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         assert source.search_type in self.search_types
 
@@ -129,7 +132,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
             #         f"Source missing query/query search_parameter ({source.filename})"
             #     )
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def _retrieve_from_index(self) -> typing.List[dict]:
         params = self.search_source.search_parameters
@@ -514,7 +517,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         selected_changes = []
         print()
-        self.review_manager.logger.info(f"Base repository: {local_base_repo}")
+        self.logger.info(f"Base repository: {local_base_repo}")
         for item in change_itemsets:
             repo_path = colrev.record.record.Record(
                 item["original_record"]
@@ -598,9 +601,9 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
             origin = git_repo.remotes.origin
             origin.pull()
             if not check_operation.review_manager.dataset.behind_remote():
-                self.review_manager.logger.info("Pulled changes")
+                self.logger.info("Pulled changes")
             else:
-                self.review_manager.logger.error(
+                self.logger.error(
                     "Repo behind remote. Pull first to avoid conflicts.\n"
                     "colrev env --pull"
                 )
@@ -683,7 +686,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
                 record_dict = matching_url_rec_l[0]
                 return record_dict
 
-        self.review_manager.logger.error(
+        self.logger.error(
             f"{Colors.RED}Record not found: {original_record[Fields.ID]}{Colors.END}"
         )
         raise colrev_exceptions.RecordNotInIndexException(original_record[Fields.ID])
@@ -746,7 +749,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         git_repo.remotes.origin.push(
             refspec=f"{record_branch_name}:{record_branch_name}"
         )
-        self.review_manager.logger.info("Pushed corrections")
+        self.logger.info("Pushed corrections")
 
         for head in git_repo.heads:
             if head.name == prev_branch_name:
@@ -755,7 +758,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         git_repo = git.Git(source_url)
         git_repo.execute(["git", "branch", "-D", record_branch_name])
 
-        self.review_manager.logger.info("Removed local corrections branch")
+        self.logger.info("Removed local corrections branch")
 
     def _reset_record_after_correction(
         self, *, record_dict: dict, rec_for_reset: dict, change_item: dict
@@ -869,11 +872,11 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         if check_review_manager.dataset.behind_remote():
             git_repo = check_review_manager.dataset.get_repo()
             origin = git_repo.remotes.origin
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Pull project changes from {git_repo.remotes.origin}"
             )
             res = origin.pull()
-            self.review_manager.logger.info(res)
+            self.logger.info(res)
 
         try:
             if not self._apply_corrections_precondition(
@@ -884,7 +887,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
             print(exc)
             return
 
-        check_review_manager.logger.info(
+        self.logger.info(
             "Precondition for correction (pull-request) checked."
         )
 

--- a/colrev/packages/local_index/src/local_index_pdf_get.py
+++ b/colrev/packages/local_index/src/local_index_pdf_get.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Retrieval of PDFs from the LocalIndex"""
 from __future__ import annotations
+from typing import Optional
 
 import shutil
 from pathlib import Path
@@ -14,6 +15,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods
@@ -30,7 +32,9 @@ class LocalIndexPDFGet(base_classes.PDFGetPackageBaseClass):
         *,
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.pdf_get_operation = pdf_get_operation
         self.review_manager = pdf_get_operation.review_manager

--- a/colrev/packages/local_index/src/local_index_pdf_get.py
+++ b/colrev/packages/local_index/src/local_index_pdf_get.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Retrieval of PDFs from the LocalIndex"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import shutil
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -15,7 +16,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/local_index/src/local_index_prep.py
+++ b/colrev/packages/local_index/src/local_index_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Conslidation of metadata based on LocalIndex as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.packages.local_index.src.local_index as local_index_connector
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -30,7 +32,8 @@ class LocalIndexPrep(base_classes.PrepPackageBaseClass):
     )
     always_apply_changes = True
 
-    def __init__(self, *, prep_operation: colrev.ops.prep.Prep, settings: dict) -> None:
+    def __init__(self, *, prep_operation: colrev.ops.prep.Prep, settings: dict, logger: Optional[logging.Logger] = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
         self.local_index_source = local_index_connector.LocalIndexSearchSource(

--- a/colrev/packages/local_index/src/local_index_prep.py
+++ b/colrev/packages/local_index/src/local_index_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Conslidation of metadata based on LocalIndex as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.packages.local_index.src.local_index as local_index_connector
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 
@@ -32,7 +33,13 @@ class LocalIndexPrep(base_classes.PrepPackageBaseClass):
     )
     always_apply_changes = True
 
-    def __init__(self, *, prep_operation: colrev.ops.prep.Prep, settings: dict, logger: Optional[logging.Logger] = None) -> None:
+    def __init__(
+        self,
+        *,
+        prep_operation: colrev.ops.prep.Prep,
+        settings: dict,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/meta_analysis/src/meta_analysis.py
+++ b/colrev/packages/meta_analysis/src/meta_analysis.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Meta-analysis"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -13,6 +14,7 @@ from colrev.packages.open_citations_forward_search.src.open_citations_forward_se
 from colrev.packages.pdf_backward_search.src.pdf_backward_search import (
     BackwardSearchSource,
 )
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -26,8 +28,10 @@ class MetaAnalysis(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/meta_analysis/src/meta_analysis.py
+++ b/colrev/packages/meta_analysis/src/meta_analysis.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Meta-analysis"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -14,7 +16,6 @@ from colrev.packages.open_citations_forward_search.src.open_citations_forward_se
 from colrev.packages.pdf_backward_search.src.pdf_backward_search import (
     BackwardSearchSource,
 )
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -28,7 +29,10 @@ class MetaAnalysis(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/methodological_review/src/methodological_review.py
+++ b/colrev/packages/methodological_review/src/methodological_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Methodological review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,7 +23,10 @@ class MethodologicalReview(base_classes.ReviewTypePackageBaseClass):
     settings_class: colrev.package_manager.package_settings.DefaultSettings
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/methodological_review/src/methodological_review.py
+++ b/colrev/packages/methodological_review/src/methodological_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Methodological review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -20,8 +22,10 @@ class MethodologicalReview(base_classes.ReviewTypePackageBaseClass):
     settings_class: colrev.package_manager.package_settings.DefaultSettings
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/narrative_review/src/narrative_review.py
+++ b/colrev/packages/narrative_review/src/narrative_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Narrative review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,7 +23,10 @@ class NarrativeReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/narrative_review/src/narrative_review.py
+++ b/colrev/packages/narrative_review/src/narrative_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Narrative review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -20,8 +22,10 @@ class NarrativeReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/obsidian/src/obsidian.py
+++ b/colrev/packages/obsidian/src/obsidian.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Creation of an Obsidian database as part of the data operations"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 from collections import Counter
 from pathlib import Path
+from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -14,7 +15,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 
 class Obsidian(base_classes.DataPackageBaseClass):

--- a/colrev/packages/obsidian/src/obsidian.py
+++ b/colrev/packages/obsidian/src/obsidian.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Creation of an Obsidian database as part of the data operations"""
 from __future__ import annotations
+from typing import Optional
 
 from collections import Counter
 from pathlib import Path
@@ -13,6 +14,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 
 class Obsidian(base_classes.DataPackageBaseClass):
@@ -54,7 +56,9 @@ class Obsidian(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
         self.data_operation = data_operation
 
@@ -105,7 +109,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
                 self.review_manager.path
                 / colrev.record.record.Record(record_dict).get_tei_filename()
             )
-            self.review_manager.logger.info(f"  extract keywords for {tei_file.name}")
+            self.logger.info(f"  extract keywords for {tei_file.name}")
 
             if tei_file.is_file():
                 tei = colrev.env.tei_parser.TEIParser(tei_path=tei_file)
@@ -124,7 +128,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
         included = self.data_operation.get_record_ids_for_synthesis(records)
         missing_records = self._get_obsidian_missing(included=included)
         if len(missing_records) == 0:
-            self.review_manager.logger.info("All records included. Nothing to export.")
+            self.logger.info("All records included. Nothing to export.")
             return
 
         inbox_text = ""
@@ -214,7 +218,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
         if silent_mode:
             return
 
-        self.review_manager.logger.debug("Export to obsidian endpoint")
+        self.logger.debug("Export to obsidian endpoint")
 
         self._append_missing_records(records=records)
 

--- a/colrev/packages/ocrmypdf/src/ocrmypdf.py
+++ b/colrev/packages/ocrmypdf/src/ocrmypdf.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """OCR as a PDF preparation operation"""
 from __future__ import annotations
+from typing import Optional
 
 import os
 import shutil
@@ -17,6 +18,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import PDFDefectCodes
+import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code
@@ -34,7 +36,9 @@ class OCRMyPDF(base_classes.PDFPrepPackageBaseClass):
         *,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager
 

--- a/colrev/packages/ocrmypdf/src/ocrmypdf.py
+++ b/colrev/packages/ocrmypdf/src/ocrmypdf.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """OCR as a PDF preparation operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import os
 import shutil
 from pathlib import Path
+from typing import Optional
 
 import docker
 from pydantic import Field
@@ -18,7 +19,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import PDFDefectCodes
-import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: OpenAlex"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 
 import requests
 from pydantic import Field

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: OpenAlex"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -43,7 +44,9 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         # Note: not yet implemented
         # Note : once this is implemented, add "colrev.open_alex" to the default settings

--- a/colrev/packages/open_alex/src/open_alex_metadata_prep.py
+++ b/colrev/packages/open_alex/src/open_alex_metadata_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on OpenAlex API as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.packages.open_alex.src.open_alex as open_alex_connector
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/open_alex/src/open_alex_metadata_prep.py
+++ b/colrev/packages/open_alex/src/open_alex_metadata_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on OpenAlex API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.packages.open_alex.src.open_alex as open_alex_connector
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -30,7 +32,9 @@ class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
 

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: OpenCitations"""
 from __future__ import annotations
-from typing import Optional
 
 import json
 import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 import requests
 from pydantic import Field
@@ -40,7 +40,10 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
@@ -151,9 +154,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
             if not self._fw_search_condition(record=record):
                 continue
 
-            self.logger.info(
-                f"Run forward search for {record[Fields.ID]}"
-            )
+            self.logger.info(f"Run forward search for {record[Fields.ID]}")
 
             new_records = self._get_forward_search_records(record_dict=record)
 

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Connector to OpenLibrary (API)"""
 from __future__ import annotations
+from typing import Optional
 
 import json
 import logging
@@ -53,7 +54,9 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # OpenLibrary as a search_source
@@ -164,7 +167,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 timeout=prep_operation.timeout,
             )
             ret.raise_for_status()
-            # prep_operation.review_manager.logger.debug(url)
+            # self.logger.debug(url)
             if '"error": "notfound"' in ret.text:
                 record.remove_field(key=Fields.ISBN)
 
@@ -211,7 +214,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 timeout=prep_operation.timeout,
             )
             ret.raise_for_status()
-            # prep_operation.review_manager.logger.debug(url)
+            # self.logger.debug(url)
 
             # if we have an exact match, we don't need to check the similarity
             if '"numFoundExact": true,' not in ret.text:

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """Connector to OpenLibrary (API)"""
 from __future__ import annotations
-from typing import Optional
 
 import json
 import logging
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 
 import requests
 from pydantic import Field

--- a/colrev/packages/open_library/src/open_library_prep.py
+++ b/colrev/packages/open_library/src/open_library_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on OpenLibrary API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.packages.open_library.src.open_library as open_library_connector
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code
@@ -29,7 +31,9 @@ class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.open_library_connector = open_library_connector.OpenLibrarySearchSource(

--- a/colrev/packages/open_library/src/open_library_prep.py
+++ b/colrev/packages/open_library/src/open_library_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on OpenLibrary API as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.packages.open_library.src.open_library as open_library_connector
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Searchsource:OSF"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -54,7 +55,9 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
 
         if settings:
@@ -159,7 +162,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
             parameters=self.search_source.search_parameters["query"],
             api_key=self._get_api_key(),
         )
-        self.review_manager.logger.info(f"Retrieve {api.overall()} records")
+        self.logger.info(f"Retrieve {api.overall()} records")
 
         while True:
             for record_dict in api.retrieve_records():

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Searchsource:OSF"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 """Creation of a markdown paper as part of the data operations"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import os
 import re
 import shutil
@@ -11,6 +11,7 @@ import typing
 from collections import Counter
 from pathlib import Path
 from threading import Timer
+from typing import Optional
 
 import docker
 import requests
@@ -30,7 +31,6 @@ from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import Filepaths
 from colrev.writer.write_utils import write_file
-import logging
 
 
 class PaperMarkdownSettings(BaseModel):
@@ -164,9 +164,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             with open(template_name, "wb") as file:
                 file.write(filedata)
         else:
-            self.logger.error(
-                f"Could not retrieve {template_name} from the package"
-            )
+            self.logger.error(f"Could not retrieve {template_name} from the package")
             return False
         self.review_manager.dataset.add_changes(template_name)
         return True
@@ -518,9 +516,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         else:
             if not silent_mode:
                 self.review_manager.report_logger.info("Update paper")
-                self.logger.info(
-                    f"Update paper ({self.settings.paper_path.name})"
-                )
+                self.logger.info(f"Update paper ({self.settings.paper_path.name})")
             self._add_missing_records_to_paper(
                 missing_records=missing_records,
                 silent_mode=silent_mode,
@@ -719,9 +715,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             self.review_manager.paths.records.touch()
 
         if not self.settings.paper_path.is_file():
-            self.logger.error(
-                "File %s does not exist.", self.settings.paper_path
-            )
+            self.logger.error("File %s does not exist.", self.settings.paper_path)
             self.logger.info("Complete processing and use colrev data")
             return
 

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Creation of a markdown paper as part of the data operations"""
 from __future__ import annotations
+from typing import Optional
 
 import os
 import re
@@ -29,6 +30,7 @@ from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import Filepaths
 from colrev.writer.write_utils import write_file
+import logging
 
 
 class PaperMarkdownSettings(BaseModel):
@@ -91,7 +93,9 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.data_operation = data_operation
         self.review_manager = data_operation.review_manager
 
@@ -160,7 +164,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             with open(template_name, "wb") as file:
                 file.write(filedata)
         else:
-            self.review_manager.logger.error(
+            self.logger.error(
                 f"Could not retrieve {template_name} from the package"
             )
             return False
@@ -187,7 +191,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             )
             self.review_manager.dataset.add_changes(self.settings.paper_path)
             self.review_manager.dataset.add_changes(Path(csl_filename))
-            self.review_manager.logger.debug("Downloaded csl file for offline use")
+            self.logger.debug("Downloaded csl file for offline use")
 
     def _check_new_record_source_tag(
         self,
@@ -244,7 +248,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             + "the document."
         )
         self.review_manager.report_logger.warning(msg)
-        self.review_manager.logger.warning(msg)
+        self.logger.warning(msg)
         if line != "\n":
             writer.write("\n")
         marker = f"{self.NEW_RECORD_SOURCE_TAG}_Records to synthesize_:\n\n"
@@ -256,7 +260,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                 f" {missing_record} added"
             )
             if not silent_mode:
-                self.review_manager.logger.info(
+                self.logger.info(
                     # f" {missing_record}".ljust(self._PAD, " ") + " added"
                     f" {missing_record} added"
                 )
@@ -297,13 +301,13 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
 
         for paper_id_added in paper_ids_added:
             if not silent_mode:
-                self.review_manager.logger.info(
+                self.logger.info(
                     f" {Colors.GREEN}{paper_id_added}".ljust(45)
                     + f"add to paper{Colors.END}"
                 )
 
         if not silent_mode:
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Added to {paper_path.name}".ljust(24)
                 + f"{nr_records_added}".rjust(15, " ")
                 + " records"
@@ -368,7 +372,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
     def _create_paper(self, silent_mode: bool) -> None:
         if not silent_mode:
             self.review_manager.report_logger.info("Create paper")
-            self.review_manager.logger.info("Create paper")
+            self.logger.info("Create paper")
 
         title = "Paper template"
         readme_file = self.review_manager.paths.readme
@@ -479,10 +483,10 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                         screening_criteria="NA",
                     )
 
-                    self.review_manager.logger.info(f"Excluded {record_id}")
+                    self.logger.info(f"Excluded {record_id}")
                     self.review_manager.report_logger.info(f"Excluded {record_id}")
                 else:
-                    self.review_manager.logger.error(f"Did not find ID {record_id}")
+                    self.logger.error(f"Did not find ID {record_id}")
                     writer.write(line)
                     line = reader.readline()
                     continue
@@ -499,7 +503,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             record_id_list=list(synthesized_record_status_matrix.keys()),
         )
         missing_records = sorted(missing_records)
-        # review_manager.logger.debug(f"missing_records: {missing_records}")
+        # self.logger.debug(f"missing_records: {missing_records}")
 
         self._check_new_record_source_tag()
 
@@ -508,13 +512,13 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                 self.review_manager.report_logger.info(
                     f"All records included in {self.settings.paper_path.name}"
                 )
-            # review_manager.logger.debug(
+            # self.logger.debug(
             #     f"All records included in {self.settings.paper_path.name}"
             # )
         else:
             if not silent_mode:
                 self.review_manager.report_logger.info("Update paper")
-                self.review_manager.logger.info(
+                self.logger.info(
                     f"Update paper ({self.settings.paper_path.name})"
                 )
             self._add_missing_records_to_paper(
@@ -531,13 +535,13 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
 
             non_sample_records = colrev.loader.load_utils.load(
                 filename=self.non_sample_references,
-                logger=self.review_manager.logger,
+                logger=self.logger,
             )
 
             records_to_add = colrev.loader.load_utils.loads(
                 load_string=filedata.decode("utf-8"),
                 implementation="bib",
-                logger=self.review_manager.logger,
+                logger=self.logger,
             )
 
             # maybe prefix "non_sample_NameYear"? (also avoid conflicts with records.bib)
@@ -553,7 +557,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                 k: v for k, v in records_to_add.items() if k not in non_sample_records
             }
             if duplicated_keys:
-                self.review_manager.logger.error(
+                self.logger.error(
                     f"{Colors.RED}Cannot add {duplicated_keys} to "
                     f"{self.NON_SAMPLE_REFERENCES_RELATIVE}, "
                     f"please change ID and add manually:{Colors.END}"
@@ -580,7 +584,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         if prisma_endpoint_l:
             if "PRISMA.png" not in self.settings.paper_path.read_text(encoding="UTF-8"):
                 if not silent_mode:
-                    self.review_manager.logger.info("Add PRISMA diagram to paper")
+                    self.logger.info("Add PRISMA diagram to paper")
                 self._append_to_non_sample_references(
                     module="colrev.packages.prisma",
                     filepath=Path("prisma/prisma-refs.bib"),
@@ -696,7 +700,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             container.remove()
 
         except docker.errors.ImageNotFound:
-            self.review_manager.logger.error("Docker image not found")
+            self.logger.error("Docker image not found")
         except docker.errors.ContainerError as exc:
             if "Temporary failure in name resolution" in str(exc):
                 raise colrev_exceptions.ServiceNotAvailableException(
@@ -715,10 +719,10 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             self.review_manager.paths.records.touch()
 
         if not self.settings.paper_path.is_file():
-            self.review_manager.logger.error(
+            self.logger.error(
                 "File %s does not exist.", self.settings.paper_path
             )
-            self.review_manager.logger.info("Complete processing and use colrev data")
+            self.logger.info("Complete processing and use colrev data")
             return
 
         self._retrieve_default_csl()
@@ -728,7 +732,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         word_template = self.settings.word_template
 
         if not self._retrieve_default_word_template(word_template):
-            self.review_manager.logger.error(f"Word template {word_template} not found")
+            self.logger.error(f"Word template {word_template} not found")
             return
 
         output_relative_path = self.settings.paper_output.relative_to(
@@ -739,11 +743,11 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             not self.review_manager.dataset.has_changes(self.paper_relative_path)
             and self.settings.paper_output.is_file()
         ):
-            self.review_manager.logger.debug("Skipping paper build (no changes)")
+            self.logger.debug("Skipping paper build (no changes)")
             return
 
         if self.review_manager.verbose_mode:
-            self.review_manager.logger.info("Build paper")
+            self.logger.info("Build paper")
 
         script = (
             f"{self.paper_relative_path.as_posix()} --filter pandoc-crossref --citeproc "
@@ -771,7 +775,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                 self.paper_relative_path, change_type="unstaged"
             )
         ):
-            self.review_manager.logger.warning(
+            self.logger.warning(
                 f"{Colors.RED}Skipping updates of "
                 f"{self.paper_relative_path} due to unstaged changes{Colors.END}"
             )

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: backward search (based on PDFs and GROBID)"""
 from __future__ import annotations
-from typing import Optional
 
 import json
 import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 import inquirer
 import pandas as pd
@@ -53,7 +53,10 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
@@ -371,22 +374,16 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         records = self.review_manager.dataset.load_records_dict()
 
         if not records:
-            self.logger.info(
-                "No records imported. Cannot run backward search yet."
-            )
+            self.logger.info("No records imported. Cannot run backward search yet.")
             return
         min_intext_citations = self.search_source.search_parameters[
             "min_intext_citations"
         ]
-        self.logger.info(
-            f"Set min_intext_citations={min_intext_citations}"
-        )
+        self.logger.info(f"Set min_intext_citations={min_intext_citations}")
         nr_references_threshold = self.search_source.search_parameters.get(
             "min_ref_freq", 1
         )
-        self.logger.info(
-            f"Set nr_references_threshold={nr_references_threshold}"
-        )
+        self.logger.info(f"Set nr_references_threshold={nr_references_threshold}")
 
         selected_records = {
             rid: record
@@ -463,9 +460,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         for record in tqdm(selected_records.values()):
             try:
 
-                self.logger.info(
-                    f" run backward search for {record[Fields.ID]}"
-                )
+                self.logger.info(f" run backward search for {record[Fields.ID]}")
 
                 pdf_path = review_manager.path / Path(record[Fields.FILE])
                 tei = colrev.env.tei_parser.TEIParser(

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: plos"""
+from typing import Optional
 import datetime
 import logging
 import typing
@@ -46,7 +47,9 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.search_source = self._get_search_source(settings)
         self.plos_lock = Lock()
@@ -224,20 +227,20 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.api.last_updated = plos_feed.get_last_updated()
 
         num_records = self.api.get_len_total()
-        self.review_manager.logger.info(f"Total: {num_records:,} records")
+        self.logger.info(f"Total: {num_records:,} records")
 
         # It retrieves only new records added since the last sync, avoiding a full download.
         if not rerun:
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Retrieve papers indexed since {self.api.last_updated.split('T', maxsplit=1)[0]}"
             )
             num_records = self.api.get_len()
 
-        self.review_manager.logger.info(f"Retrieve {num_records:,} records")
+        self.logger.info(f"Retrieve {num_records:,} records")
 
         estimated_time = num_records * 0.5
         estimated_time_formatted = str(datetime.timedelta(seconds=int(estimated_time)))
-        self.review_manager.logger.info(f"Estimated time: {estimated_time_formatted}")
+        self.logger.info(f"Estimated time: {estimated_time_formatted}")
 
         try:
             for record in self.api.get_records():
@@ -291,7 +294,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         if source.search_type == SearchType.API:
             self._validate_api_params()
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     # pylint: disable=pointless-statement
     def _validate_api_params(self) -> None:

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: plos"""
-from typing import Optional
 import datetime
 import logging
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 
 import colrev.env.language_service
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
+++ b/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Jupyter notebook for prep-man operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pathlib import Path
 
@@ -11,6 +12,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -22,13 +24,15 @@ class CurationJupyterNotebookManPrep(base_classes.PrepManPackageBaseClass):
     ci_supported: bool = Field(default=False)
 
     def __init__(
-        self, *, prep_man_operation: colrev.ops.prep_man.PrepMan, settings: dict
+        self, *, prep_man_operation: colrev.ops.prep_man.PrepMan, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
         Path("prep_man").mkdir(exist_ok=True)
         if not Path("prep_man/prep_man_curation.ipynb").is_file():
-            prep_man_operation.review_manager.logger.info(
+            self.logger.info(
                 f"Activated jupyter notebook to"
                 f"{Path('prep_man/prep_man_curation.ipynb')}"
             )

--- a/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
+++ b/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Jupyter notebook for prep-man operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -12,7 +13,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=too-few-public-methods
 
@@ -24,7 +24,10 @@ class CurationJupyterNotebookManPrep(base_classes.PrepManPackageBaseClass):
     ci_supported: bool = Field(default=False)
 
     def __init__(
-        self, *, prep_man_operation: colrev.ops.prep_man.PrepMan, settings: dict,
+        self,
+        *,
+        prep_man_operation: colrev.ops.prep_man.PrepMan,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/prescreen_table/src/prescreen_table.py
+++ b/colrev/packages/prescreen_table/src/prescreen_table.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Prescreen based on a table"""
 from __future__ import annotations
+from typing import Optional
 
 import csv
 from pathlib import Path
@@ -15,6 +16,7 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -33,7 +35,9 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         *,
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = prescreen_operation.review_manager
         self.settings = self.settings_class(**settings)
 
@@ -51,7 +55,7 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         # instead of overwriting
         # export_table_format as a settings parameter
 
-        self.review_manager.logger.info("Loading records for export")
+        self.logger.info("Loading records for export")
 
         tbl = []
         for record in records.values():
@@ -103,18 +107,18 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         if export_table_format.lower() == "csv":
             screen_df = pd.DataFrame(tbl)
             screen_df.to_csv("prescreen.csv", index=False, quoting=csv.QUOTE_ALL)
-            self.review_manager.logger.info("Created prescreen.csv")
+            self.logger.info("Created prescreen.csv")
 
         if export_table_format.lower() == "xlsx":
             screen_df = pd.DataFrame(tbl)
             screen_df.to_excel("prescreen.xlsx", index=False, sheet_name="screen")
-            self.review_manager.logger.info("Created prescreen.xlsx")
+            self.logger.info("Created prescreen.xlsx")
 
-        self.review_manager.logger.info(
+        self.logger.info(
             f"To prescreen records, {Colors.ORANGE}enter [in|out] "
             f"in the presceen_inclusion column.{Colors.END}"
         )
-        self.review_manager.logger.info(
+        self.logger.info(
             f"Afterwards, run {Colors.ORANGE}colrev prescreen --import_table "
             f"prescreen.{export_table_format.lower()}{Colors.END}"
         )
@@ -129,11 +133,11 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
 
         # pylint: disable=too-many-branches
 
-        self.review_manager.logger.info(f"Load {import_table_path}")
+        self.logger.info(f"Load {import_table_path}")
 
         # pylint: disable=duplicate-code
         if not Path(import_table_path).is_file():
-            self.review_manager.logger.error(
+            self.logger.error(
                 f"Did not find {import_table_path} - exiting."
             )
             return
@@ -148,13 +152,13 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         prescreened_records = prescreen_df.to_dict("records")
 
         if "presceen_inclusion" not in prescreened_records[0]:
-            self.review_manager.logger.warning("presceen_inclusion column missing")
+            self.logger.warning("presceen_inclusion column missing")
             return
 
         prescreen_included = 0
         prescreen_excluded = 0
         nr_todo = 0
-        self.review_manager.logger.info("Update prescreen results")
+        self.logger.info("Update prescreen results")
         for prescreened_record in prescreened_records:
             if prescreened_record.get(Fields.ID, "") in records:
                 record = colrev.record.record.Record(
@@ -182,30 +186,30 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
                 elif prescreened_record.get("presceen_inclusion", "") == "TODO":
                     nr_todo += 1
                 else:
-                    self.review_manager.logger.warning(
+                    self.logger.warning(
                         "Invalid value in prescreen_inclusion: "
                         f"{prescreened_record.get('presceen_inclusion', '')} "
                         f"({prescreened_record.get('ID', 'NO_ID')})"
                     )
 
             else:
-                self.review_manager.logger.warning(
+                self.logger.warning(
                     f"ID not in records: {prescreened_record.get('ID', '')}"
                 )
 
-        self.review_manager.logger.info(
+        self.logger.info(
             f" {Colors.GREEN}{prescreen_included} records prescreen_included{Colors.END}"
         )
-        self.review_manager.logger.info(
+        self.logger.info(
             f" {Colors.RED}{prescreen_excluded} records prescreen_excluded{Colors.END}"
         )
 
-        self.review_manager.logger.info(
+        self.logger.info(
             f" {Colors.ORANGE}{nr_todo} records to prescreen{Colors.END}"
         )
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.logger.info("Completed import")
+        self.logger.info("Completed import")
 
     def run_prescreen(
         self,

--- a/colrev/packages/prescreen_table/src/prescreen_table.py
+++ b/colrev/packages/prescreen_table/src/prescreen_table.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Prescreen based on a table"""
 from __future__ import annotations
-from typing import Optional
 
 import csv
+import logging
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from pydantic import Field
@@ -16,7 +17,6 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -137,9 +137,7 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
 
         # pylint: disable=duplicate-code
         if not Path(import_table_path).is_file():
-            self.logger.error(
-                f"Did not find {import_table_path} - exiting."
-            )
+            self.logger.error(f"Did not find {import_table_path} - exiting.")
             return
 
         if import_table_path.endswith(".csv"):
@@ -204,9 +202,7 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
             f" {Colors.RED}{prescreen_excluded} records prescreen_excluded{Colors.END}"
         )
 
-        self.logger.info(
-            f" {Colors.ORANGE}{nr_todo} records to prescreen{Colors.END}"
-        )
+        self.logger.info(f" {Colors.ORANGE}{nr_todo} records to prescreen{Colors.END}")
 
         self.review_manager.dataset.save_records_dict(records)
         self.logger.info("Completed import")

--- a/colrev/packages/prisma/src/prisma.py
+++ b/colrev/packages/prisma/src/prisma.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Creation of a PRISMA chart as part of the data operations"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import os
 import typing
 from pathlib import Path
+from typing import Optional
 
 import docker
 import pandas as pd
@@ -19,7 +20,6 @@ import colrev.exceptions as colrev_exceptions
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 from colrev.constants import Colors
-import logging
 
 if typing.TYPE_CHECKING:
     import colrev.ops.data

--- a/colrev/packages/profile/src/profile.py
+++ b/colrev/packages/profile/src/profile.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Creation of a profile of studies as part of the data operations"""
 from __future__ import annotations
+from typing import Optional
 
 from pathlib import Path
 
@@ -16,6 +17,7 @@ import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
+import logging
 
 
 class Profile(base_classes.DataPackageBaseClass):
@@ -38,7 +40,9 @@ class Profile(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
         self.data_operation = data_operation
 
@@ -66,7 +70,7 @@ class Profile(base_classes.DataPackageBaseClass):
     def _update_profile(self, silent_mode: bool) -> None:
         """Create a profile of the sample"""
 
-        self.review_manager.logger.info("Create sample profile")
+        self.logger.info("Create sample profile")
 
         def prep_records(*, records: dict) -> pd.DataFrame:
             for record in records.values():
@@ -116,11 +120,11 @@ class Profile(base_classes.DataPackageBaseClass):
                 Fields.ID
             ].tolist()
             if len(missing_outlet) > 0:
-                self.review_manager.logger.info(f"No outlet: {missing_outlet}")
+                self.logger.info(f"No outlet: {missing_outlet}")
             return observations
 
         # if not status.get_completeness_condition():
-        #     self.review_manager.logger.warning(
+        #     self.logger.warning(
         #  f"{Colors.RED}Sample not completely processed!{Colors.END}")
 
         records = self.review_manager.dataset.load_records_dict()
@@ -134,10 +138,10 @@ class Profile(base_classes.DataPackageBaseClass):
         )
 
         if observations.empty:
-            self.review_manager.logger.info("No sample/observations available")
+            self.logger.info("No sample/observations available")
             return
 
-        self.review_manager.logger.info("Generate output/sample.csv")
+        self.logger.info("Generate output/sample.csv")
         observations.to_csv(output_dir / Path("sample.csv"), index=False)
 
         tabulated = pd.pivot_table(
@@ -161,7 +165,7 @@ class Profile(base_classes.DataPackageBaseClass):
         tabulated = tabulated[year_list]
         tabulated.sort_values(by=("All"), ascending=True, inplace=True)
 
-        self.review_manager.logger.info("Generate profile output/journals_years.csv")
+        self.logger.info("Generate profile output/journals_years.csv")
         tabulated.to_csv(output_dir / Path("journals_years.csv"))
 
         tabulated = pd.pivot_table(
@@ -172,10 +176,10 @@ class Profile(base_classes.DataPackageBaseClass):
             fill_value=0,
             margins=True,
         )
-        self.review_manager.logger.info("Generate output/ENTRYTYPES.csv")
+        self.logger.info("Generate output/ENTRYTYPES.csv")
         tabulated.to_csv(output_dir / Path("ENTRYTYPES.csv"))
 
-        self.review_manager.logger.info(f"Files are available in {output_dir.name}")
+        self.logger.info(f"Files are available in {output_dir.name}")
 
     def update_data(
         self,

--- a/colrev/packages/profile/src/profile.py
+++ b/colrev/packages/profile/src/profile.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Creation of a profile of studies as part of the data operations"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from pydantic import BaseModel
@@ -17,7 +18,6 @@ import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
-import logging
 
 
 class Profile(base_classes.DataPackageBaseClass):

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -4,6 +4,7 @@
 A CoLRev SearchSource plugin to scrape and import records from PROSPERO.
 """
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -44,7 +45,9 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         """Initialize the ProsperoSearchSource plugin."""
 
         self.search_source = self._get_search_source(settings)
@@ -112,8 +115,8 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
                 f"Prospero search_type must be one of {self.search_types}, "
                 f"not {self.search_source.search_type}"
             )
-        if self.review_manager.logger:
-            self.review_manager.logger.debug(
+        if self.logger:
+            self.logger.debug(
                 "Validate SearchSource %s", self.search_source.filename
             )
 
@@ -127,12 +130,12 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if "query" in (self.search_source.search_parameters or {}):
             self.search_word = self.search_source.search_parameters["query"]
-            self.review_manager.logger.debug(
+            self.logger.debug(
                 "Using query from search_parameters: %s", self.search_word
             )
         else:
             self.search_word = input("Enter your search query: ").strip()
-            self.review_manager.logger.debug(
+            self.logger.debug(
                 "Using user-input query: %s", self.search_word
             )
 
@@ -143,19 +146,19 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
     ) -> None:
         """Add newly scraped records to the feed."""
         if rerun and self.review_manager:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Performing a search of the full history (may take time)"
             )
 
         search_word = self.get_search_word()
-        self.review_manager.logger.info("Prospero search with query: %s", search_word)
+        self.logger.info("Prospero search with query: %s", search_word)
 
         prospero_api = colrev.packages.prospero.src.prospero_api.PROSPEROAPI(
-            search_word, logger=self.review_manager.logger
+            search_word, logger=self.logger
         )
 
         for record_dict in prospero_api.get_next_record():
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"retrieve record: {record_dict[Fields.URL]}"
             )
 

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -4,11 +4,11 @@
 A CoLRev SearchSource plugin to scrape and import records from PROSPERO.
 """
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -116,9 +116,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
                 f"not {self.search_source.search_type}"
             )
         if self.logger:
-            self.logger.debug(
-                "Validate SearchSource %s", self.search_source.filename
-            )
+            self.logger.debug("Validate SearchSource %s", self.search_source.filename)
 
     def get_search_word(self) -> str:
         """
@@ -135,9 +133,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
         else:
             self.search_word = input("Enter your search query: ").strip()
-            self.logger.debug(
-                "Using user-input query: %s", self.search_word
-            )
+            self.logger.debug("Using user-input query: %s", self.search_word)
 
         return self.search_word
 
@@ -146,9 +142,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
     ) -> None:
         """Add newly scraped records to the feed."""
         if rerun and self.review_manager:
-            self.logger.info(
-                "Performing a search of the full history (may take time)"
-            )
+            self.logger.info("Performing a search of the full history (may take time)")
 
         search_word = self.get_search_word()
         self.logger.info("Prospero search with query: %s", search_word)
@@ -158,9 +152,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         for record_dict in prospero_api.get_next_record():
-            self.logger.info(
-                f"retrieve record: {record_dict[Fields.URL]}"
-            )
+            self.logger.info(f"retrieve record: {record_dict[Fields.URL]}")
 
             try:
                 if not record_dict.get(Fields.AUTHOR, "") and not record_dict.get(

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: PsycINFO"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 from pathlib import Path
@@ -35,8 +36,10 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://www.apa.org/search"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.source_operation = source_operation
         self.review_manager = source_operation.review_manager

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """SearchSource: PsycINFO"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -36,7 +36,10 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://www.apa.org/search"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: Pubmed"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 import pandas as pd
@@ -337,9 +337,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         rerun: bool,
     ) -> None:
         if rerun:
-            self.logger.info(
-                "Performing a search of the full history (may take time)"
-            )
+            self.logger.info("Performing a search of the full history (may take time)")
 
         api = pubmed_api.PubmedAPI(
             parameters=self.search_source.search_parameters,

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Pubmed"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -53,7 +54,9 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # Pubmed as a search_source
@@ -171,7 +174,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Validate the SearchSource (parameters etc.)"""
 
         source = self.search_source
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
 
         if source.filename.name != self._pubmed_md_filename.name:
             if "query" not in source.search_parameters:
@@ -182,7 +185,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
             # if "query_file" in source.search_parameters:
             # ...
 
-        self.review_manager.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug(f"SearchSource {source.filename} validated")
 
     def check_availability(
         self, *, source_operation: colrev.process.operation.Operation
@@ -230,7 +233,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
                 parameters=self.search_source.search_parameters,
                 email=self.email,
                 session=self.review_manager.get_cached_session(),
-                logger=self.review_manager.logger,
+                logger=self.logger,
             )
 
             retrieved_record = api.query_id(pubmed_id=record.data["pubmedid"])
@@ -334,7 +337,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         rerun: bool,
     ) -> None:
         if rerun:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Performing a search of the full history (may take time)"
             )
 
@@ -342,7 +345,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
             parameters=self.search_source.search_parameters,
             email=self.email,
             session=self.review_manager.get_cached_session(),
-            logger=self.review_manager.logger,
+            logger=self.logger,
         )
 
         for record in api.get_query_return():
@@ -351,7 +354,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
                 if "" == record.data.get(Fields.AUTHOR, "") and "" == record.data.get(
                     Fields.TITLE, ""
                 ):
-                    self.review_manager.logger.warning(f"Skipped record: {record.data}")
+                    self.logger.warning(f"Skipped record: {record.data}")
                     continue
                 prep_record = colrev.record.record_prep.PrepRecord(record.data)
 
@@ -381,7 +384,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
             parameters=self.search_source.search_parameters,
             email=self.email,
             session=self.review_manager.get_cached_session(),
-            logger=self.review_manager.logger,
+            logger=self.logger,
         )
 
         for feed_record_dict in pubmed_feed.feed_records.values():

--- a/colrev/packages/pubmed/src/pubmed_metadata_prep.py
+++ b/colrev/packages/pubmed/src/pubmed_metadata_prep.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on the Pubmed API as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.packages.pubmed.src.pubmed as pubmed_connector
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 

--- a/colrev/packages/pubmed/src/pubmed_metadata_prep.py
+++ b/colrev/packages/pubmed/src/pubmed_metadata_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on the Pubmed API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.packages.pubmed.src.pubmed as pubmed_connector
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -33,7 +35,9 @@ class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
 

--- a/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
+++ b/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Qualitative systematic review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -13,6 +14,7 @@ from colrev.packages.open_citations_forward_search.src.open_citations_forward_se
 from colrev.packages.pdf_backward_search.src.pdf_backward_search import (
     BackwardSearchSource,
 )
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -27,8 +29,10 @@ class QualitativeSystematicReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
+++ b/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Qualitative systematic review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -14,7 +16,6 @@ from colrev.packages.open_citations_forward_search.src.open_citations_forward_se
 from colrev.packages.pdf_backward_search.src.pdf_backward_search import (
     BackwardSearchSource,
 )
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -29,7 +30,10 @@ class QualitativeSystematicReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/ref_check/src/ref_check.py
+++ b/colrev/packages/ref_check/src/ref_check.py
@@ -1,8 +1,10 @@
 #! /usr/bin/env python
 """DataPackageBaseClass: RefCheck"""
+from typing import Optional
 import colrev.ops.data
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import DataPackageBaseClass
+import logging
 
 # pylint: disable=unused-argument
 
@@ -17,7 +19,9 @@ class RefCheck(DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.data_operation = data_operation
         self.review_manager = data_operation.review_manager
 

--- a/colrev/packages/ref_check/src/ref_check.py
+++ b/colrev/packages/ref_check/src/ref_check.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """DataPackageBaseClass: RefCheck"""
+import logging
 from typing import Optional
+
 import colrev.ops.data
 import colrev.package_manager.package_settings
 from colrev.package_manager.package_base_classes import DataPackageBaseClass
-import logging
 
 # pylint: disable=unused-argument
 

--- a/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
+++ b/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Removal of broken IDs as a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 from pydantic import Field
@@ -11,7 +13,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import DefectCodes
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
+++ b/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Removal of broken IDs as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import Field
 
@@ -10,6 +11,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import DefectCodes
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -30,7 +32,9 @@ class RemoveBrokenIDPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = colrev.package_manager.package_settings.DefaultSettings(
             **settings
         )

--- a/colrev/packages/remove_coverpage/src/remove_cover_page.py
+++ b/colrev/packages/remove_coverpage/src/remove_cover_page.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Cover-page removal as a PDF preparation operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import shutil
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pymupdf
 from pydantic import Field
@@ -15,7 +16,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import Filepaths
-import logging
 
 # pylint: disable=duplicate-code
 

--- a/colrev/packages/remove_coverpage/src/remove_cover_page.py
+++ b/colrev/packages/remove_coverpage/src/remove_cover_page.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Cover-page removal as a PDF preparation operation"""
 from __future__ import annotations
+from typing import Optional
 
 import shutil
 import typing
@@ -14,6 +15,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import Filepaths
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -33,7 +35,9 @@ class PDFCoverPage(base_classes.PDFPrepPackageBaseClass):
         *,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager
 

--- a/colrev/packages/remove_last_page/src/remove_last_page.py
+++ b/colrev/packages/remove_last_page/src/remove_last_page.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Last-page removal as a PDF preparation operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import shutil
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pymupdf
 from pydantic import Field
@@ -15,7 +16,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import Filepaths
-import logging
 
 # pylint: disable=duplicate-code
 

--- a/colrev/packages/remove_last_page/src/remove_last_page.py
+++ b/colrev/packages/remove_last_page/src/remove_last_page.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Last-page removal as a PDF preparation operation"""
 from __future__ import annotations
+from typing import Optional
 
 import shutil
 import typing
@@ -14,6 +15,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import Filepaths
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -33,7 +35,9 @@ class PDFLastPage(base_classes.PDFPrepPackageBaseClass):
         *,
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,  # pylint: disable=unused-argument
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager
 

--- a/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
+++ b/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Removal of broken URLs (error 500) a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 import requests
 from pydantic import Field
@@ -10,6 +11,7 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -36,7 +38,9 @@ class RemoveError500URLsPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager

--- a/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
+++ b/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Removal of broken URLs (error 500) a prep operation"""
 from __future__ import annotations
+
+import logging
 from typing import Optional
 
 import requests
@@ -11,7 +13,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/scientometric/src/scientometric.py
+++ b/colrev/packages/scientometric/src/scientometric.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Scientometric study"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -20,8 +22,10 @@ class ScientometricReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/scientometric/src/scientometric.py
+++ b/colrev/packages/scientometric/src/scientometric.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Scientometric study"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,7 +23,10 @@ class ScientometricReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/scope_prescreen/src/scope_prescreen.py
+++ b/colrev/packages/scope_prescreen/src/scope_prescreen.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """Prescreen based on specified scope"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import typing
 from sqlite3 import OperationalError
+from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -18,7 +19,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -310,9 +310,7 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
         ) in operation.review_manager.settings.prescreen.prescreen_package_endpoints:
             if existing_scope_prescreen["endpoint"] != "colrev.scope_prescreen":
                 continue
-            self.logger.info(
-                "Integrating into existing colrev.scope_prescreen"
-            )
+            self.logger.info("Integrating into existing colrev.scope_prescreen")
             for key, value in params_dict.items():
                 if (
                     key in existing_scope_prescreen

--- a/colrev/packages/scope_prescreen/src/scope_prescreen.py
+++ b/colrev/packages/scope_prescreen/src/scope_prescreen.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Prescreen based on specified scope"""
 from __future__ import annotations
+from typing import Optional
 
 import typing
 from sqlite3 import OperationalError
@@ -17,6 +18,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -85,7 +87,9 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
         *,
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         if "TimeScopeFrom" in settings:
             settings["TimeScopeFrom"] = int(settings["TimeScopeFrom"])
             assert settings["TimeScopeFrom"] > 1900
@@ -306,7 +310,7 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
         ) in operation.review_manager.settings.prescreen.prescreen_package_endpoints:
             if existing_scope_prescreen["endpoint"] != "colrev.scope_prescreen":
                 continue
-            operation.review_manager.logger.info(
+            self.logger.info(
                 "Integrating into existing colrev.scope_prescreen"
             )
             for key, value in params_dict.items():
@@ -314,7 +318,7 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
                     key in existing_scope_prescreen
                     and existing_scope_prescreen[key] != value
                 ):
-                    operation.review_manager.logger.info(
+                    self.logger.info(
                         f"Replacing {key} ({existing_scope_prescreen[key]} -> {value})"
                     )
 

--- a/colrev/packages/scoping_review/src/scoping_review.py
+++ b/colrev/packages/scoping_review/src/scoping_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Scoping review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -20,8 +22,10 @@ class ScopingReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/scoping_review/src/scoping_review.py
+++ b/colrev/packages/scoping_review/src/scoping_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Scoping review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -22,7 +23,10 @@ class ScopingReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """SearchSource: Scopus"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -37,7 +37,10 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://www.scopus.com/search/form.uri?display=advanced"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Scopus"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 from pathlib import Path
@@ -36,8 +37,10 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://www.scopus.com/search/form.uri?display=advanced"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.search_source = self.settings_class(**settings)
         self.quality_model = self.review_manager.get_qm()

--- a/colrev/packages/screen_table/src/screen_table.py
+++ b/colrev/packages/screen_table/src/screen_table.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Screen based on a table"""
 from __future__ import annotations
+from typing import Optional
 
 import csv
 import typing
@@ -17,6 +18,7 @@ import colrev.record.record
 import colrev.settings
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 class TableScreen(base_classes.ScreenPackageBaseClass):
@@ -33,14 +35,16 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
         *,
         screen_operation: colrev.ops.screen.Screen,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = screen_operation.review_manager
         self.screen_operation = screen_operation
         self.settings = self.settings_class(**settings)
 
     def _create_screening_table(self, *, records: dict, split: list) -> list:
         # pylint: disable=too-many-branches
-        self.review_manager.logger.info("Loading records for export")
+        self.logger.info("Loading records for export")
 
         screening_criteria = util_cli_screen.get_screening_criteria_from_user_input(
             screen_operation=self.screen_operation, records=records
@@ -129,7 +133,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
         if export_table_format.lower() == "csv":
             screen_df = pd.DataFrame(tbl)
             screen_df.to_csv(self.screen_table_path, index=False, quoting=csv.QUOTE_ALL)
-            self.review_manager.logger.info(f"Created {self.screen_table_path}")
+            self.logger.info(f"Created {self.screen_table_path}")
 
         if export_table_format.lower() == "xlsx":
             screen_df = pd.DataFrame(tbl)
@@ -138,7 +142,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
                 index=False,
                 sheet_name="screen",
             )
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Created {self.screen_table_path.with_suffix('.xlsx')}"
             )
 
@@ -156,7 +160,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
             import_table_path = self.screen_table_path
 
         if not Path(import_table_path).is_file():
-            self.review_manager.logger.error(
+            self.logger.error(
                 f"Did not find {import_table_path} - exiting."
             )
             return

--- a/colrev/packages/screen_table/src/screen_table.py
+++ b/colrev/packages/screen_table/src/screen_table.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Screen based on a table"""
 from __future__ import annotations
-from typing import Optional
 
 import csv
+import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from pydantic import Field
@@ -18,7 +19,6 @@ import colrev.record.record
 import colrev.settings
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 class TableScreen(base_classes.ScreenPackageBaseClass):
@@ -142,9 +142,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
                 index=False,
                 sheet_name="screen",
             )
-            self.logger.info(
-                f"Created {self.screen_table_path.with_suffix('.xlsx')}"
-            )
+            self.logger.info(f"Created {self.screen_table_path.with_suffix('.xlsx')}")
 
         return
 
@@ -160,9 +158,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
             import_table_path = self.screen_table_path
 
         if not Path(import_table_path).is_file():
-            self.logger.error(
-                f"Did not find {import_table_path} - exiting."
-            )
+            self.logger.error(f"Did not find {import_table_path} - exiting.")
             return
 
         screen_df = pd.read_csv(import_table_path)

--- a/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
+++ b/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on SemanticScholar API as a prep operation"""
 from __future__ import annotations
-from typing import Optional
 
 import json
+import logging
+from typing import Optional
 
 import requests
 from pydantic import Field
@@ -16,7 +17,6 @@ import colrev.record.record_prep
 import colrev.record.record_similarity
 from colrev.constants import Fields
 from colrev.packages.semanticscholar.src import record_transformer
-import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code

--- a/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
+++ b/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Consolidation of metadata based on SemanticScholar API as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 import json
 
@@ -15,6 +16,7 @@ import colrev.record.record_prep
 import colrev.record.record_similarity
 from colrev.constants import Fields
 from colrev.packages.semanticscholar.src import record_transformer
+import logging
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=duplicate-code
@@ -37,7 +39,9 @@ class SemanticScholarPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager
@@ -54,7 +58,7 @@ class SemanticScholarPrep(base_classes.PrepPackageBaseClass):
         search_api_url = "https://api.semanticscholar.org/graph/v1/paper/search?query="
         url = search_api_url + record_in.data.get(Fields.TITLE, "").replace(" ", "+")
 
-        # prep_operation.review_manager.logger.debug(url)
+        # self.logger.debug(url)
         ret = self.session.request(
             "GET", url, headers=self.headers, timeout=self.prep_operation.timeout
         )
@@ -69,7 +73,7 @@ class SemanticScholarPrep(base_classes.PrepPackageBaseClass):
 
         paper_id = items[0]["paperId"]
         record_retrieval_url = "https://api.semanticscholar.org/v1/paper/" + paper_id
-        # prep_operation.review_manager.logger.debug(record_retrieval_url)
+        # self.logger.debug(record_retrieval_url)
         ret_ent = self.session.request(
             "GET",
             record_retrieval_url,

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: Semantic Scholar"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from multiprocessing import Lock
 from pathlib import Path
+from typing import Optional
 
 import requests
 from pydantic import Field
@@ -183,9 +183,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             print(exc)
             raise colrev_exceptions.ServiceNotAvailableException(exc)
 
-        self.logger.info(
-            str(record_return.total) + " records have been found.\n"
-        )
+        self.logger.info(str(record_return.total) + " records have been found.\n")
 
         if record_return.total == 0:
             self.logger.info(
@@ -291,9 +289,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         # rerun not implemented yet
         if rerun:
-            self.logger.info(
-                "Performing a search of the full history (may take time)"
-            )
+            self.logger.info("Performing a search of the full history (may take time)")
         try:
             params = self.search_source.search_parameters
             _search_return = self._get_semantic_scholar_api(params=params, rerun=rerun)

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Semantic Scholar"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -74,7 +75,9 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # Semantic Scholar as a search source
@@ -134,7 +137,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         elif subject == "author":
             _search_return = self.author_search(params=params, rerun=rerun)
         else:
-            self.review_manager.logger.info("No search parameters were found.")
+            self.logger.info("No search parameters were found.")
             raise NotImplementedError
 
         return _search_return
@@ -173,19 +176,19 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             SemanticScholarException.SemanticScholarException,
             SemanticScholarException.BadQueryParametersException,
         ) as exc:
-            self.review_manager.logger.error(
+            self.logger.error(
                 "Error: Something went wrong during the search with the Python Client."
                 + " This program will close."
             )
             print(exc)
             raise colrev_exceptions.ServiceNotAvailableException(exc)
 
-        self.review_manager.logger.info(
+        self.logger.info(
             str(record_return.total) + " records have been found.\n"
         )
 
         if record_return.total == 0:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Search aborted because no records were found. This program will close."
             )
             raise colrev_exceptions.ServiceNotAvailableException(
@@ -204,14 +207,14 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
                 SemanticScholarException.SemanticScholarException,
                 SemanticScholarException.BadQueryParametersException,
             ) as exc:
-                self.review_manager.logger.error(
+                self.logger.error(
                     "Error: Something went wrong during the search with the Python Client."
                     + " This program will close."
                 )
                 print(exc)
                 raise colrev_exceptions.ServiceNotAvailableException(exc)
         else:
-            self.review_manager.logger.error(
+            self.logger.error(
                 'Error: Search type "Search for paper" is not available with your parameters.\n'
                 + "Search parameter: "
                 + str(params.get("paper_ids"))
@@ -231,14 +234,14 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
                 SemanticScholarException.SemanticScholarException,
                 SemanticScholarException.BadQueryParametersException,
             ) as exc:
-                self.review_manager.logger.error(
+                self.logger.error(
                     "Error: Something went wrong during the search with the Python Client."
                     + " This program will close."
                 )
                 print(exc)
                 raise colrev_exceptions.ServiceNotAvailableException(exc)
         else:
-            self.review_manager.logger.error(
+            self.logger.error(
                 '\nError: Search type "Search for author" is not available with your parameters.\n'
                 + "Search parameter: "
                 + str(params.get("author_ids"))
@@ -288,7 +291,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         # rerun not implemented yet
         if rerun:
-            self.review_manager.logger.info(
+            self.logger.info(
                 "Performing a search of the full history (may take time)"
             )
         try:
@@ -296,14 +299,14 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             _search_return = self._get_semantic_scholar_api(params=params, rerun=rerun)
 
         except SemanticScholarException.BadQueryParametersException as exc:
-            self.review_manager.logger.error(
+            self.logger.error(
                 "Error: Invalid Search Parameters. The Program will close."
             )
             print(exc)
             raise colrev_exceptions.ServiceNotAvailableException(exc)
             # KeyError  # error in semanticscholar package:
         except (KeyError, PermissionError) as exc:
-            self.review_manager.logger.error(
+            self.logger.error(
                 "Error: Search could not be conducted. Please check your Parameters and API key."
             )
             print(exc)
@@ -318,7 +321,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev_exceptions.RecordNotParsableException,
             colrev_exceptions.NotFeedIdentifiableException,
         ) as exc:
-            self.review_manager.logger.error(
+            self.logger.error(
                 "Error: Retrieved records were not parsable into feed and result file."
             )
             print(exc)

--- a/colrev/packages/source_specific_prep/src/source_specific_prep.py
+++ b/colrev/packages/source_specific_prep/src/source_specific_prep.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Source-specific preparation as a prep operation"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -14,7 +15,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import EndpointType
 from colrev.constants import Fields
-import logging
 
 # pylint: disable=duplicate-code
 

--- a/colrev/packages/source_specific_prep/src/source_specific_prep.py
+++ b/colrev/packages/source_specific_prep/src/source_specific_prep.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Source-specific preparation as a prep operation"""
 from __future__ import annotations
+from typing import Optional
 
 from pathlib import Path
 
@@ -13,6 +14,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import EndpointType
 from colrev.constants import Fields
+import logging
 
 # pylint: disable=duplicate-code
 
@@ -34,7 +36,9 @@ class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
         *,
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = prep_operation.review_manager
 
@@ -73,7 +77,7 @@ class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
                 else:
                     print(f"error: {source.endpoint}")
             except colrev_exceptions.MissingDependencyError as exc:
-                self.review_manager.logger.warn(exc)
+                self.logger.warn(exc)
 
         if "howpublished" in record.data and Fields.URL not in record.data:
             if Fields.URL in record.data["howpublished"]:

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Springer Link"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -51,8 +52,10 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://link.springer.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.search_source = self.settings_class(**settings)
         self.quality_model = self.review_manager.get_qm()

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: Springer Link"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 import typing
 import urllib.parse
 from pathlib import Path
+from typing import Optional
 
 import inquirer
 import pandas as pd
@@ -52,7 +52,10 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://link.springer.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/structured/src/structured.py
+++ b/colrev/packages/structured/src/structured.py
@@ -1,12 +1,13 @@
 #! /usr/bin/env python
 """Structured data extraction as part of the data operations"""
 from __future__ import annotations
-from typing import Optional
 
 import csv
+import logging
 import typing
 from dataclasses import asdict
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from git.exc import GitCommandError
@@ -22,7 +23,6 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/structured/src/structured.py
+++ b/colrev/packages/structured/src/structured.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Structured data extraction as part of the data operations"""
 from __future__ import annotations
+from typing import Optional
 
 import csv
 import typing
@@ -21,6 +22,7 @@ import colrev.record.record
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 
 # pylint: disable=too-few-public-methods
@@ -72,7 +74,9 @@ class StructuredData(base_classes.DataPackageBaseClass):
         *,
         data_operation: colrev.ops.data.Data,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
 
         if "version" not in settings:
@@ -135,7 +139,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
         # Note : missing IDs are added through update_data
 
     def _set_fields(self) -> None:
-        self.review_manager.logger.info("Add fields for data extraction")
+        self.logger.info("Add fields for data extraction")
         try:
             _ = self.review_manager.dataset.get_repo()
         except GitCommandError:
@@ -199,7 +203,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
 
             if not silent_mode:
                 self.review_manager.report_logger.info("Update structured data")
-                self.review_manager.logger.info(
+                self.logger.info(
                     f"Update structured data ({self.settings.data_path_relative})"
                 )
 
@@ -215,7 +219,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
                     columns=data_df.columns, fill_value="TODO"
                 )
                 data_df = pd.concat([data_df, add_record], axis=0, ignore_index=True)
-                review_manager.logger.info(
+                self.logger.info(
                     f" {Colors.GREEN}{record_id}".ljust(45)
                     + f"add to structured_data{Colors.END}"
                 )
@@ -226,13 +230,13 @@ class StructuredData(base_classes.DataPackageBaseClass):
             data_df.to_csv(self.data_path, index=False, quoting=csv.QUOTE_ALL)
 
             if not (0 == nr_records_added and silent_mode):
-                review_manager.logger.info(
+                self.logger.info(
                     f"Added to {self.settings.data_path_relative}".ljust(24)
                     + f"{nr_records_added}".rjust(15, " ")
                     + " records"
                 )
 
-                review_manager.logger.info(
+                self.logger.info(
                     f"Added to {self.settings.data_path_relative}".ljust(24)
                     + f"{nr_records_added}".rjust(15, " ")
                     + " records"

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: SYNERGY-datasets"""
 from __future__ import annotations
-from typing import Optional
 
 import datetime
 import logging
 import tempfile
 import typing
 from pathlib import Path
+from typing import Optional
 
 import inquirer
 import pandas as pd
@@ -52,7 +52,10 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
@@ -174,9 +177,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
             input("ENTER to continue anyway")
         else:
-            self.logger.info(
-                f"Missing metadata: {missing_metadata_percentage:.2%}"
-            )
+            self.logger.info(f"Missing metadata: {missing_metadata_percentage:.2%}")
         return dataset_df
 
     def _update_decisions(self, *, decisions: dict, record: dict) -> None:
@@ -218,9 +219,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
             if len(v) > 1 and len(set(v)) != 1
         }
         if decisions[Fields.DOI] or decisions["pmid"] or decisions["openalex_id"]:
-            self.logger.error(
-                "Errors in dataset: ambiguous inclusion decisions:"
-            )
+            self.logger.error("Errors in dataset: ambiguous inclusion decisions:")
             msg = (
                 f"{Colors.RED}"
                 + f"- dois: {', '.join(decisions['doi'])}"

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: SYNERGY-datasets"""
 from __future__ import annotations
+from typing import Optional
 
 import datetime
 import logging
@@ -51,8 +52,10 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         self.search_source = self.settings_class(**settings)
         self.quality_model = self.review_manager.get_qm()
@@ -126,7 +129,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
                 params_dict[key] = value
 
         if len(params_dict) == 0:
-            operation.review_manager.logger.info("Retrieving available datasets")
+            self.logger.info("Retrieving available datasets")
             params_dict = cls.__select_datset_interactively()
 
         assert "dataset" in params_dict
@@ -166,12 +169,12 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         missing_metadata_percentage = missing_metadata.sum() / dataset_df.shape[0]
         if missing_metadata_percentage > 0.1:
-            self.review_manager.logger.error(
+            self.logger.error(
                 f"Missing metadata percentage: {missing_metadata_percentage}"
             )
             input("ENTER to continue anyway")
         else:
-            self.review_manager.logger.info(
+            self.logger.info(
                 f"Missing metadata: {missing_metadata_percentage:.2%}"
             )
         return dataset_df
@@ -215,7 +218,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
             if len(v) > 1 and len(set(v)) != 1
         }
         if decisions[Fields.DOI] or decisions["pmid"] or decisions["openalex_id"]:
-            self.review_manager.logger.error(
+            self.logger.error(
                 "Errors in dataset: ambiguous inclusion decisions:"
             )
             msg = (
@@ -253,7 +256,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     def _validate_source(self) -> None:
         source = self.search_source
-        self.review_manager.logger.debug(f"Validate SearchSource {source.filename}")
+        self.logger.debug(f"Validate SearchSource {source.filename}")
         assert source.search_type == SearchType.API
 
     def search(self, rerun: bool) -> None:
@@ -331,8 +334,8 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
             # The linking of doi/... should happen in the prep operation
 
         self._check_quality(decisions=decisions)
-        self.review_manager.logger.info(f"Dropped {empty_records} empty records")
-        self.review_manager.logger.info(f"Dropped {duplicates} duplicate records")
+        self.logger.info(f"Dropped {empty_records} empty records")
+        self.logger.info(f"Dropped {duplicates} duplicate records")
         self.review_manager.dataset.load_records_dict()
         synergy_feed.save()
 

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: Taylor and Francis"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -32,7 +32,10 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Taylor and Francis"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -31,8 +32,10 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
         self.source_operation = source_operation

--- a/colrev/packages/theoretical_review/src/theoretical_review.py
+++ b/colrev/packages/theoretical_review/src/theoretical_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Theoretical review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -23,7 +24,10 @@ class TheoreticalReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/theoretical_review/src/theoretical_review.py
+++ b/colrev/packages/theoretical_review/src/theoretical_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Theoretical review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -21,8 +23,10 @@ class TheoreticalReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Transport Research International Documentation"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -38,8 +39,10 @@ class TransportResearchInternationalDocumentation(
     db_url = "https://trid.trb.org/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.source_operation = source_operation
         self.review_manager = source_operation.review_manager

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: Transport Research International Documentation"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -39,7 +39,10 @@ class TransportResearchInternationalDocumentation(
     db_url = "https://trid.trb.org/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/umbrella/src/umbrella_review.py
+++ b/colrev/packages/umbrella/src/umbrella_review.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """Umbrella review"""
+from typing import Optional
 from pydantic import Field
 
 import colrev.ops.search
@@ -7,6 +8,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -21,8 +23,10 @@ class UmbrellaReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict
+        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:

--- a/colrev/packages/umbrella/src/umbrella_review.py
+++ b/colrev/packages/umbrella/src/umbrella_review.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Umbrella review"""
+import logging
 from typing import Optional
+
 from pydantic import Field
 
 import colrev.ops.search
@@ -8,7 +10,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import logging
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -23,7 +24,10 @@ class UmbrellaReview(base_classes.ReviewTypePackageBaseClass):
     ci_supported: bool = Field(default=True)
 
     def __init__(
-        self, *, operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: Unknown source (default for all other sources)"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from pydantic import Field
@@ -54,7 +54,10 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
     _padding = 40
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Unknown source (default for all other sources)"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import re
@@ -53,8 +54,10 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
     _padding = 40
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
         self.language_service = colrev.env.language_service.LanguageService()

--- a/colrev/packages/unpaywall/src/unpaywall.py
+++ b/colrev/packages/unpaywall/src/unpaywall.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Retrieval of PDFs from the unpaywall API"""
 from __future__ import annotations
-from typing import Optional
 
 import json
+import logging
 import os
 from pathlib import Path
+from typing import Optional
 
 import pymupdf
 import requests
@@ -17,7 +18,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.packages.unpaywall.src import utils
-import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/unpaywall/src/unpaywall.py
+++ b/colrev/packages/unpaywall/src/unpaywall.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Retrieval of PDFs from the unpaywall API"""
 from __future__ import annotations
+from typing import Optional
 
 import json
 import os
@@ -16,6 +17,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.packages.unpaywall.src import utils
+import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods
@@ -36,7 +38,9 @@ class Unpaywall(base_classes.PDFGetPackageBaseClass):
         *,
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_operation.review_manager
         self.pdf_get_operation = pdf_get_operation
@@ -132,7 +136,7 @@ class Unpaywall(base_classes.PDFGetPackageBaseClass):
                 if Fields.FULLTEXT not in record.data:
                     record.data[Fields.FULLTEXT] = url
                 if self.review_manager.verbose_mode:
-                    self.review_manager.logger.info(
+                    self.logger.info(
                         "Unpaywall retrieval error " f"{res.status_code} - {url}"
                     )
         except (

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 """SearchSource: Unpaywall"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 import typing
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Unpaywall"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 import typing
@@ -42,7 +43,9 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         *,
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
         if settings:
             # Unpaywall as a search_source

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Web of Science"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 from pathlib import Path
@@ -36,8 +37,10 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "http://webofscience.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.source_operation = source_operation
         self.review_manager = source_operation.review_manager

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """SearchSource: Web of Science"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -37,7 +37,10 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "http://webofscience.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)

--- a/colrev/packages/website_screenshot/src/website_screenshot.py
+++ b/colrev/packages/website_screenshot/src/website_screenshot.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Creation of screenshots (PDFs) for online ENTRYTYPES"""
 from __future__ import annotations
+from typing import Optional
 
 import time
 from datetime import datetime
@@ -19,6 +20,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
+import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods
@@ -36,7 +38,9 @@ class WebsiteScreenshot(base_classes.PDFGetPackageBaseClass):
         *,
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,
         settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_operation.review_manager
         self.pdf_get_operation = pdf_get_operation

--- a/colrev/packages/website_screenshot/src/website_screenshot.py
+++ b/colrev/packages/website_screenshot/src/website_screenshot.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 """Creation of screenshots (PDFs) for online ENTRYTYPES"""
 from __future__ import annotations
-from typing import Optional
 
+import logging
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 import docker
 import requests
@@ -20,7 +21,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import RecordState
-import logging
 
 # pylint: disable=duplicate-code
 # pylint: disable=too-few-public-methods

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Wiley"""
 from __future__ import annotations
+from typing import Optional
 
 import logging
 from pathlib import Path
@@ -33,8 +34,10 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://onlinelibrary.wiley.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict
+        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
         self.search_source = self.settings_class(**settings)
         self.source_operation = source_operation
         self.review_manager = source_operation.review_manager

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """SearchSource: Wiley"""
 from __future__ import annotations
-from typing import Optional
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 
@@ -34,7 +34,10 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     db_url = "https://onlinelibrary.wiley.com/"
 
     def __init__(
-        self, *, source_operation: colrev.process.operation.Operation, settings: dict,
+        self,
+        *,
+        source_operation: colrev.process.operation.Operation,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add an optional logger argument to each package class
- initialize a default logger using `logging.getLogger(__name__)` when none is provided
- replace `review_manager.logger` with `self.logger`
- import `Optional` and `logging` where needed

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'colrev')*

------
https://chatgpt.com/codex/tasks/task_e_688cf9c4bf88832aa68cb28df98b548a