### PR TITLE
refactor: centralize pretty printing utilities

### DIFF
--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -13,6 +13,7 @@ import yaml
 from git.exc import InvalidGitRepositoryError
 
 import colrev.exceptions as colrev_exceptions
+import colrev.utils
 from colrev.constants import ExitCodes
 from colrev.constants import Fields
 from colrev.constants import OperationsType
@@ -687,9 +688,7 @@ class Checker:
             ):
                 prior = self._retrieve_prior()
                 self.review_manager.logger.debug("prior")
-                self.review_manager.logger.debug(
-                    self.review_manager.p_printer.pformat(prior)
-                )
+                self.review_manager.logger.debug(colrev.utils.pformat(prior))
             else:  # if RECORDS_FILE not yet in git history
                 prior = {}
 

--- a/colrev/ops/distribute.py
+++ b/colrev/ops/distribute.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import colrev.env.tei_parser
 import colrev.process.operation
 import colrev.settings
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import SearchType
@@ -91,7 +92,7 @@ class Distribute(colrev.process.operation.Operation):
                 shutil.copyfile(path, target_pdf_path)
 
                 self.review_manager.logger.info(
-                    f"append {self.review_manager.p_printer.pformat(record)} "
+                    f"append {colrev.utils.pformat(record)} "
                     "to data/search/local_import.bib"
                 )
                 target_bib_file = target / Path("data/search/local_import.bib")

--- a/colrev/ops/merge.py
+++ b/colrev/ops/merge.py
@@ -8,6 +8,7 @@ from dictdiffer import diff
 from git.exc import GitCommandError
 
 import colrev.process.operation
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import OperationsType
@@ -73,7 +74,7 @@ class Merge(colrev.process.operation.Operation):
             del comparison_other_record[Fields.STATUS]
 
             if comparison_current_record != comparison_other_record:
-                comparison_diff = self.review_manager.p_printer.pformat(
+                comparison_diff = colrev.utils.pformat(
                     list(diff(comparison_current_record, comparison_other_record))
                 )
                 changed_records.append(f"{current_record_id}: " f"{comparison_diff}")
@@ -242,7 +243,7 @@ class Merge(colrev.process.operation.Operation):
             records_reconciled=current_branch_records,
         )
         print("Statistics:")
-        self.review_manager.p_printer.pprint(validation_details["statistics"])
+        colrev.utils.pprint(validation_details["statistics"])
 
         print(
             f"\n{Colors.ORANGE}Please add (git add .) and commit (git commit){Colors.END}"

--- a/colrev/ops/pdf_get_man.py
+++ b/colrev/ops/pdf_get_man.py
@@ -11,6 +11,7 @@ import pandas as pd
 import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.record.record
+import colrev.utils
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
@@ -116,9 +117,7 @@ class PDFGetMan(colrev.process.operation.Operation):
             conditions=[{Fields.STATUS: RecordState.pdf_needs_manual_retrieval}]
         )
         pdf_get_man_data = {"nr_tasks": nr_tasks, "PAD": pad, "items": items}
-        self.review_manager.logger.debug(
-            self.review_manager.p_printer.pformat(pdf_get_man_data)
-        )
+        self.review_manager.logger.debug(colrev.utils.pformat(pdf_get_man_data))
         return pdf_get_man_data
 
     def pdfs_retrieved_manually(self) -> bool:

--- a/colrev/ops/pdf_prep_man.py
+++ b/colrev/ops/pdf_prep_man.py
@@ -11,6 +11,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.record.record
 import colrev.record.record_pdf
+import colrev.utils
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import Filepaths
@@ -74,9 +75,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
             conditions=[{Fields.STATUS: RecordState.pdf_needs_manual_preparation}]
         )
         pdf_prep_man_data = {"nr_tasks": nr_tasks, "PAD": pad, "items": items}
-        self.review_manager.logger.debug(
-            self.review_manager.p_printer.pformat(pdf_prep_man_data)
-        )
+        self.review_manager.logger.debug(colrev.utils.pformat(pdf_prep_man_data))
         return pdf_prep_man_data
 
     def pdfs_prepared_manually(self) -> bool:

