### PR TITLE
refactor: update get_api_feed calls

### DIFF
--- a/colrev/ops/custom_scripts/custom_search_source_script.py
+++ b/colrev/ops/custom_scripts/custom_search_source_script.py
@@ -34,9 +34,10 @@ class CustomSearch(base_classes.SearchSourcePackageBaseClass):
         """Run the search"""
 
         feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
         retrieved_record = {
             Fields.ID: "ID00001",

--- a/colrev/ops/repare.py
+++ b/colrev/ops/repare.py
@@ -138,9 +138,10 @@ class Repare(colrev.process.operation.Operation):
         ]
         for search_source in file_search_sources:
             files_dir_feed = search_source.get_api_feed(
-                review_manager=self.review_manager,
                 source_identifier="UNKNOWN",
                 update_only=True,
+                logger=self.review_manager.logger,
+                verbose_mode=self.review_manager.verbose_mode,
             )
             prefix = search_source.get_origin_prefix()
             for record_dict in records.values():
@@ -164,9 +165,10 @@ class Repare(colrev.process.operation.Operation):
         for source in self.review_manager.settings.sources:
             source_feeds[str(source.filename).replace("data/search/", "")] = (
                 source.get_api_feed(
-                    review_manager=self.review_manager,
                     source_identifier="NA",
                     update_only=False,
+                    logger=self.review_manager.logger,
+                    verbose_mode=self.review_manager.verbose_mode,
                 ).feed_records
             )
         return source_feeds

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -319,9 +319,10 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if self.search_source.search_type == SearchType.API:
             ais_feed = self.search_source.get_api_feed(
-                review_manager=self.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
+                logger=self.review_manager.logger,
+                verbose_mode=self.review_manager.verbose_mode,
             )
             self._run_api_search(
                 ais_feed=ais_feed,

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -346,9 +346,10 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of ArXiv"""
 
         arxiv_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         # if self.search_source.search_type == SearchType.MD:

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -177,9 +177,10 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         colrev_project_search_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
         # pylint: disable=colrev-missed-constant-usage
         project_url = self.search_source.search_parameters["scope"]["url"]

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -468,9 +468,10 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         crossref_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         if self.search_source.search_type in [

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -326,9 +326,10 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         dblp_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
         if self.search_source.search_type == SearchType.MD:
             self._run_md_search(dblp_feed=dblp_feed)
@@ -436,7 +437,6 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                 # Note : need to reload file
                 # because the object is not shared between processes
                 dblp_feed = self.search_source.get_api_feed(
-                    review_manager=self.review_manager,
                     source_identifier=self.source_identifier,
                     update_only=False,
                     prep_mode=True,

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -159,9 +159,10 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of ERIC"""
 
         eric_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -229,7 +229,6 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
 
             # Note : need to reload file because the object is not shared between processes
             europe_pmc_feed = self.search_source.get_api_feed(
-                review_manager=prep_operation.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=False,
                 prep_mode=True,
@@ -290,9 +289,10 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         # https://europepmc.org/RestfulWebService
 
         europe_pmc_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -708,9 +708,10 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         records = self.review_manager.dataset.load_records_dict()
         files_dir_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         linked_file_paths = [

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -215,9 +215,10 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if self.search_source.search_type == SearchType.API:
             github_feed = self.search_source.get_api_feed(
-                review_manager=self.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
+                logger=self.review_manager.logger,
+                verbose_mode=self.review_manager.verbose_mode,
             )
             self._run_api_search(github_feed)
 

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -157,9 +157,10 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if self.search_source.search_type == SearchType.API:
             ieee_feed = self.search_source.get_api_feed(
-                review_manager=self.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
+                logger=self.review_manager.logger,
+                verbose_mode=self.review_manager.verbose_mode,
             )
             self._run_api_search(ieee_feed=ieee_feed, rerun=rerun)
 

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -212,9 +212,10 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         local_index_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.MD:
@@ -400,7 +401,6 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
 
             # Note : need to reload file because the object is not shared between processes
             local_index_feed = self.search_source.get_api_feed(
-                review_manager=self.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=False,
                 prep_mode=True,
@@ -652,9 +652,10 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         original_record = change_item["original_record"]
 
         local_index_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=True,
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         try:

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -113,7 +113,6 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
 
             # Note : need to reload file because the object is not shared between processes
             open_alex_feed = self.search_source.get_api_feed(
-                review_manager=self.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=False,
                 prep_mode=True,

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -145,9 +145,10 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
             return
 
         forward_search_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         for record in records.values():

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -280,7 +280,6 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
             self.open_library_lock.acquire(timeout=60)
             open_library_feed = self.search_source.get_api_feed(
-                review_manager=prep_operation.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=False,
                 prep_mode=True,

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -148,9 +148,10 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
     def search(self, rerun: bool) -> None:
         """Run a search of OSF"""
         osf_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
         self._run_api_search(osf_feed=osf_feed, rerun=rerun)
 

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -412,9 +412,10 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         selected_references = df_all_references[df_all_references["meets_criteria"]]
         pdf_backward_search_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         for item in selected_references.to_dict(orient="records"):

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -309,9 +309,10 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         # Create the Object SearchAPIFeed which mange the search on the API
 
         plos_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -172,9 +172,10 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         prospero_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=False,
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         self.run_api_search(prospero_feed=prospero_feed, rerun=rerun)

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -251,7 +251,6 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
 
                 # Note : need to reload file because the object is not shared between processes
                 pubmed_feed = self.search_source.get_api_feed(
-                    review_manager=self.review_manager,
                     source_identifier=self.source_identifier,
                     update_only=False,
                     prep_mode=True,
@@ -415,9 +414,10 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         pubmed_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.MD:

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -283,9 +283,10 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         # load file because the object is not shared between processes
         s2_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
         # rerun not implemented yet
         if rerun:

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -131,9 +131,10 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if self.search_source.search_type == SearchType.API:
             springer_feed = self.search_source.get_api_feed(
-                review_manager=self.review_manager,
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
+                logger=self.review_manager.logger,
+                verbose_mode=self.review_manager.verbose_mode,
             )
             self._run_api_search(springer_feed=springer_feed, rerun=rerun)
             return

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -268,9 +268,10 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         dataset_df = self._load_dataset()
 
         synergy_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=False,
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
         existing_keys = {
             Fields.DOI: [

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -135,9 +135,10 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of Unpaywall"""
 
         unpaywall_feed = self.search_source.get_api_feed(
-            review_manager=self.review_manager,
             source_identifier=self.source_identifier,
             update_only=(not rerun),
+            logger=self.review_manager.logger,
+            verbose_mode=self.review_manager.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:

--- a/colrev/ui_cli/search_backward_selective.py
+++ b/colrev/ui_cli/search_backward_selective.py
@@ -43,9 +43,10 @@ def main(*, search_operation: colrev.ops.search.Search, bws: str) -> None:
         comment="",
     )
     feed = search_source.get_api_feed(
-        review_manager=search_operation.review_manager,
         source_identifier="bws_id",
         update_only=False,
+        logger=search_operation.review_manager.logger,
+        verbose_mode=search_operation.review_manager.verbose_mode,
     )
 
     # print list

--- a/tests/2_ops/search_api_feed_test.py
+++ b/tests/2_ops/search_api_feed_test.py
@@ -35,9 +35,10 @@ def fixture_search_feed(
     )
     base_repo_review_manager.get_search_operation()
     feed = source.get_api_feed(
-        review_manager=base_repo_review_manager,
         source_identifier="doi",
         update_only=True,
+        logger=base_repo_review_manager.logger,
+        verbose_mode=base_repo_review_manager.verbose_mode,
     )
 
     prev_sources = base_repo_review_manager.settings.sources
@@ -81,9 +82,10 @@ def test_search_feed_update(  # type: ignore
     )
     # base_repo_review_manager.get_search_operation()
     search_feed = source.get_api_feed(
-        review_manager=base_repo_review_manager,
         source_identifier="doi",
         update_only=True,
+        logger=base_repo_review_manager.logger,
+        verbose_mode=base_repo_review_manager.verbose_mode,
     )
     assert search_feed._available_ids == {"10.111/2222": "000001"}
     assert search_feed._next_incremental_id == 2


### PR DESCRIPTION
## Summary
- update search source get_api_feed calls to remove review_manager argument
- pass logger and verbose_mode to get_api_feed

## Testing
- `pre-commit run --files colrev/ops/custom_scripts/custom_search_source_script.py colrev/ops/repare.py colrev/packages/ais_library/src/aisel.py colrev/packages/arxiv/src/arxiv.py colrev/packages/colrev_project/src/colrev_project.py colrev/packages/crossref/src/crossref_search_source.py colrev/packages/dblp/src/dblp.py colrev/packages/eric/src/eric.py colrev/packages/europe_pmc/src/europe_pmc.py colrev/packages/files_dir/src/files_dir.py colrev/packages/github/src/github_search_source.py colrev/packages/ieee/src/ieee.py colrev/packages/local_index/src/local_index.py colrev/packages/open_alex/src/open_alex.py colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py colrev/packages/open_library/src/open_library.py colrev/packages/osf/src/osf.py colrev/packages/pdf_backward_search/src/pdf_backward_search.py colrev/packages/plos/src/plos_search_source.py colrev/packages/prospero/src/prospero_search_source.py colrev/packages/pubmed/src/pubmed.py colrev/packages/semanticscholar/src/semanticscholar_search_source.py colrev/packages/springer_link/src/springer_link.py colrev/packages/synergy_datasets/src/synergy_datasets.py colrev/packages/unpaywall/src/unpaywall_search_source.py colrev/ui_cli/search_backward_selective.py tests/2_ops/search_api_feed_test.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') response 403)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'colrev')*

------
https://chatgpt.com/codex/tasks/task_e_688f21afc298832a8d858eb0029599f4