### PR TITLE
refactor: inject logger into SearchAPIFeed

### DIFF
--- a/colrev/settings.py
+++ b/colrev/settings.py
@@ -168,6 +168,7 @@ class SearchSource(BaseModel):
             source_identifier=source_identifier,
             search_source=self,
             update_only=update_only,
+            logger=review_manager.logger,
             prep_mode=prep_mode,
         )
 


### PR DESCRIPTION
## Summary
- allow `SearchAPIFeed` to receive a logger during initialization
- use passed logger throughout `SearchAPIFeed`
- provide logger when constructing `SearchAPIFeed` from settings

## Testing
- `ruff check colrev/ops/search_api_feed.py colrev/settings.py`
- `pip install -e .` *(failed: Could not find a version that satisfies the requirement hatchling)*
- `PYTHONPATH=$PWD pytest -q` *(failed: PackageNotFoundError: No package metadata was found for colrev)*

------
https://chatgpt.com/codex/tasks/task_e_688ddff62b88832ab27cfece4107f473