--- a/colrev/ops/prep_debug.py
+++ b/colrev/ops/prep_debug.py
@@ -13,6 +13,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.ops.prep
 import colrev.process.operation
 import colrev.record.record_prep
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import Fields
 
@@ -62,7 +63,7 @@ class PrepDebug(colrev.ops.prep.Prep):
         if diffs:
             change_report = (
                 f"{prep_package_endpoint} changed:\n"
-                f"{Colors.ORANGE}{self.review_manager.p_printer.pformat(diffs)}{Colors.END}\n"
+                f"{Colors.ORANGE}{colrev.utils.pformat(diffs)}{Colors.END}\n"
             )
 
             self.review_manager.logger.info(change_report)
@@ -154,7 +155,7 @@ class PrepDebug(colrev.ops.prep.Prep):
                 for item in preparation_data:
                     record = self.prepare(item)
                     self.review_manager.logger.info(
-                        f"Result:\n" f"{self.review_manager.p_printer.pformat(record)}"
+                        f"Result:\n" f"{colrev.utils.pformat(record)}"
                     )
         except requests_ConnectionError as exc:
             if "OSError(24, 'Too many open files" in str(exc):

--- a/colrev/ops/prep_man.py
+++ b/colrev/ops/prep_man.py
@@ -12,6 +12,7 @@ import colrev.env.language_service
 import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.record.record_prep
+import colrev.utils
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
@@ -92,10 +93,10 @@ class PrepMan(colrev.process.operation.Operation):
             )
 
         print("Entry type statistics overall:")
-        self.review_manager.p_printer.pprint(overall_types[Fields.ENTRYTYPE])
+        colrev.utils.pprint(overall_types[Fields.ENTRYTYPE])
 
         print("Entry type statistics (needs_manual_preparation):")
-        self.review_manager.p_printer.pprint(stats[Fields.ENTRYTYPE])
+        colrev.utils.pprint(stats[Fields.ENTRYTYPE])
 
         return pd.DataFrame(crosstab, columns=[Fields.ORIGIN, "hint"])
 
@@ -241,9 +242,7 @@ class PrepMan(colrev.process.operation.Operation):
             "all_ids": all_ids,
             "PAD": pad,
         }
-        self.review_manager.logger.debug(
-            self.review_manager.p_printer.pformat(md_prep_man_data)
-        )
+        self.review_manager.logger.debug(colrev.utils.pformat(md_prep_man_data))
         return md_prep_man_data
 
     def set_data(self, *, record_dict: dict) -> None:

--- a/colrev/ops/push.py
+++ b/colrev/ops/push.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import colrev.process.operation
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
@@ -134,7 +135,7 @@ class Push(colrev.process.operation.Operation):
                 }
             )
 
-        corrections = self.review_manager.p_printer.pformat(prepared_change_list)
+        corrections = colrev.utils.pformat(prepared_change_list)
 
         text = (
             "Dear Sir or Madam,\n\nwe have noticed potential corrections and "

--- a/colrev/ops/search_api_feed.py
+++ b/colrev/ops/search_api_feed.py
@@ -12,6 +12,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.loader.load_utils
 import colrev.loader.load_utils_formatter
 import colrev.record.record_merger
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import DefectCodes
 from colrev.constants import ENTRYTYPES
@@ -385,9 +386,7 @@ class SearchAPIFeed:
                     f"({similarity_score}) in {main_record.data['ID']}:{Colors.END}"
                 )
                 self.review_manager.logger.info(
-                    self.review_manager.p_printer.pformat(
-                        [x for x in dict_diff if "change" == x[0]]
-                    )
+                    colrev.utils.pformat([x for x in dict_diff if "change" == x[0]])
                 )
             return True
         return False

--- a/colrev/ops/trace.py
+++ b/colrev/ops/trace.py
@@ -8,6 +8,7 @@ import typing
 import dictdiffer
 
 import colrev.process.operation
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import OperationsType
 
