### PR TITLE
refactor: replace SearchSource with SearchFile

### DIFF
--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: ABI/INFORM (ProQuest)"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -67,7 +68,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -270,7 +271,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for ABI/INFORM (ProQuest)"""
 

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: ABI/INFORM (ProQuest)"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: ACM Digital Library"""
 from __future__ import annotations
+import search_query
 
 import logging
 from pathlib import Path
@@ -62,7 +63,7 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {}
@@ -146,7 +147,7 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
     # pylint: disable=colrev-missed-constant-usage
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for ACM Digital Library"""
 

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: ACM Digital Library"""
 from __future__ import annotations
-import search_query
 
 import logging
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: AIS electronic Library"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -163,7 +164,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
         params_dict = {}
         if params:
@@ -191,16 +192,16 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 assert host and host.endswith("aisel.aisnet.org")
                 q_params = cls._parse_query(query=params_dict["url"])
                 filename = operation.get_unique_filename(file_path_string="ais")
-                search_source = colrev.settings.SearchSource(
-                    endpoint=cls.endpoint,
-                    filename=filename,
+                search_source = search_query.SearchFile(
+                    platform=cls.endpoint,
+                    filepath=filename,
                     search_type=SearchType.API,
-                    search_parameters=q_params,
+                    search_string=q_params,
                     comment="",
                 )
             else:
                 # Add API search without params
-                search_source = operation.create_api_source(endpoint=cls.endpoint)
+                search_source = operation.create_api_source(platform=cls.endpoint)
 
         # elif search_type == SearchType.TOC:
         else:
@@ -217,8 +218,8 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self.logger.debug(f"Validate SearchSource {source.filename}")
 
         if source.search_type == SearchType.API:
-            if "query" not in source.search_parameters:
-                # if "search_terms" not in source.search_parameters["query"]:
+            if "query" not in source.search_string:
+                # if "search_terms" not in source.search_string["query"]:
                 raise colrev_exceptions.InvalidQueryException("query parameter missing")
 
         self.logger.debug("SearchSource %s validated", source.filename)
@@ -245,7 +246,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
             return urllib.parse.quote(final)
 
-        params = self.search_source.search_parameters
+        params = self.search_source.search_string
         final_q = query_from_params(params)
 
         query_string = (
@@ -504,7 +505,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
-        source: colrev.settings.SearchSource,
+        source: search_query.SearchFile,
     ) -> colrev.record.record.Record:
         """Source-specific preparation for the AIS electronic Library (AISeL)"""
 

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: AIS electronic Library"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
@@ -11,6 +10,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: arXiv"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
@@ -12,6 +11,7 @@ from urllib.parse import urlparse
 
 import feedparser
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: CoLRev project"""
 from __future__ import annotations
-import search_query
 
 import logging
 import shutil
@@ -12,6 +11,7 @@ from typing import Optional
 
 import pandas as pd
 import pandasql as ps
+import search_query
 from git import Repo
 from pandasql.sqldf import PandaSQLException
 from pydantic import Field

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: DBLP"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+import search_query
 from pydantic import BaseModel
 from pydantic import Field
 

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: EBSCOHost"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: EBSCOHost"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -67,7 +68,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -127,7 +128,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
-        source: colrev.settings.SearchSource,
+        source: search_query.SearchFile,
     ) -> colrev.record.record.Record:
         """Source-specific preparation for EBSCOHost"""
 

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: ERIC"""
 from __future__ import annotations
+import search_query
 
 import logging
 import typing
@@ -54,11 +55,11 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
             # ERIC as a search_source
             self.search_source = settings
         else:
-            self.search_source = colrev.settings.SearchSource(
-                endpoint=self.endpoint,
-                filename=Path("data/search/eric.bib"),
+            self.search_source = search_query.SearchFile(
+                platform=self.endpoint,
+                filepath=Path("data/search/eric.bib"),
                 search_type=SearchType.OTHER,
-                search_parameters={},
+                search_string={},
                 comment="",
             )
 
@@ -100,7 +101,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search -a)"""
 
         params_dict = {}
@@ -129,11 +130,11 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
             if ":" in search:
                 search = ERICSearchSource._search_split(search)
             filename = operation.get_unique_filename(file_path_string=f"eric_{search}")
-            search_source = colrev.settings.SearchSource(
-                endpoint=cls.endpoint,
-                filename=filename,
+            search_source = search_query.SearchFile(
+                platform=cls.endpoint,
+                filepath=filename,
                 search_type=SearchType.API,
-                search_parameters={"query": search, "start": start, "rows": rows},
+                search_string={"query": search, "start": start, "rows": rows},
                 comment="",
             )
 
@@ -149,7 +150,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         self, *, eric_feed: colrev.ops.search_api_feed.SearchAPIFeed, rerun: bool
     ) -> None:
 
-        api = eric_api.ERICAPI(params=self.search_source.search_parameters)
+        api = eric_api.ERICAPI(params=self.search_source.search_string)
         for record in api.get_query_return():
             eric_feed.add_update_record(record)
 
@@ -268,7 +269,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for ERIC"""
 

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: ERIC"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
@@ -9,6 +8,7 @@ import urllib.parse
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: Europe PMC"""
 from __future__ import annotations
-import search_query
 
 import json
 import logging
@@ -14,6 +13,7 @@ from urllib.parse import quote
 from urllib.parse import urlparse
 
 import requests
+import search_query
 from pydantic import BaseModel
 from pydantic import Field
 from rapidfuzz import fuzz

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Europe PMC"""
 from __future__ import annotations
+import search_query
 
 import json
 import logging
@@ -24,7 +25,6 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 import colrev.record.record_prep
 import colrev.record.record_similarity
-import colrev.settings
 from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.constants import SearchSourceHeuristicStatus
@@ -35,18 +35,19 @@ from colrev.packages.europe_pmc.src import europe_pmc_api
 # pylint: disable=unused-argument
 
 
-class EuropePMCSearchSourceSettings(colrev.settings.SearchSource, BaseModel):
+class EuropePMCSearchSourceSettings(search_query.SearchFile, BaseModel):
     """Settings for EuropePMCSearchSource"""
 
     # pylint: disable=too-many-instance-attributes
-    endpoint: str
-    filename: Path
+    platform: str
+    filepath: Path
     search_type: SearchType
-    search_parameters: dict
+    search_string: dict
+    version: typing.Optional[str]
     comment: typing.Optional[str]
 
     _details = {
-        "search_parameters": {
+        "search_string": {
             "tooltip": "Currently supports a scope item "
             "with venue_key and journal_abbreviated fields."
         },
@@ -97,11 +98,11 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
             if europe_pmc_md_source_l:
                 self.search_source = europe_pmc_md_source_l[0]
             else:
-                self.search_source = colrev.settings.SearchSource(
-                    endpoint=self.endpoint,
-                    filename=self._europe_pmc_md_filename,
+                self.search_source = search_query.SearchFile(
+                    platform=self.endpoint,
+                    filepath=self._europe_pmc_md_filename,
                     search_type=SearchType.MD,
-                    search_parameters={},
+                    search_string={},
                     comment="",
                 )
 
@@ -276,7 +277,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         assert source.search_type in self.search_types
 
-        if "query" not in source.search_parameters:
+        if "query" not in source.search_string:
             raise colrev_exceptions.InvalidQueryException(
                 "Query required in search_parameters"
             )
@@ -308,7 +309,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                 source=self.search_source,
             )
 
-        # if self.search_source.search_type == colrev.settings.SearchSource.MD:
+        # if self.search_source.search_type == search_query.SearchFile.MD:
         # self._run_md_search_update(
         #     search_operation=search_operation,
         #     europe_pmc_feed=europe_pmc_feed,
@@ -327,7 +328,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         try:
             _, email = self.review_manager.get_committer()
             api = europe_pmc_api.EPMCAPI(
-                params=self.search_source.search_parameters,
+                params=self.search_source.search_string,
                 email=email,
                 session=self.review_manager.get_cached_session(),
             )
@@ -377,7 +378,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {}
@@ -390,7 +391,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                     params_dict[key] = value
 
         if len(params_dict) == 0:
-            search_source = operation.create_api_source(endpoint=cls.endpoint)
+            search_source = operation.create_api_source(platform=cls.endpoint)
 
         # pylint: disable=colrev-missed-constant-usage
         elif "url" in params_dict:
@@ -401,11 +402,11 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                     "https://europepmc.org/search?query=", ""
                 )
                 filename = operation.get_unique_filename(file_path_string="europepmc")
-                search_source = colrev.settings.SearchSource(
-                    endpoint=cls.endpoint,
-                    filename=filename,
+                search_source = search_query.SearchFile(
+                    platform=cls.endpoint,
+                    filepath=filename,
                     search_type=SearchType.API,
-                    search_parameters={"query": query},
+                    search_string={"query": query},
                     comment="",
                 )
             else:
@@ -441,7 +442,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Europe PMC"""
         record.data[Fields.AUTHOR].rstrip(".")

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: directory containing PDF files (based on GROBID)"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -76,13 +77,13 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
         self.pdfs_path = self.review_manager.path / Path(
-            self.search_source.search_parameters["scope"]["path"]
+            self.search_source.search_string["scope"]["path"]
         )
 
         self.subdir_pattern: re.Pattern = re.compile("")
         self.r_subdir_pattern: re.Pattern = re.compile("")
-        if "subdir_pattern" in self.search_source.search_parameters.get("scope", {}):
-            self.subdir_pattern = self.search_source.search_parameters["scope"][
+        if "subdir_pattern" in self.search_source.search_string.get("scope", {}):
+            self.subdir_pattern = self.search_source.search_string["scope"][
                 "subdir_pattern"
             ]
             self.logger.info(f"Activate subdir_pattern: {self.subdir_pattern}")
@@ -143,7 +144,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             return
 
         search_rd = colrev.loader.load_utils.load(
-            filename=self.search_source.filename,
+            filepath=self.search_source.filename,
             logger=self.logger,
             unique_id_field="ID",
         )
@@ -176,7 +177,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if len(search_rd.values()) != 0:
 
-            write_file(records_dict=search_rd, filename=self.search_source.filename)
+            write_file(records_dict=search_rd, filepath=self.search_source.filename)
 
         if records:
             for record_dict in records.values():
@@ -347,7 +348,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
 
                 # add details based on path
                 record_dict = self._update_fields_based_on_pdf_dirs(
-                    record_dict=record_dict, params=self.search_source.search_parameters
+                    record_dict=record_dict, params=self.search_source.search_string
                 )
 
         except colrev_exceptions.TEIException:
@@ -383,8 +384,8 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         assert source.search_type == SearchType.FILES
 
-        if "subdir_pattern" in source.search_parameters:
-            if source.search_parameters["subdir_pattern"] != [
+        if "subdir_pattern" in source.search_string:
+            if source.search_string["subdir_pattern"] != [
                 "NA",
                 "volume_number",
                 Fields.YEAR,
@@ -394,16 +395,16 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
                     "subdir_pattern not in [NA, volume_number, year, volume]"
                 )
 
-        if "sub_dir_pattern" in source.search_parameters:
+        if "sub_dir_pattern" in source.search_string:
             raise colrev_exceptions.InvalidQueryException(
                 "sub_dir_pattern: deprecated. use subdir_pattern"
             )
 
-        if "scope" not in source.search_parameters:
+        if "scope" not in source.search_string:
             raise colrev_exceptions.InvalidQueryException(
                 "scope required in search_parameters"
             )
-        if "path" not in source.search_parameters["scope"]:
+        if "path" not in source.search_string["scope"]:
             raise colrev_exceptions.InvalidQueryException(
                 "path required in search_parameters/scope"
             )
@@ -742,16 +743,16 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         filename = operation.get_unique_filename(file_path_string="files")
         # pylint: disable=no-value-for-parameter
-        search_source = colrev.settings.SearchSource(
-            endpoint="colrev.files_dir",
-            filename=filename,
+        search_source = search_query.SearchFile(
+            platform="colrev.files_dir",
+            filepath=filename,
             search_type=SearchType.FILES,
-            search_parameters={"scope": {"path": "data/pdfs"}},
+            search_string={"scope": {"path": "data/pdfs"}},
             comment="",
         )
         operation.add_source_and_search(search_source)
@@ -876,7 +877,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
-        source: colrev.settings.SearchSource,
+        source: search_query.SearchFile,
     ) -> colrev.record.record.Record:
         """Source-specific preparation for files"""
 

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: directory containing PDF files (based on GROBID)"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
@@ -11,6 +10,7 @@ from typing import Optional
 
 import pymupdf
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.env.local_index

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: GitHub"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 import inquirer
+import search_query
 from github import Auth
 from github import Github
 from pydantic import Field

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: GitHub"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -80,11 +81,11 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
             if github_md_source_l:
                 self.search_source = github_md_source_l[0]
             else:
-                self.search_source = colrev.settings.SearchSource(
-                    endpoint=self.endpoint,
-                    filename=self._github_md_filename,
+                self.search_source = search_query.SearchFile(
+                    platform=self.endpoint,
+                    filepath=self._github_md_filename,
                     search_type=SearchType.MD,
-                    search_parameters={},
+                    search_string={},
                     comment="",
                 )
             self.github_lock = Lock()
@@ -113,7 +114,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
     @classmethod
     def add_endpoint(
         cls, operation: colrev.ops.search.Search, params: str
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         cls._get_api_key()
@@ -132,10 +133,10 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
                     print("Invalid search parameter format")
 
         if len(params_dict) == 0:
-            search_source = operation.create_api_source(endpoint="colrev.github")
+            search_source = operation.create_api_source(platform="colrev.github")
 
             # Checking where to search
-            search_source.search_parameters["scope"] = cls._choice_scope()
+            search_source.search_string["scope"] = cls._choice_scope()
 
         else:
             if Fields.URL in params_dict:
@@ -152,11 +153,11 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
                 query = params_dict
 
             filename = operation.get_unique_filename(file_path_string="github")
-            search_source = colrev.settings.SearchSource(
-                endpoint="colrev.github",
-                filename=filename,
+            search_source = search_query.SearchFile(
+                platform="colrev.github",
+                filepath=filename,
                 search_type=SearchType.API,
-                search_parameters=query,
+                search_string=query,
                 comment="",
             )
 
@@ -187,11 +188,11 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         self, github_feed: colrev.ops.search_api_feed.SearchAPIFeed
     ) -> None:
 
-        if not self.search_source.search_parameters:
+        if not self.search_source.search_string:
             raise ValueError("No search parameters defined for GitHub search source")
 
-        keywords = self.search_source.search_parameters.get("query", "")
-        scope = self.search_source.search_parameters.get("scope", "")
+        keywords = self.search_source.search_string.get("query", "")
+        scope = self.search_source.search_string.get("scope", "")
         query = f"{keywords} in:{scope}"
 
         # Getting API key
@@ -237,7 +238,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for GitHub"""
         return record

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: GoogleScholar"""
 from __future__ import annotations
-import search_query
 
 import logging
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: GoogleScholar"""
 from __future__ import annotations
+import search_query
 
 import logging
 from pathlib import Path
@@ -76,7 +77,7 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -203,7 +204,7 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for GoogleScholar"""
         if "cites: https://scholar.google.com/scholar?cites=" in record.data.get(

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: IEEEXplore"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
@@ -9,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
+import search_query
 from pydantic import Field
 
 import colrev.ops.prep

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: IEEEXplore"""
 from __future__ import annotations
+import search_query
 
 import logging
 import typing
@@ -59,11 +60,11 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         if settings:
             self.search_source = settings
         else:
-            self.search_source = colrev.settings.SearchSource(
-                endpoint=self.endpoint,
-                filename=Path("data/search/ieee.bib"),
+            self.search_source = search_query.SearchFile(
+                platform=self.endpoint,
+                filepath=Path("data/search/ieee.bib"),
                 search_type=SearchType.OTHER,
-                search_parameters={},
+                search_string={},
                 comment="",
             )
         self.source_operation = source_operation
@@ -86,7 +87,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
     @classmethod
     def add_endpoint(
         cls, operation: colrev.ops.search.Search, params: str
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {}
@@ -104,7 +105,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.API:
             if len(params_dict) == 0:
-                search_source = operation.create_api_source(endpoint=cls.endpoint)
+                search_source = operation.create_api_source(platform=cls.endpoint)
 
             # pylint: disable=colrev-missed-constant-usage
             elif (
@@ -131,11 +132,11 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
                     file_path_string=f"ieee_{last_value}"
                 )
 
-                search_source = colrev.settings.SearchSource(
-                    endpoint=cls.endpoint,
-                    filename=filename,
+                search_source = search_query.SearchFile(
+                    platform=cls.endpoint,
+                    filepath=filename,
                     search_type=SearchType.API,
-                    search_parameters=search_parameters,
+                    search_string=search_parameters,
                     comment="",
                 )
             else:
@@ -190,7 +191,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         api_key = self._get_api_key()
 
         api = colrev.packages.ieee.src.ieee_api.XPLORE(
-            parameters=self.search_source.search_parameters, api_key=api_key
+            parameters=self.search_source.search_string, api_key=api_key
         )
         while True:
             retrieved_records = api.get_records()
@@ -363,7 +364,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for IEEEXplore"""
 

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: JSTOR"""
 from __future__ import annotations
-import search_query
 
 import logging
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: JSTOR"""
 from __future__ import annotations
+import search_query
 
 import logging
 from pathlib import Path
@@ -63,7 +64,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -205,7 +206,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for JSTOR"""
 

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: LocalIndex"""
 from __future__ import annotations
-import search_query
 
 import difflib
 import logging
@@ -13,6 +12,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import git
+import search_query
 from pydantic import Field
 
 import colrev.env.local_index

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: OpenAlex"""
 from __future__ import annotations
+import search_query
 
 import logging
 import typing
@@ -64,11 +65,11 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         if open_alex_md_source_l:
             self.search_source = open_alex_md_source_l[0]
         else:
-            self.search_source = colrev.settings.SearchSource(
-                endpoint="colrev.open_alex",
-                filename=self._open_alex_md_filename,
+            self.search_source = search_query.SearchFile(
+                platform="colrev.open_alex",
+                filepath=self._open_alex_md_filename,
                 search_type=SearchType.MD,
-                search_parameters={},
+                search_string={},
                 comment="",
             )
 
@@ -87,7 +88,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         raise colrev_exceptions.PackageParameterError(
@@ -191,7 +192,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for OpenAlex"""
 

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: OpenAlex"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
@@ -10,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: OpenCitations"""
 from __future__ import annotations
+import search_query
 
 import json
 import logging
@@ -53,13 +54,13 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.crossref_api = crossref_api.CrossrefAPI(params={})
 
     @classmethod
-    def get_default_source(cls) -> colrev.settings.SearchSource:
+    def get_default_source(cls) -> search_query.SearchFile:
         """Get the default SearchSource settings"""
-        return colrev.settings.SearchSource(
-            endpoint="colrev.open_citations_forward_search",
-            filename=Path("data/search/forward_search.bib"),
+        return search_query.SearchFile(
+            platform="colrev.open_citations_forward_search",
+            filepath=Path("data/search/forward_search.bib"),
             search_type=SearchType.FORWARD_SEARCH,
-            search_parameters={
+            search_string={
                 "scope": {Fields.STATUS: "rev_included|rev_synthesized"}
             },
             comment="",
@@ -74,13 +75,13 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         assert source.search_type == SearchType.FORWARD_SEARCH
 
-        if "scope" not in source.search_parameters:
+        if "scope" not in source.search_string:
             raise colrev_exceptions.InvalidQueryException(
                 "Scope required in the search_parameters"
             )
 
         if (
-            source.search_parameters["scope"][Fields.STATUS]
+            source.search_string["scope"][Fields.STATUS]
             != "rev_included|rev_synthesized"
         ):
             raise colrev_exceptions.InvalidQueryException(
@@ -95,8 +96,8 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         # rev_included/rev_synthesized required, but record not in rev_included/rev_synthesized
         if (
-            Fields.STATUS in self.search_source.search_parameters["scope"]
-            and self.search_source.search_parameters["scope"][Fields.STATUS]
+            Fields.STATUS in self.search_source.search_string["scope"]
+            and self.search_source.search_string["scope"][Fields.STATUS]
             == "rev_included|rev_synthesized"
             and record[Fields.STATUS]
             not in [
@@ -194,7 +195,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint"""
 
         search_source = cls.get_default_source()
@@ -225,7 +226,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for forward searches (OpenCitations)"""
         return record

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: OpenCitations"""
 from __future__ import annotations
-import search_query
 
 import json
 import logging
@@ -10,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
@@ -60,9 +60,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
             platform="colrev.open_citations_forward_search",
             filepath=Path("data/search/forward_search.bib"),
             search_type=SearchType.FORWARD_SEARCH,
-            search_string={
-                "scope": {Fields.STATUS: "rev_included|rev_synthesized"}
-            },
+            search_string={"scope": {Fields.STATUS: "rev_included|rev_synthesized"}},
             comment="",
         )
 

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """Connector to OpenLibrary (API)"""
 from __future__ import annotations
+import search_query
 
 import json
 import logging
@@ -72,11 +73,11 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
             if open_library_md_source_l:
                 self.search_source = open_library_md_source_l[0]
             else:
-                self.search_source = colrev.settings.SearchSource(
-                    endpoint="colrev.open_library",
-                    filename=self._open_library_md_filename,
+                self.search_source = search_query.SearchFile(
+                    platform="colrev.open_library",
+                    filepath=self._open_library_md_filename,
                     search_type=SearchType.MD,
-                    search_parameters={},
+                    search_string={},
                     comment="",
                 )
 
@@ -247,7 +248,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
         raise NotImplementedError
 
@@ -324,7 +325,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for OpenLibrary"""
 

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """Connector to OpenLibrary (API)"""
 from __future__ import annotations
-import search_query
 
 import json
 import logging
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Searchsource:OSF"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.env.environment_manager

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: backward search (based on PDFs and GROBID)"""
 from __future__ import annotations
-import search_query
 
 import json
 import logging
@@ -12,6 +11,7 @@ from typing import Optional
 import inquirer
 import pandas as pd
 import requests
+import search_query
 from bib_dedupe.bib_dedupe import block
 from bib_dedupe.bib_dedupe import cluster
 from bib_dedupe.bib_dedupe import match
@@ -378,9 +378,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         if not records:
             self.logger.info("No records imported. Cannot run backward search yet.")
             return
-        min_intext_citations = self.search_source.search_string[
-            "min_intext_citations"
-        ]
+        min_intext_citations = self.search_source.search_string["min_intext_citations"]
         self.logger.info("Set min_intext_citations=%s", min_intext_citations)
         nr_references_threshold = self.search_source.search_string.get(
             "min_ref_freq", 1

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -6,6 +6,7 @@ import typing
 from multiprocessing import Lock
 from pathlib import Path
 from typing import Optional
+
 import search_query
 
 import colrev.env.language_service
@@ -272,9 +273,9 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         ):
             return False
 
-        year_from, year_to = self.search_source.search_string["scope"][
-            "years"
-        ].split("-")
+        year_from, year_to = self.search_source.search_string["scope"]["years"].split(
+            "-"
+        )
 
         if not retrieved_record_dict.get(Fields.YEAR, -1000).isdigit():
             return True

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """SearchSource: PROSPERO
+import search_query
 
 A CoLRev SearchSource plugin to scrape and import records from PROSPERO.
 """
@@ -20,12 +21,10 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 import colrev.packages.prospero.src.prospero_api
 import colrev.process
-import colrev.settings
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.ops.search import Search
-from colrev.settings import SearchSource
 
 
 class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
@@ -58,42 +57,42 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     def _get_search_source(
         self, settings: typing.Optional[dict]
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Retrieve and configure the search source based on provided settings."""
         if settings:
             return self.settings_class(**settings)
 
         fallback_filename = Path("data/search/prospero.bib")
-        return SearchSource(
-            endpoint="colrev.prospero",
-            filename=fallback_filename,
+        return search_query.SearchFile(
+            platform="colrev.prospero",
+            filepath=fallback_filename,
             search_type=SearchType.API,
-            search_parameters={},
+            search_string={},
             comment="fallback search_source",
         )
 
     @classmethod
     def add_endpoint(
         cls, operation: Search, params: str
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Adds Prospero as a search source endpoint based on user-provided parameters."""
         if len(params) == 0:
-            search_source = operation.create_api_source(endpoint=cls.endpoint)
-            search_source.search_parameters[Fields.URL] = (
+            search_source = operation.create_api_source(platform=cls.endpoint)
+            search_source.search_string[Fields.URL] = (
                 cls.db_url + "search?" + "#searchadvanced"
             )
-            search_source.search_parameters["version"] = "0.1.0"
+            search_source.search_string["version"] = "0.1.0"
             operation.add_source_and_search(search_source)
             return search_source
 
         query = {"query": params}
         filename = operation.get_unique_filename(file_path_string="prospero_results")
 
-        new_search_source = SearchSource(
-            endpoint=cls.endpoint,
-            filename=filename,
+        new_search_source = search_query.SearchFile(
+            platform=cls.endpoint,
+            filepath=filename,
             search_type=SearchType.API,
-            search_parameters=query,
+            search_string=query,
             comment="Search source for Prospero protocols",
         )
         operation.add_source_and_search(new_search_source)
@@ -117,7 +116,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
                 f"not {self.search_source.search_type}"
             )
         if self.logger:
-            self.logger.debug("Validate SearchSource %s", self.search_source.filename)
+            self.logger.debug("Validate SearchFile %s", self.search_source.filename)
 
     def get_search_word(self) -> str:
         """
@@ -127,8 +126,8 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         if self.search_word is not None:
             return self.search_word
 
-        if "query" in (self.search_source.search_parameters or {}):
-            self.search_word = self.search_source.search_parameters["query"]
+        if "query" in (self.search_source.search_string or {}):
+            self.search_word = self.search_source.search_string["query"]
             self.logger.debug(
                 "Using query from search_parameters: %s", self.search_word
             )
@@ -219,7 +218,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
-        source: colrev.settings.SearchSource,
+        source: search_query.SearchFile,
     ) -> colrev.record.record_prep.PrepRecord:
         """Map fields to standardized fields for CoLRev (matching interface signature)."""
         return record

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -72,9 +72,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
     @classmethod
-    def add_endpoint(
-        cls, operation: Search, params: str
-    ) -> search_query.SearchFile:
+    def add_endpoint(cls, operation: Search, params: str) -> search_query.SearchFile:
         """Adds Prospero as a search source endpoint based on user-provided parameters."""
         if len(params) == 0:
             search_source = operation.create_api_source(platform=cls.endpoint)

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: PsycINFO"""
 from __future__ import annotations
+import search_query
 
 import logging
 from pathlib import Path
@@ -66,7 +67,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -189,7 +190,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for PsycINFO"""
 

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: PsycINFO"""
 from __future__ import annotations
-import search_query
 
 import logging
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: Pubmed"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
@@ -12,6 +11,7 @@ from urllib.parse import urlparse
 
 import pandas as pd
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: Scopus"""
 from __future__ import annotations
-import search_query
 
 import logging
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.loader.bib

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Scopus"""
 from __future__ import annotations
+import search_query
 
 import logging
 from pathlib import Path
@@ -68,7 +69,7 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -180,7 +181,7 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Scopus"""
 

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: Semantic Scholar"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
@@ -10,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+import search_query
 from pydantic import Field
 from semanticscholar import SemanticScholar
 from semanticscholar import SemanticScholarException

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Semantic Scholar"""
 from __future__ import annotations
+import search_query
 
 import logging
 import typing
@@ -24,7 +25,6 @@ import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.process.operation
 import colrev.record.record
-import colrev.settings
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
@@ -84,11 +84,11 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             # Semantic Scholar as a search source
             self.search_source = settings
         else:
-            self.search_source = colrev.settings.SearchSource(
-                endpoint="colrev.semanticscholar",
-                filename=self._s2_filename,
+            self.search_source = search_query.SearchFile(
+                platform="colrev.semanticscholar",
+                filepath=self._s2_filename,
                 search_type=SearchType.API,
-                search_parameters={},
+                search_string={},
                 comment="",
             )
             self.s2_lock = Lock()
@@ -293,7 +293,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         if rerun:
             self.logger.info("Performing a search of the full history (may take time)")
         try:
-            params = self.search_source.search_parameters
+            params = self.search_source.search_string
             _search_return = self._get_semantic_scholar_api(params=params, rerun=rerun)
 
         except SemanticScholarException.BadQueryParametersException as exc:
@@ -331,7 +331,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         # get search parameters from the user interface
@@ -363,11 +363,11 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         filename = operation.get_unique_filename(file_path_string="semanticscholar")
 
-        search_source = colrev.settings.SearchSource(
-            endpoint="colrev.semanticscholar",
-            filename=filename,
+        search_source = search_query.SearchFile(
+            platform="colrev.semanticscholar",
+            filepath=filename,
             search_type=SearchType.API,
-            search_parameters=search_params,
+            search_string=search_params,
             comment="",
         )
         operation.add_source_and_search(search_source)
@@ -410,7 +410,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
-        source: colrev.settings.SearchSource,
+        source: search_query.SearchFile,
     ) -> colrev.record.record_prep.PrepRecord:
         """Source-specific preparation for Semantic Scholar"""
         # Not yet implemented

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Springer Link"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -19,7 +20,6 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
-import colrev.settings
 from colrev.constants import Colors
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
@@ -85,7 +85,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -101,17 +101,17 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         elif search_type == SearchType.API:
             filename = operation.get_unique_filename(file_path_string="springer_link")
-            search_source = colrev.settings.SearchSource(
-                endpoint=cls.endpoint,
-                filename=filename,
+            search_source = search_query.SearchFile(
+                platform=cls.endpoint,
+                filepath=filename,
                 search_type=SearchType.API,
-                search_parameters={},
+                search_string={},
                 comment="",
             )
             params_dict.update(vars(search_source))
             instance = cls(source_operation=operation, settings=params_dict)
             instance.api_ui()
-            search_source.search_parameters = instance._add_constraints()
+            search_source.search_string = instance._add_constraints()
 
         else:
             raise NotImplementedError
@@ -284,7 +284,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     def get_query_return(self) -> typing.Iterator[colrev.record.record.Record]:
         """Get the records from a API search"""
-        query = self.build_query(self.search_source.search_parameters)
+        query = self.build_query(self.search_source.search_string)
         api_key = self.get_api_key()
         start = 1
 
@@ -546,7 +546,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Springer Link"""
 

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: Springer Link"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
@@ -13,6 +12,7 @@ from typing import Optional
 import inquirer
 import pandas as pd
 import requests
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: SYNERGY-datasets"""
 from __future__ import annotations
-import search_query
 
 import datetime
 import logging
@@ -12,6 +11,7 @@ from typing import Optional
 
 import inquirer
 import pandas as pd
+import search_query
 from git import Repo
 from pydantic import Field
 

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: SYNERGY-datasets"""
 from __future__ import annotations
+import search_query
 
 import datetime
 import logging
@@ -123,7 +124,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {}
@@ -141,11 +142,11 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         filename = operation.get_unique_filename(
             file_path_string=f"SYNERGY_{dataset.replace('/', '_').replace('_ids.csv', '')}"
         )
-        search_source = colrev.settings.SearchSource(
-            endpoint="colrev.synergy_datasets",
-            filename=filename,
+        search_source = search_query.SearchFile(
+            platform="colrev.synergy_datasets",
+            filepath=filename,
             search_type=SearchType.API,
-            search_parameters={"dataset": dataset},
+            search_string={"dataset": dataset},
             comment="",
         )
         operation.add_source_and_search(search_source)
@@ -158,7 +159,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         Repo.clone_from(
             "https://github.com/asreview/synergy-dataset", temp_path, depth=1
         )
-        dataset_name = self.search_source.search_parameters["dataset"]
+        dataset_name = self.search_source.search_string["dataset"]
         dataset_df = pd.read_csv(temp_path / Path("datasets") / dataset_name)
 
         # check data structure
@@ -372,7 +373,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for SYNERGY-datasets"""
 

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Taylor and Francis"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -59,7 +60,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -124,7 +125,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Taylor and Francis"""
 

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: Taylor and Francis"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Transport Research International Documentation"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -64,7 +65,7 @@ class TransportResearchInternationalDocumentation(
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -211,7 +212,7 @@ class TransportResearchInternationalDocumentation(
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Transport Research International Documentation"""
 

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: Transport Research International Documentation"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Unknown source (default for all other sources)"""
 from __future__ import annotations
+import search_query
 
 import logging
 import re
@@ -78,7 +79,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {}
@@ -769,7 +770,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
-        source: colrev.settings.SearchSource,
+        source: search_query.SearchFile,
     ) -> colrev.record.record.Record:
         """Source-specific preparation for unknown sources"""
 

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """SearchSource: Unknown source (default for all other sources)"""
 from __future__ import annotations
-import search_query
 
 import logging
 import re
@@ -9,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
+import search_query
 from pydantic import Field
 from rapidfuzz import fuzz
 

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 """SearchSource: Unpaywall"""
 from __future__ import annotations
-import search_query
 
 import logging
 import typing
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Unpaywall"""
 from __future__ import annotations
+import search_query
 
 import logging
 import typing
@@ -51,11 +52,11 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
             # Unpaywall as a search_source
             self.search_source = settings
         else:
-            self.search_source = colrev.settings.SearchSource(
-                endpoint=self.endpoint,
-                filename=Path("data/search/unpaywall.bib"),
+            self.search_source = search_query.SearchFile(
+                platform=self.endpoint,
+                filepath=Path("data/search/unpaywall.bib"),
                 search_type=SearchType.API,
-                search_parameters={},
+                search_string={},
                 comment="",
             )
 
@@ -68,7 +69,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
     @classmethod
     def add_endpoint(
         cls, operation: colrev.ops.search.Search, params: str
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search -a )"""
 
         params_dict = {}
@@ -81,7 +82,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
                     params_dict[key] = value
 
         if len(params_dict) == 0:
-            search_source = operation.create_api_source(endpoint=cls.endpoint)
+            search_source = operation.create_api_source(platform=cls.endpoint)
 
         # pylint: disable=colrev-missed-constant-usage
         elif "https://api.unpaywall.org/v2/search" in params_dict["url"]:
@@ -106,11 +107,11 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
                 )
             )
 
-            search_source = colrev.settings.SearchSource(
-                endpoint=cls.endpoint,
-                filename=filename,
+            search_source = search_query.SearchFile(
+                platform=cls.endpoint,
+                filepath=filename,
                 search_type=SearchType.API,
-                search_parameters=search_parameters,
+                search_string=search_parameters,
                 comment="",
             )
         else:
@@ -125,7 +126,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         self, *, unpaywall_feed: colrev.ops.search_api_feed.SearchAPIFeed, rerun: bool
     ) -> None:
 
-        api = UnpaywallAPI(self.search_source.search_parameters)
+        api = UnpaywallAPI(self.search_source.search_string)
         for record in api.get_query_records():
             unpaywall_feed.add_update_record(record)
 
@@ -170,7 +171,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         return record
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Unpaywall"""
         return record

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Web of Science"""
 from __future__ import annotations
+import search_query
 
 import logging
 from pathlib import Path
@@ -79,7 +80,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -168,7 +169,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
-        source: colrev.settings.SearchSource,
+        source: search_query.SearchFile,
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Web of Science"""
 

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: Web of Science"""
 from __future__ import annotations
-import search_query
 
 import logging
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
 """SearchSource: Wiley"""
 from __future__ import annotations
-import search_query
 
 import logging
 from pathlib import Path
 from typing import Optional
 
+import search_query
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """SearchSource: Wiley"""
 from __future__ import annotations
+import search_query
 
 import logging
 from pathlib import Path
@@ -62,7 +63,7 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         cls,
         operation: colrev.ops.search.Search,
         params: str,
-    ) -> colrev.settings.SearchSource:
+    ) -> search_query.SearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -115,7 +116,7 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         raise NotImplementedError
 
     def prepare(
-        self, record: colrev.record.record.Record, source: colrev.settings.SearchSource
+        self, record: colrev.record.record.Record, source: search_query.SearchFile
     ) -> colrev.record.record.Record:
         """Source-specific preparation for Wiley"""
 


### PR DESCRIPTION
## Summary
- ensure new `search_query.SearchFile` instances use `filepath` while keeping `load()` implementations untouched
- update remaining Prospero search source to use `search_query.SearchFile`

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}' | tr '\n' ' ')` *(failed: CONNECT tunnel failed 403)*
- `pip install -e .` *(failed: Could not find a version that satisfies the requirement hatchling (403 Forbidden))*
- `pytest` *(failed: ModuleNotFoundError: No module named 'colrev')*

------
https://chatgpt.com/codex/tasks/task_e_689223af7f54832a812a68ba772e68a7