### PR TITLE
refactor: use lazy logging and fix lint warnings

### DIFF
--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -221,7 +221,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 # if "search_terms" not in source.search_parameters["query"]:
                 raise colrev_exceptions.InvalidQueryException("query parameter missing")
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def _get_ais_query_return(self) -> list:
         def query_from_params(params: dict) -> str:

--- a/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
@@ -307,9 +307,8 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
                 )
         else:
             self.logger.info(
-                "Retrieve PDFs manually and copy the files to "
-                f"the {pdf_dir}. Afterwards, use "
-                "colrev pdf-get-man"
+                "Retrieve PDFs manually and copy the files to the %s. Afterwards, use colrev pdf-get-man",
+                pdf_dir,
             )
 
         return records

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -69,7 +69,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
                 "url field required in search_parameters"
             )
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     # pylint: disable=colrev-missed-constant-usage
     @classmethod

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -343,7 +343,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         if source.search_type == SearchType.API:
             self._validate_api_params()
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def _restore_url(
         self,
@@ -429,14 +429,15 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.logger.info(f"Total: {nrecs:,} records")
         if not rerun:
             self.logger.info(
-                f"Retrieve papers indexed since {self.api.last_updated.split('T', maxsplit=1)[0]}"
+                "Retrieve papers indexed since %s",
+                self.api.last_updated.split("T", maxsplit=1)[0],
             )
             nrecs = self.api.get_number_of_records()
 
-        self.logger.info(f"Retrieve {nrecs:,} records")
+        self.logger.info("Retrieve %s records", f"{nrecs:,}")
         estimated_time = nrecs * 0.5
         estimated_time_formatted = str(datetime.timedelta(seconds=int(estimated_time)))
-        self.logger.info(f"Estimated time: {estimated_time_formatted}")
+        self.logger.info("Estimated time: %s", estimated_time_formatted)
 
         try:
             for retrieved_record in self.api.get_records():

--- a/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
+++ b/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
@@ -192,14 +192,16 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
                         )
                         self.review_manager.save_settings()
                         self.logger.info(
-                            f"{Colors.GREEN}Added {source_missing_in_dedupe} "
-                            f"to dedupe.scripts{Colors.END}"
+                            "%sAdded %s to dedupe.scripts%s",
+                            Colors.GREEN,
+                            source_missing_in_dedupe,
+                            Colors.END,
                         )
 
     def _add_first_source_if_deduplicated(self, *, records: dict) -> None:
         self.logger.info(
-            f"Starting with records from {self.settings.selected_source}"
-            " (setting to md_processed as the initial records)"
+            "Starting with records from %s (setting to md_processed as the initial records)",
+            self.settings.selected_source,
         )
 
         source_records = [
@@ -286,7 +288,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
                 ),
             )
         else:
-            self.logger.info(f"{Colors.GREEN}No duplicates found{Colors.END}")
+            self.logger.info("%sNo duplicates found%s", Colors.GREEN, Colors.END)
 
     def _prep_records(self, *, records: dict) -> dict:
         required_fields = [
@@ -554,11 +556,13 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         # thereby discards previous changes
         if len(decision_list) == 0:
             self.logger.info(
-                f"{Colors.GREEN}No merge-candidates identified between sets{Colors.END}"
+                "%sNo merge-candidates identified between sets%s",
+                Colors.GREEN,
+                Colors.END,
             )
             return
 
-        self.logger.info(f"{Colors.GREEN}Duplicates identified{Colors.END}")
+        self.logger.info("%sDuplicates identified%s", Colors.GREEN, Colors.END)
 
         preferred_masterdata_sources = [
             s

--- a/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
+++ b/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
@@ -74,13 +74,19 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
             records_df = pd.DataFrame.from_records(list(selected_records))
             if records_df.shape[0] == 0:
                 self.logger.info(
-                    f"{Colors.GREEN}Source {source_origin} fully merged{Colors.END}"
+                    "%sSource %s fully merged%s",
+                    Colors.GREEN,
+                    source_origin,
+                    Colors.END,
                 )
             else:
                 self.logger.info(
-                    f"{Colors.ORANGE}Source {source_origin} not fully merged{Colors.END}"
+                    "%sSource %s not fully merged%s",
+                    Colors.ORANGE,
+                    source_origin,
+                    Colors.END,
                 )
-                self.logger.info(f"Exporting details to dedupe/{source_origin}.xlsx")
+                self.logger.info("Exporting details to dedupe/%s.xlsx", source_origin)
 
                 records_df = records_df[
                     records_df.columns.intersection(

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -260,7 +260,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                 + str(int(seconds % 60)).zfill(2)
             )
 
-            self.logger.info(f"Estimated runtime [hh:mm:ss]: {formatted_time}")
+            self.logger.info("Estimated runtime [hh:mm:ss]: %s", formatted_time)
 
         while True:
             api.set_next_url()
@@ -318,7 +318,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                 "scope or query required in search_parameters"
             )
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def search(self, rerun: bool) -> None:
         """Run a search of DBLP"""

--- a/colrev/packages/download_from_website/src/download_from_website.py
+++ b/colrev/packages/download_from_website/src/download_from_website.py
@@ -71,11 +71,12 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                         with open(pdf_filepath, "wb") as pdf_file:
                             pdf_file.write(pdf_response.content)
                         self.logger.debug(
-                            f"PDF downloaded successfully as {pdf_filepath}"
+                            "PDF downloaded successfully as %s", pdf_filepath
                         )
                     else:
                         self.logger.debug(
-                            f"Failed to download PDF. Status code: {pdf_response.status_code}"
+                            "Failed to download PDF. Status code: %s",
+                            pdf_response.status_code,
                         )
                 else:
                     self.logger.debug("Paper title not found on the page.")
@@ -83,7 +84,8 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                 self.logger.debug("PDF link not found on the page.")
         else:
             self.logger.debug(
-                f"Failed to retrieve the article page. Status code: {response.status_code}"
+                "Failed to retrieve the article page. Status code: %s",
+                response.status_code,
             )
 
     def _download_from_bmj_open_science(
@@ -111,11 +113,12 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                             pdf_file.write(pdf_response.content)
 
                         self.logger.debug(
-                            f"PDF downloaded successfully as {pdf_filepath}"
+                            "PDF downloaded successfully as %s", pdf_filepath
                         )
                     else:
                         self.logger.debug(
-                            f"Failed to download PDF. Status code: {pdf_response.status_code}"
+                            "Failed to download PDF. Status code: %s",
+                            pdf_response.status_code,
                         )
                 else:
                     self.logger.debug("PDF URL not found on the page.")
@@ -123,7 +126,8 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                 self.logger.debug("PDF link not found on the page.")
         else:
             self.logger.debug(
-                f"Failed to retrieve the article page. Status code: {response.status_code}"
+                "Failed to retrieve the article page. Status code: %s",
+                response.status_code,
             )
 
     def _download_unknown(
@@ -155,11 +159,12 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                             pdf_file.write(pdf_response.content)
 
                         self.logger.debug(
-                            f"PDF downloaded successfully as {pdf_filepath}"
+                            "PDF downloaded successfully as %s", pdf_filepath
                         )
                     else:
                         self.logger.debug(
-                            f"Failed to download PDF. Status code: {pdf_response.status_code}"
+                            "Failed to download PDF. Status code: %s",
+                            pdf_response.status_code,
                         )
                 else:
                     self.logger.debug("PDF URL not found on the page.")
@@ -167,7 +172,8 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
                 self.logger.debug("PDF link not found on the page.")
         else:
             self.logger.debug(
-                f"Failed to retrieve the Minerva Medica page. Status code: {response.status_code}"
+                "Failed to retrieve the Minerva Medica page. Status code: %s",
+                response.status_code,
             )
 
     def get_pdf(

--- a/colrev/packages/enlit/src/enlit.py
+++ b/colrev/packages/enlit/src/enlit.py
@@ -49,18 +49,22 @@ def _extract_references_from_records(
             elif len(refs) < 10:
                 col = Colors.ORANGE
             review_manager.logger.info(
-                f" extracted {col}{str(len(refs)).rjust(4)}{Colors.END} references from {record[Fields.FILE]}"
+                " extracted %s%s%s references from %s",
+                col,
+                str(len(refs)).rjust(4),
+                Colors.END,
+                record[Fields.FILE],
             )
         except FileNotFoundError:
             review_manager.logger.warning(
-                f"Could not find TEI file for {record[Fields.FILE]}: "
-                "Please check the TEI file or the PDF."
+                "Could not find TEI file for %s: Please check the TEI file or the PDF.",
+                record[Fields.FILE],
             )
             continue
         except colrev_exceptions.TEIException:
             review_manager.logger.warning(
-                f"Could not extract references from {record[Fields.FILE]}: "
-                "Please check the TEI file or the PDF."
+                "Could not extract references from %s: Please check the TEI file or the PDF.",
+                record[Fields.FILE],
             )
             continue
 
@@ -86,7 +90,8 @@ def _load_included_records(review_manager: ReviewManager) -> pd.DataFrame:
     }
 
     review_manager.logger.info(
-        f"Loaded {len(records)} records (rev_included or rev_synthesized)."
+        "Loaded %s records (rev_included or rev_synthesized).",
+        len(records),
     )
     return records
 
@@ -114,7 +119,7 @@ def main() -> None:
 
     def sum_nr_references(values: list) -> int:
         """Sum all integers in a list."""
-        return sum([int(value) for value in values if value != ""])
+        return sum(int(value) for value in values if value != "")
 
     records_df = prep(df_all_references, verbosity_level=0)
     deduplication_pairs = block(records_df, verbosity_level=0)
@@ -155,7 +160,10 @@ def main() -> None:
 
     pre_duplication_size = df_all_references.shape[0]
     review_manager.logger.info(
-        f"Citation network: {Colors.GREEN}{pre_duplication_size} references{Colors.END}"
+        "Citation network: %s%s references%s",
+        Colors.GREEN,
+        pre_duplication_size,
+        Colors.END,
     )
     review_manager.logger.info("Start deduplication...")
 
@@ -194,8 +202,13 @@ def main() -> None:
     after_duplication_size = df_all_references.shape[0]
     nr_duplicates = pre_duplication_size - after_duplication_size
     review_manager.logger.info(
-        f"Remove {Colors.RED}{str(nr_duplicates).rjust(6)} duplicates{Colors.END}:"
-        f"    {Colors.GREEN}{str(after_duplication_size).rjust(6)} references{Colors.END}"
+        "Remove %s%s duplicates%s:    %s%s references%s",
+        Colors.RED,
+        str(nr_duplicates).rjust(6),
+        Colors.END,
+        Colors.GREEN,
+        str(after_duplication_size).rjust(6),
+        Colors.END,
     )
 
     # Filter to keep only rows where nr_references > 0
@@ -203,17 +216,26 @@ def main() -> None:
     nr_cited = df_all_references.shape[0]
     non_cited_references = after_duplication_size - nr_cited
     review_manager.logger.info(
-        f"Remove {Colors.RED}{str(non_cited_references).rjust(6)} non-cited{Colors.END}:"
-        f"     {Colors.GREEN}{str(nr_cited).rjust(6)} references{Colors.END}"
+        "Remove %s%s non-cited%s:     %s%s references%s",
+        Colors.RED,
+        str(non_cited_references).rjust(6),
+        Colors.END,
+        Colors.GREEN,
+        str(nr_cited).rjust(6),
+        Colors.END,
     )
 
     df_all_references = df_all_references[df_all_references["in_sample"]]
     nr_in_sample = df_all_references.shape[0]
     out_of_sample_difference = nr_cited - nr_in_sample
     review_manager.logger.info(
-        f"Remove {Colors.RED}{str(out_of_sample_difference).rjust(6)} "
-        f"out-of-sample{Colors.END}: {Colors.GREEN}{str(nr_in_sample).rjust(6)} "
-        f"references{Colors.END}"
+        "Remove %s%s out-of-sample%s: %s%s references%s",
+        Colors.RED,
+        str(out_of_sample_difference).rjust(6),
+        Colors.END,
+        Colors.GREEN,
+        str(nr_in_sample).rjust(6),
+        Colors.END,
     )
 
     # df_all_references.to_csv("export_2.csv", index=False, encoding="utf-8-sig")
@@ -243,6 +265,8 @@ def main() -> None:
 
     # save to csv
     review_manager.logger.info(
-        f"Saving list to {Colors.GREEN}enlit_references.csv{Colors.END}"
+        "Saving list to %senlit_references.csv%s",
+        Colors.GREEN,
+        Colors.END,
     )
     df_all_references.to_csv("enlit_references.csv", index=False, encoding="utf-8-sig")

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -274,7 +274,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                 "Query required in search_parameters"
             )
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def search(self, rerun: bool) -> None:
         """Run a search of Europe PMC"""

--- a/colrev/packages/export_man_prep/src/prep_man_export.py
+++ b/colrev/packages/export_man_prep/src/prep_man_export.py
@@ -264,9 +264,10 @@ class ExportManPrep(base_classes.PrepManPackageBaseClass):
                 if v["note"] != ""
             )
             self.logger.info(
-                f" {Colors.ORANGE}{original_record.data['ID']}".ljust(46)
-                + f"{man_prep_note}"
-                + f"{Colors.END}"
+                " %s%s%s",
+                f"{Colors.ORANGE}{original_record.data['ID']}".ljust(46),
+                man_prep_note,
+                Colors.END,
             )
 
     def _import_record(

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -407,7 +407,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             raise colrev_exceptions.InvalidQueryException(
                 "path required in search_parameters/scope"
             )
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def _add_md_string(self, *, record_dict: dict) -> dict:
         # To identify potential duplicates
@@ -541,7 +541,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
                 return new_record
         # otherwise: reindex all
 
-        self.logger.info(f" extract metadata from {file_path}")
+        self.logger.info(" extract metadata from %s", file_path)
         try:
             if not self.review_manager.settings.is_curated_masterdata_repo():
                 # retrieve_based_on_colrev_pdf_id
@@ -558,7 +558,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             else:
                 new_record = self._get_grobid_metadata(file_path=file_path)
         except FileNotFoundError:
-            self.logger.error(f"File not found: {file_path} (skipping)")
+            self.logger.error("File not found: %s (skipping)", file_path)
             return {}
         except (
             colrev_exceptions.PDFHashError,
@@ -581,9 +581,11 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         ]
         if potential_duplicates:
             self.logger.warning(
-                f" {Colors.RED}skip record (PDF potential duplicate): "
-                f"{new_record['file']} {Colors.END} "
-                f"({','.join([r['file'] for r in potential_duplicates])})"
+                " %sskip record (PDF potential duplicate): %s %s (%s)",
+                Colors.RED,
+                new_record["file"],
+                Colors.END,
+                ",".join([r["file"] for r in potential_duplicates]),
             )
 
         return new_record

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -209,7 +209,9 @@ class GithubPages(base_classes.DataPackageBaseClass):
             )
             if not silent_mode:
                 self.logger.info(
-                    f"Data available at: https://{username}.github.io/{project}/"
+                    "Data available at: https://%s.github.io/%s/",
+                    username,
+                    project,
                 )
         else:
             if not silent_mode:

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -133,7 +133,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
             #         f"Source missing query/query search_parameter ({source.filename})"
             #     )
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def _retrieve_from_index(self) -> typing.List[dict]:
         params = self.search_source.search_parameters

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -86,7 +86,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
                 "search_parameters/scope/colrev_status must be rev_included|rev_synthesized"
             )
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def _fw_search_condition(self, *, record: dict) -> bool:
         if Fields.DOI not in record:

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -164,7 +164,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             with open(template_name, "wb") as file:
                 file.write(filedata)
         else:
-            self.logger.error(f"Could not retrieve {template_name} from the package")
+            self.logger.error("Could not retrieve %s from the package", template_name)
             return False
         self.review_manager.dataset.add_changes(template_name)
         return True
@@ -253,15 +253,9 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         writer.write(marker)
         for missing_record in missing_records:
             writer.write(missing_record)
-            self.review_manager.report_logger.info(
-                # f" {missing_record}".ljust(self._PAD, " ") + " added"
-                f" {missing_record} added"
-            )
+            self.review_manager.report_logger.info(" %s added", missing_record)
             if not silent_mode:
-                self.logger.info(
-                    # f" {missing_record}".ljust(self._PAD, " ") + " added"
-                    f" {missing_record} added"
-                )
+                self.logger.info(" %s added", missing_record)
 
     # pylint: disable=too-many-arguments
     def _update_new_records_source_section(
@@ -288,27 +282,30 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
 
         for paper_id in paper_ids_added:
             self.review_manager.report_logger.info(
-                # f" {missing_record}".ljust(self._PAD, " ")
-                f" {paper_id}"
-                + f" added to {paper_path.name}"
+                " %s added to %s",
+                paper_id,
+                paper_path.name,
             )
         nr_records_added = len(missing_records)
         self.review_manager.report_logger.info(
-            f"{nr_records_added} records added to {self.settings.paper_path.name}"
+            "%s records added to %s",
+            nr_records_added,
+            self.settings.paper_path.name,
         )
 
         for paper_id_added in paper_ids_added:
             if not silent_mode:
                 self.logger.info(
-                    f" {Colors.GREEN}{paper_id_added}".ljust(45)
-                    + f"add to paper{Colors.END}"
+                    " %sadd to paper%s",
+                    f"{Colors.GREEN}{paper_id_added}".ljust(45),
+                    Colors.END,
                 )
 
         if not silent_mode:
             self.logger.info(
-                f"Added to {paper_path.name}".ljust(24)
-                + f"{nr_records_added}".rjust(15, " ")
-                + " records"
+                "%s%s records",
+                f"Added to {paper_path.name}".ljust(24),
+                f"{nr_records_added}".rjust(15, " "),
             )
 
         # skip empty lines between to connect lists
@@ -481,10 +478,10 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                         screening_criteria="NA",
                     )
 
-                    self.logger.info(f"Excluded {record_id}")
-                    self.review_manager.report_logger.info(f"Excluded {record_id}")
+                    self.logger.info("Excluded %s", record_id)
+                    self.review_manager.report_logger.info("Excluded %s", record_id)
                 else:
-                    self.logger.error(f"Did not find ID {record_id}")
+                    self.logger.error("Did not find ID %s", record_id)
                     writer.write(line)
                     line = reader.readline()
                     continue
@@ -516,7 +513,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         else:
             if not silent_mode:
                 self.review_manager.report_logger.info("Update paper")
-                self.logger.info(f"Update paper ({self.settings.paper_path.name})")
+                self.logger.info("Update paper (%s)", self.settings.paper_path.name)
             self._add_missing_records_to_paper(
                 missing_records=missing_records,
                 silent_mode=silent_mode,
@@ -726,7 +723,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         word_template = self.settings.word_template
 
         if not self._retrieve_default_word_template(word_template):
-            self.logger.error(f"Word template {word_template} not found")
+            self.logger.error("Word template %s not found", word_template)
             return
 
         output_relative_path = self.settings.paper_output.relative_to(

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -105,7 +105,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
                     "search_parameters/scope/colrev_status must be rev_included|rev_synthesized"
                 )
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def _bw_search_condition(self, *, record: dict) -> bool:
         # rev_included/rev_synthesized required, but record not in rev_included/rev_synthesized
@@ -379,11 +379,11 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         min_intext_citations = self.search_source.search_parameters[
             "min_intext_citations"
         ]
-        self.logger.info(f"Set min_intext_citations={min_intext_citations}")
+        self.logger.info("Set min_intext_citations=%s", min_intext_citations)
         nr_references_threshold = self.search_source.search_parameters.get(
             "min_ref_freq", 1
         )
-        self.logger.info(f"Set nr_references_threshold={nr_references_threshold}")
+        self.logger.info("Set nr_references_threshold=%s", nr_references_threshold)
 
         selected_records = {
             rid: record

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -227,20 +227,21 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.api.last_updated = plos_feed.get_last_updated()
 
         num_records = self.api.get_len_total()
-        self.logger.info(f"Total: {num_records:,} records")
+        self.logger.info("Total: %s records", f"{num_records:,}")
 
         # It retrieves only new records added since the last sync, avoiding a full download.
         if not rerun:
             self.logger.info(
-                f"Retrieve papers indexed since {self.api.last_updated.split('T', maxsplit=1)[0]}"
+                "Retrieve papers indexed since %s",
+                self.api.last_updated.split("T", maxsplit=1)[0],
             )
             num_records = self.api.get_len()
 
-        self.logger.info(f"Retrieve {num_records:,} records")
+        self.logger.info("Retrieve %s records", f"{num_records:,}")
 
         estimated_time = num_records * 0.5
         estimated_time_formatted = str(datetime.timedelta(seconds=int(estimated_time)))
-        self.logger.info(f"Estimated time: {estimated_time_formatted}")
+        self.logger.info("Estimated time: %s", estimated_time_formatted)
 
         try:
             for record in self.api.get_records():

--- a/colrev/packages/prescreen_table/src/prescreen_table.py
+++ b/colrev/packages/prescreen_table/src/prescreen_table.py
@@ -115,12 +115,15 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
             self.logger.info("Created prescreen.xlsx")
 
         self.logger.info(
-            f"To prescreen records, {Colors.ORANGE}enter [in|out] "
-            f"in the presceen_inclusion column.{Colors.END}"
+            "To prescreen records, %senter [in|out] in the presceen_inclusion column.%s",
+            Colors.ORANGE,
+            Colors.END,
         )
         self.logger.info(
-            f"Afterwards, run {Colors.ORANGE}colrev prescreen --import_table "
-            f"prescreen.{export_table_format.lower()}{Colors.END}"
+            "Afterwards, run %scolrev prescreen --import_table prescreen.%s%s",
+            Colors.ORANGE,
+            export_table_format.lower(),
+            Colors.END,
         )
 
     def import_table(
@@ -133,11 +136,11 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
 
         # pylint: disable=too-many-branches
 
-        self.logger.info(f"Load {import_table_path}")
+        self.logger.info("Load %s", import_table_path)
 
         # pylint: disable=duplicate-code
         if not Path(import_table_path).is_file():
-            self.logger.error(f"Did not find {import_table_path} - exiting.")
+            self.logger.error("Did not find %s - exiting.", import_table_path)
             return
 
         if import_table_path.endswith(".csv"):
@@ -185,24 +188,36 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
                     nr_todo += 1
                 else:
                     self.logger.warning(
-                        "Invalid value in prescreen_inclusion: "
-                        f"{prescreened_record.get('presceen_inclusion', '')} "
-                        f"({prescreened_record.get('ID', 'NO_ID')})"
+                        "Invalid value in prescreen_inclusion: %s (%s)",
+                        prescreened_record.get("presceen_inclusion", ""),
+                        prescreened_record.get("ID", "NO_ID"),
                     )
 
             else:
                 self.logger.warning(
-                    f"ID not in records: {prescreened_record.get('ID', '')}"
+                    "ID not in records: %s",
+                    prescreened_record.get("ID", ""),
                 )
 
         self.logger.info(
-            f" {Colors.GREEN}{prescreen_included} records prescreen_included{Colors.END}"
+            " %s%d records prescreen_included%s",
+            Colors.GREEN,
+            prescreen_included,
+            Colors.END,
         )
         self.logger.info(
-            f" {Colors.RED}{prescreen_excluded} records prescreen_excluded{Colors.END}"
+            " %s%d records prescreen_excluded%s",
+            Colors.RED,
+            prescreen_excluded,
+            Colors.END,
         )
 
-        self.logger.info(f" {Colors.ORANGE}{nr_todo} records to prescreen{Colors.END}")
+        self.logger.info(
+            " %s%d records to prescreen%s",
+            Colors.ORANGE,
+            nr_todo,
+            Colors.END,
+        )
 
         self.review_manager.dataset.save_records_dict(records)
         self.logger.info("Completed import")

--- a/colrev/packages/profile/src/profile.py
+++ b/colrev/packages/profile/src/profile.py
@@ -179,7 +179,7 @@ class Profile(base_classes.DataPackageBaseClass):
         self.logger.info("Generate output/ENTRYTYPES.csv")
         tabulated.to_csv(output_dir / Path("ENTRYTYPES.csv"))
 
-        self.logger.info(f"Files are available in {output_dir.name}")
+        self.logger.info("Files are available in %s", output_dir.name)
 
     def update_data(
         self,

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -152,7 +152,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         for record_dict in prospero_api.get_next_record():
-            self.logger.info(f"retrieve record: {record_dict[Fields.URL]}")
+            self.logger.info("retrieve record: %s", record_dict[Fields.URL])
 
             try:
                 if not record_dict.get(Fields.AUTHOR, "") and not record_dict.get(

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -185,7 +185,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
             # if "query_file" in source.search_parameters:
             # ...
 
-        self.logger.debug(f"SearchSource {source.filename} validated")
+        self.logger.debug("SearchSource %s validated", source.filename)
 
     def check_availability(
         self, *, source_operation: colrev.process.operation.Operation

--- a/colrev/packages/screen_table/src/screen_table.py
+++ b/colrev/packages/screen_table/src/screen_table.py
@@ -142,7 +142,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
                 index=False,
                 sheet_name="screen",
             )
-            self.logger.info(f"Created {self.screen_table_path.with_suffix('.xlsx')}")
+            self.logger.info("Created %s", self.screen_table_path.with_suffix(".xlsx"))
 
         return
 

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -183,7 +183,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             print(exc)
             raise colrev_exceptions.ServiceNotAvailableException(exc)
 
-        self.logger.info(str(record_return.total) + " records have been found.\n")
+        self.logger.info("%s records have been found.\n", record_return.total)
 
         if record_return.total == 0:
             self.logger.info(
@@ -213,9 +213,8 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
                 raise colrev_exceptions.ServiceNotAvailableException(exc)
         else:
             self.logger.error(
-                'Error: Search type "Search for paper" is not available with your parameters.\n'
-                + "Search parameter: "
-                + str(params.get("paper_ids"))
+                'Error: Search type "Search for paper" is not available with your parameters.\nSearch parameter: %s',
+                params.get("paper_ids"),
             )
             raise colrev_exceptions.ServiceNotAvailableException(
                 "Search parameter error."
@@ -240,9 +239,8 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
                 raise colrev_exceptions.ServiceNotAvailableException(exc)
         else:
             self.logger.error(
-                '\nError: Search type "Search for author" is not available with your parameters.\n'
-                + "Search parameter: "
-                + str(params.get("author_ids"))
+                '\nError: Search type "Search for author" is not available with your parameters.\nSearch parameter: %s',
+                params.get("author_ids"),
             )
             raise colrev_exceptions.ServiceNotAvailableException(
                 "Search parameter error."

--- a/colrev/packages/structured/src/structured.py
+++ b/colrev/packages/structured/src/structured.py
@@ -220,8 +220,9 @@ class StructuredData(base_classes.DataPackageBaseClass):
                 )
                 data_df = pd.concat([data_df, add_record], axis=0, ignore_index=True)
                 self.logger.info(
-                    f" {Colors.GREEN}{record_id}".ljust(45)
-                    + f"add to structured_data{Colors.END}"
+                    " %sadd to structured_data%s",
+                    f"{Colors.GREEN}{record_id}".ljust(45),
+                    Colors.END,
                 )
                 nr_records_added = nr_records_added + 1
 
@@ -231,15 +232,15 @@ class StructuredData(base_classes.DataPackageBaseClass):
 
             if not (0 == nr_records_added and silent_mode):
                 self.logger.info(
-                    f"Added to {self.settings.data_path_relative}".ljust(24)
-                    + f"{nr_records_added}".rjust(15, " ")
-                    + " records"
+                    "%s%s records",
+                    f"Added to {self.settings.data_path_relative}".ljust(24),
+                    f"{nr_records_added}".rjust(15, " "),
                 )
 
                 self.logger.info(
-                    f"Added to {self.settings.data_path_relative}".ljust(24)
-                    + f"{nr_records_added}".rjust(15, " ")
-                    + " records"
+                    "%s%s records",
+                    f"Added to {self.settings.data_path_relative}".ljust(24),
+                    f"{nr_records_added}".rjust(15, " "),
                 )
             return records
 

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -173,11 +173,13 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         missing_metadata_percentage = missing_metadata.sum() / dataset_df.shape[0]
         if missing_metadata_percentage > 0.1:
             self.logger.error(
-                f"Missing metadata percentage: {missing_metadata_percentage}"
+                "Missing metadata percentage: %s", missing_metadata_percentage
             )
             input("ENTER to continue anyway")
         else:
-            self.logger.info(f"Missing metadata: {missing_metadata_percentage:.2%}")
+            self.logger.info(
+                "Missing metadata: %s", f"{missing_metadata_percentage:.2%}"
+            )
         return dataset_df
 
     def _update_decisions(self, *, decisions: dict, record: dict) -> None:
@@ -333,8 +335,8 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
             # The linking of doi/... should happen in the prep operation
 
         self._check_quality(decisions=decisions)
-        self.logger.info(f"Dropped {empty_records} empty records")
-        self.logger.info(f"Dropped {duplicates} duplicate records")
+        self.logger.info("Dropped %s empty records", empty_records)
+        self.logger.info("Dropped %s duplicate records", duplicates)
         self.review_manager.dataset.load_records_dict()
         synergy_feed.save()
 


### PR DESCRIPTION
## Summary
- replace f-string logging with lazy `%s` formatting across multiple package modules
- resolve remaining pylint issues including generator expression and long line in ENLIT
- standardize metadata quality logs in synergy_datasets

## Testing
- `pre-commit run --files colrev/packages/ais_library/src/aisel.py colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py colrev/packages/colrev_project/src/colrev_project.py colrev/packages/crossref/src/crossref_search_source.py colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py colrev/packages/dblp/src/dblp.py colrev/packages/download_from_website/src/download_from_website.py colrev/packages/enlit/src/enlit.py colrev/packages/europe_pmc/src/europe_pmc.py colrev/packages/export_man_prep/src/prep_man_export.py colrev/packages/files_dir/src/files_dir.py colrev/packages/github_pages/src/github_pages.py colrev/packages/local_index/src/local_index.py colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py colrev/packages/paper_md/src/paper_md.py colrev/packages/pdf_backward_search/src/pdf_backward_search.py colrev/packages/plos/src/plos_search_source.py colrev/packages/prescreen_table/src/prescreen_table.py colrev/packages/profile/src/profile.py colrev/packages/prospero/src/prospero_search_source.py colrev/packages/pubmed/src/pubmed.py colrev/packages/screen_table/src/screen_table.py colrev/packages/semanticscholar/src/semanticscholar_search_source.py colrev/packages/structured/src/structured.py colrev/packages/synergy_datasets/src/synergy_datasets.py` (fails: CONNECT tunnel failed, response 403)
- `pytest --disable-warnings` (fails: ModuleNotFoundError: No module named 'colrev')
- `pip install -e .` (fails: Could not connect to proxy / hatchling not found)


------
https://chatgpt.com/codex/tasks/task_e_688dd3503558832abf453ccbe727f209