@@ -27,7 +28,7 @@ class Trace(colrev.process.operation.Operation):
         )
 
     def _print_diff(self, *, diff: dict, color: str, lpad: int = 5) -> None:
-        formatted_diff = self.review_manager.p_printer.pformat(diff)
+        formatted_diff = colrev.utils.pformat(diff)
         lines = formatted_diff.splitlines()
         print(
             color

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -21,6 +21,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import FieldSet
@@ -558,7 +559,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
                         + f": {Colors.GREEN}{values[0][1]}{Colors.END}"
                     )
                 else:
-                    self.review_manager.p_printer.pprint(change_item)
+                    colrev.utils.pprint(change_item)
             selected_changes.append(item)
         return selected_changes
 

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 import os
-import pprint
 import typing
 from datetime import timedelta
 from pathlib import Path
@@ -97,7 +96,6 @@ class ReviewManager:
 
             self.environment_manager = self.get_environment_manager()
 
-            self.p_printer = pprint.PrettyPrinter(indent=4, width=140, compact=False)
             # run update before settings/data (which may require changes/fail without update)
             if not skip_upgrade:  # pragma: no cover
                 self._check_update()

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -27,6 +27,7 @@ import colrev.ui_cli.add_package_to_settings
 import colrev.ui_cli.cli_status_printer
 import colrev.ui_cli.cli_validation
 import colrev.ui_cli.dedupe_errors
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
@@ -561,7 +562,7 @@ def search(
 
     if view:
         for source in search_operation.sources:
-            search_operation.review_manager.p_printer.pprint(source)
+            colrev.utils.pprint(source)
         return
 
     if add:
@@ -2058,12 +2059,12 @@ def data(
             data_operation.review_manager.settings.data.data_package_endpoints
         )
         for data_endpoint in data_endpoints:
-            data_operation.review_manager.p_printer.pprint(data_endpoint)
+            colrev.utils.pprint(data_endpoint)
         return
 
     if reading_heuristics:
         heuristic_results = data_operation.reading_heuristics()
-        review_manager.p_printer.pprint(heuristic_results)
+        colrev.utils.pprint(heuristic_results)
         return
     if setup_custom_script:
         data_operation.setup_custom_script()

--- a/colrev/utils.py
+++ b/colrev/utils.py
@@ -1,0 +1,18 @@
+#! /usr/bin/env python3
+"""Utility helpers for CoLRev."""
+from __future__ import annotations
+
+import pprint
+import typing
+
+_p_printer = pprint.PrettyPrinter(indent=4, width=140, compact=False)
+
+
+def pformat(obj: typing.Any) -> str:
+    """Return a pretty-formatted representation of ``obj``."""
+    return _p_printer.pformat(obj)
+
+
+def pprint(obj: typing.Any) -> None:
+    """Pretty-print ``obj`` using repository defaults."""
+    _p_printer.pprint(obj)


### PR DESCRIPTION
## Summary
- centralize PrettyPrinter usage in new `utils` module
- remove `p_printer` from `ReviewManager` and update callers

## Testing
- `pre-commit run --files colrev/utils.py colrev/review_manager.py colrev/ui_cli/cli.py colrev/ops/pdf_get_man.py colrev/ops/prep_man.py colrev/ops/search_api_feed.py colrev/ops/checker.py colrev/ops/prep_debug.py colrev/ops/merge.py colrev/ops/push.py colrev/ops/trace.py colrev/ops/distribute.py colrev/ops/pdf_prep_man.py colrev/packages/local_index/src/local_index.py` *(fails: unable to access 'https://github.com/pre-commit/pre-commit-hooks/' - CONNECT tunnel failed: 403)*
- `PYTHONPATH=$PWD pytest tests/0_core/test_review_manager.py::TestReviewManager -q` *(fails: PackageNotFoundError: No package metadata was found for colrev)*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688db4740fbc832abe2f885afd01bc84