### PR TITLE
feat: support package-level logger and verbosity

### DIFF
--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -293,12 +293,12 @@ class PDFGetManPackageBaseClass(ABC):
     def __init__(
         self,
         *,
-       pdf_get_man_operation: colrev.ops.pdf_get_man.PDFGetMan,
-       settings: dict,
+        pdf_get_man_operation: colrev.ops.pdf_get_man.PDFGetMan,
+        settings: dict,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
-   ) -> None:
-       pass
+    ) -> None:
+        pass
 
     @abstractmethod
     def pdf_get_man(self, records: dict) -> dict:

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -43,6 +43,7 @@ class ReviewTypePackageBaseClass(abc.ABC):
         operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -80,6 +81,7 @@ class SearchSourcePackageBaseClass(ABC):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -150,6 +152,7 @@ class PrepPackageBaseClass(ABC):
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -180,6 +183,7 @@ class PrepManPackageBaseClass(ABC):
         prep_man_operation: colrev.ops.prep_man.PrepMan,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -207,6 +211,7 @@ class DedupePackageBaseClass(ABC):
         dedupe_operation: colrev.ops.dedupe.Dedupe,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ):
         pass
 
@@ -234,6 +239,7 @@ class PrescreenPackageBaseClass(ABC):
         prescreen_operation: colrev.ops.prescreen.Prescreen,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -261,6 +267,7 @@ class PDFGetPackageBaseClass(ABC):
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -286,11 +293,12 @@ class PDFGetManPackageBaseClass(ABC):
     def __init__(
         self,
         *,
-        pdf_get_man_operation: colrev.ops.pdf_get_man.PDFGetMan,
-        settings: dict,
+       pdf_get_man_operation: colrev.ops.pdf_get_man.PDFGetMan,
+       settings: dict,
         logger: Optional[logging.Logger] = None,
-    ) -> None:
-        pass
+        verbose_mode: bool = False,
+   ) -> None:
+       pass
 
     @abstractmethod
     def pdf_get_man(self, records: dict) -> dict:
@@ -316,6 +324,7 @@ class PDFPrepPackageBaseClass(ABC):
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -345,6 +354,7 @@ class PDFPrepManPackageBaseClass(ABC):
         pdf_prep_man_operation: colrev.ops.pdf_prep_man.PDFPrepMan,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -373,6 +383,7 @@ class ScreenPackageBaseClass(ABC):
         screen_operation: colrev.ops.screen.Screen,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 
@@ -400,6 +411,7 @@ class DataPackageBaseClass(ABC):
         data_operation: colrev.ops.data.Data,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         pass
 

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -73,8 +73,10 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
         self.quality_model = self.review_manager.get_qm()
@@ -321,8 +323,8 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
             ais_feed = self.search_source.get_api_feed(
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
             self._run_api_search(
                 ais_feed=ais_feed,

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -48,8 +48,10 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # arXiv as a search_source
@@ -348,8 +350,8 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         arxiv_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         # if self.search_source.search_type == SearchType.MD:

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -48,8 +48,10 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
 
@@ -179,8 +181,8 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         colrev_project_search_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
         # pylint: disable=colrev-missed-constant-usage
         project_url = self.search_source.search_parameters["scope"]["url"]

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -60,8 +60,10 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
 
         self.review_manager = source_operation.review_manager
         self.search_source = self._get_search_source(settings)
@@ -470,8 +472,8 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         crossref_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         if self.search_source.search_type in [
@@ -561,8 +563,8 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
                     update_only=False,
                     prep_mode=True,
                     records=self.review_manager.dataset.load_records_dict(),
-                    logger=self.review_manager.logger,
-                    verbose_mode=self.review_manager.verbose_mode,
+                    logger=self.logger,
+                    verbose_mode=self.verbose_mode,
                 )
 
                 crossref_feed.add_update_record(retrieved_record)
@@ -600,7 +602,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev_exceptions.RecordNotFoundInPrepSourceException,
             colrev_exceptions.RecordNotParsableException,
         ) as exc:
-            if prep_operation.review_manager.verbose_mode:
+            if self.verbose_mode:
                 print(exc)
 
         return record

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -75,8 +75,10 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         self.search_source = self._get_search_source(settings)
         self.dblp_lock = Lock()
@@ -328,8 +330,8 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         dblp_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
         if self.search_source.search_type == SearchType.MD:
             self._run_md_search(dblp_feed=dblp_feed)
@@ -441,8 +443,8 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                     update_only=False,
                     prep_mode=True,
                     records=self.review_manager.dataset.load_records_dict(),
-                    logger=self.review_manager.logger,
-                    verbose_mode=self.review_manager.verbose_mode,
+                    logger=self.logger,
+                    verbose_mode=self.verbose_mode,
                 )
 
                 dblp_feed.add_update_record(retrieved_record)

--- a/colrev/packages/dedupe/src/dedupe.py
+++ b/colrev/packages/dedupe/src/dedupe.py
@@ -38,8 +38,10 @@ class Dedupe(base_classes.DedupePackageBaseClass):
         dedupe_operation: colrev.ops.dedupe.Dedupe,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ):
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)
         self.dedupe_operation = dedupe_operation
         self.review_manager = dedupe_operation.review_manager
@@ -72,7 +74,7 @@ class Dedupe(base_classes.DedupePackageBaseClass):
             )
         ]
         verbosity_level = 0
-        if self.review_manager.verbose_mode:
+        if self.verbose_mode:
             verbosity_level = 1
         records_df.loc[
             records_df[Fields.STATUS].isin(

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -46,8 +46,10 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         self.source_operation = source_operation
         if settings:
@@ -161,8 +163,8 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         eric_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -80,8 +80,10 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # EuropePMC as a search_source
@@ -233,8 +235,8 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                 update_only=False,
                 prep_mode=True,
                 records=self.review_manager.dataset.load_records_dict(),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
             europe_pmc_feed.add_update_record(retrieved_record=retrieved_record)
 
@@ -291,8 +293,8 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         europe_pmc_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -61,8 +61,10 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         self.source_operation = source_operation
 
@@ -710,8 +712,8 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         files_dir_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         linked_file_paths = [

--- a/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
+++ b/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
@@ -42,13 +42,15 @@ class YearVolIssPrep(base_classes.PrepPackageBaseClass):
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation
         self.review_manager = prep_operation.review_manager
         self.local_index = colrev.env.local_index.LocalIndex(
-            verbose_mode=self.review_manager.verbose_mode
+            verbose_mode=self.verbose_mode
         )
         self.vol_nr_dict = self._get_vol_nr_dict()
         self.quality_model = self.review_manager.get_qm()

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -63,8 +63,10 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # GitHub as a search source
@@ -217,8 +219,8 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
             github_feed = self.search_source.get_api_feed(
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
             self._run_api_search(github_feed)
 

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -52,8 +52,10 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
 
         if settings:
@@ -159,8 +161,8 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
             ieee_feed = self.search_source.get_api_feed(
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
             self._run_api_search(ieee_feed=ieee_feed, rerun=rerun)
 

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -69,8 +69,10 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # LocalIndex as a search_source
@@ -99,7 +101,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.origin_prefix = self.search_source.get_origin_prefix()
 
         self.local_index = colrev.env.local_index.LocalIndex(
-            verbose_mode=self.review_manager.verbose_mode
+            verbose_mode=self.verbose_mode
         )
 
     def _validate_source(self) -> None:
@@ -214,8 +216,8 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         local_index_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.MD:
@@ -405,8 +407,8 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
                 update_only=False,
                 prep_mode=True,
                 records=self.review_manager.dataset.load_records_dict(),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
 
             local_index_feed.add_update_record(retrieved_record)
@@ -654,8 +656,8 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         local_index_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=True,
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         try:

--- a/colrev/packages/local_index/src/local_index_pdf_get.py
+++ b/colrev/packages/local_index/src/local_index_pdf_get.py
@@ -33,8 +33,10 @@ class LocalIndexPDFGet(base_classes.PDFGetPackageBaseClass):
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,  # pylint: disable=unused-argument
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)
         self.pdf_get_operation = pdf_get_operation
         self.review_manager = pdf_get_operation.review_manager
@@ -45,7 +47,7 @@ class LocalIndexPDFGet(base_classes.PDFGetPackageBaseClass):
         """Get PDFs from the local-index"""
 
         local_index = colrev.env.local_index.LocalIndex(
-            verbose_mode=self.review_manager.verbose_mode
+            verbose_mode=self.verbose_mode
         )
 
         try:

--- a/colrev/packages/local_index/src/local_index_pdf_get.py
+++ b/colrev/packages/local_index/src/local_index_pdf_get.py
@@ -46,9 +46,7 @@ class LocalIndexPDFGet(base_classes.PDFGetPackageBaseClass):
     ) -> colrev.record.record.Record:
         """Get PDFs from the local-index"""
 
-        local_index = colrev.env.local_index.LocalIndex(
-            verbose_mode=self.verbose_mode
-        )
+        local_index = colrev.env.local_index.LocalIndex(verbose_mode=self.verbose_mode)
 
         try:
             retrieved_record = local_index.retrieve(record.data, include_file=True)

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -45,8 +45,10 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         # Note: not yet implemented
         # Note : once this is implemented, add "colrev.open_alex" to the default settings
@@ -117,8 +119,8 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
                 update_only=False,
                 prep_mode=True,
                 records=self.review_manager.dataset.load_records_dict(),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
 
             open_alex_feed.add_update_record(retrieved_record)

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -45,8 +45,10 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.search_source = self.settings_class(**settings)
         self.review_manager = source_operation.review_manager
         self.crossref_api = crossref_api.CrossrefAPI(params={})
@@ -147,8 +149,8 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         forward_search_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         for record in records.values():

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -55,8 +55,10 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # OpenLibrary as a search_source
@@ -284,8 +286,8 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 update_only=False,
                 prep_mode=True,
                 records=self.review_manager.dataset.load_records_dict(),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
 
             open_library_feed.add_update_record(retrieved_record)

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -56,8 +56,10 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
 
         if settings:
@@ -150,8 +152,8 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         osf_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
         self._run_api_search(osf_feed=osf_feed, rerun=rerun)
 

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -94,8 +94,10 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         data_operation: colrev.ops.data.Data,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.data_operation = data_operation
         self.review_manager = data_operation.review_manager
 
@@ -737,7 +739,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             self.logger.debug("Skipping paper build (no changes)")
             return
 
-        if self.review_manager.verbose_mode:
+        if self.verbose_mode:
             self.logger.info("Build paper")
 
         script = (

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -58,8 +58,10 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if "min_intext_citations" not in settings["search_parameters"]:
             settings["search_parameters"]["min_intext_citations"] = 3
@@ -414,8 +416,8 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         pdf_backward_search_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         for item in selected_references.to_dict(orient="records"):

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -48,8 +48,10 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         self.search_source = self._get_search_source(settings)
         self.plos_lock = Lock()
@@ -311,8 +313,8 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         plos_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -46,8 +46,10 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         """Initialize the ProsperoSearchSource plugin."""
 
         self.search_source = self._get_search_source(settings)
@@ -174,8 +176,8 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         prospero_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=False,
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         self.run_api_search(prospero_feed=prospero_feed, rerun=rerun)

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -55,8 +55,10 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # Pubmed as a search_source
@@ -255,8 +257,8 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
                     update_only=False,
                     prep_mode=True,
                     records=self.review_manager.dataset.load_records_dict(),
-                    logger=self.review_manager.logger,
-                    verbose_mode=self.review_manager.verbose_mode,
+                    logger=self.logger,
+                    verbose_mode=self.verbose_mode,
                 )
 
                 pubmed_feed.add_update_record(retrieved_record)
@@ -416,8 +418,8 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         pubmed_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.MD:

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -76,8 +76,10 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # Semantic Scholar as a search source
@@ -285,8 +287,8 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         s2_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
         # rerun not implemented yet
         if rerun:

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -57,8 +57,10 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         self.search_source = self.settings_class(**settings)
         self.quality_model = self.review_manager.get_qm()
@@ -133,8 +135,8 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
             springer_feed = self.search_source.get_api_feed(
                 source_identifier=self.source_identifier,
                 update_only=(not rerun),
-                logger=self.review_manager.logger,
-                verbose_mode=self.review_manager.verbose_mode,
+                logger=self.logger,
+                verbose_mode=self.verbose_mode,
             )
             self._run_api_search(springer_feed=springer_feed, rerun=rerun)
             return

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -57,8 +57,10 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         self.search_source = self.settings_class(**settings)
         self.quality_model = self.review_manager.get_qm()
@@ -270,8 +272,8 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         synergy_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=False,
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
         existing_keys = {
             Fields.DOI: [

--- a/colrev/packages/unpaywall/src/unpaywall.py
+++ b/colrev/packages/unpaywall/src/unpaywall.py
@@ -39,8 +39,10 @@ class Unpaywall(base_classes.PDFGetPackageBaseClass):
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,
         settings: dict,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_operation.review_manager
         self.pdf_get_operation = pdf_get_operation
@@ -135,7 +137,7 @@ class Unpaywall(base_classes.PDFGetPackageBaseClass):
             else:
                 if Fields.FULLTEXT not in record.data:
                     record.data[Fields.FULLTEXT] = url
-                if self.review_manager.verbose_mode:
+                if self.verbose_mode:
                     self.logger.info(
                         "Unpaywall retrieval error " f"{res.status_code} - {url}"
                     )

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -44,8 +44,10 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         source_operation: colrev.process.operation.Operation,
         settings: typing.Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
+        verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
         if settings:
             # Unpaywall as a search_source
@@ -137,8 +139,8 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         unpaywall_feed = self.search_source.get_api_feed(
             source_identifier=self.source_identifier,
             update_only=(not rerun),
-            logger=self.review_manager.logger,
-            verbose_mode=self.review_manager.verbose_mode,
+            logger=self.logger,
+            verbose_mode=self.verbose_mode,
         )
 
         if self.search_source.search_type == SearchType.API:


### PR DESCRIPTION
## Summary
- extend package classes to accept logger and verbose_mode parameters
- route internal logging and verbosity checks through package instances

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}' | tr '\n' ' ')` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `PYTHONPATH=. pytest` *(fails: PackageNotFoundError: No package metadata was found for colrev)*

------
https://chatgpt.com/codex/tasks/task_e_688f48f0111c832aa3212b0d40d6e541