### PR TITLE
refactor package availability checks

### DIFF
--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -39,6 +39,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
     db_url = "https://arxiv.org/"
     _arxiv_md_filename = Path("data/search/md_arxiv.bib")
+    _availability_exception_message = "ArXiv"
 
     def __init__(
         self,
@@ -131,36 +132,19 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
 
         self.logger.debug(f"SearchSource {source.filename} validated")
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check status (availability) of the ArXiv API"""
 
-        # try:
-        #     # pylint: disable=duplicate-code
-        #     test_rec = {
-        #         "author": "Wang, R E and Demszky, D ",
-        #         "title": "Is ChatGPT a Good Teacher Coach?"
-        #         "Measuring Zero-Shot Performance For Scoring and Providing "
-        #           + \ "Actionable Insights on Classroom Instruction ",
-        #         "ENTRYTYPE": "article",  # might not be needed in ArXiv
-        #         "arxivid": "arXiv:2306.03090",
-        #     }
-        #     returned_record_dict = self._arxiv_query_id(
-        #         arxiv_id=test_rec["arxivid"],
-        #         timeout=20,
-        #     )
-
-        #     if returned_record_dict:
-        #         assert returned_record_dict["title"] == test_rec["title"]
-        #         assert returned_record_dict["author"] == test_rec["author"]
-        #     else:
-        #         if not source_operation.force_mode:
-        #             raise colrev_exceptions.ServiceNotAvailableException("ArXiv")
-        # except (requests.exceptions.RequestException, IndexError) as exc:
-        #     print(exc)
-        #     if not source_operation.force_mode:
-        #         raise colrev_exceptions.ServiceNotAvailableException("ArXiv") from exc
+        try:
+            ret = requests.get(
+                "https://export.arxiv.org/api/query?search_query=all:electron&start=0&max_results=1",
+                timeout=30,
+            )
+            ret.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            raise colrev_exceptions.ServiceNotAvailableException(
+                self._availability_exception_message
+            ) from exc
 
     # def _arxiv_query_id(
     #     self,

--- a/colrev/packages/crossref/src/crossref_prep.py
+++ b/colrev/packages/crossref/src/crossref_prep.py
@@ -75,11 +75,9 @@ class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.endpoint == "colrev.crossref"
         ]
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check status (availability) of the Crossref API"""
-        self.crossref_source.check_availability(source_operation=source_operation)
+        self.crossref_source.check_availability()
 
     def prepare(
         self, record: colrev.record.record_prep.PrepRecord

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -158,13 +158,8 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         operation.add_source_and_search(search_source)
         return search_source
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check status (availability) of DBLP API"""
-        if self.review_manager.force_mode:
-            return
-
         api = dblp_api.DBLPAPI(
             params={},
             email=self.email,

--- a/colrev/packages/dblp/src/dblp_api.py
+++ b/colrev/packages/dblp/src/dblp_api.py
@@ -26,6 +26,7 @@ class DBLPAPI:
 
     url = ""
     _batch_next = False
+    _availability_exception_message = "DBLP"
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -79,9 +80,13 @@ class DBLPAPI:
                 assert dblp_record.data[Fields.TITLE] == test_rec[Fields.TITLE]
                 assert dblp_record.data[Fields.AUTHOR] == test_rec[Fields.AUTHOR]
             else:
-                raise colrev_exceptions.ServiceNotAvailableException("DBLP")
-        except requests.exceptions.RequestException as exc:
-            raise colrev_exceptions.ServiceNotAvailableException("DBLP") from exc
+                raise colrev_exceptions.ServiceNotAvailableException(
+                    self._availability_exception_message
+                )
+        except (requests.exceptions.RequestException, IndexError) as exc:
+            raise colrev_exceptions.ServiceNotAvailableException(
+                self._availability_exception_message
+            ) from exc
 
     def _get_dblp_venue(
         self,

--- a/colrev/packages/dblp/src/dblp_metadata_prep.py
+++ b/colrev/packages/dblp/src/dblp_metadata_prep.py
@@ -72,11 +72,9 @@ class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.endpoint == "colrev.dblp"
         ]
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
-        """Check status (availability) of the Crossref API"""
-        self.dblp_source.check_availability(source_operation=source_operation)
+    def check_availability(self) -> None:
+        """Check status (availability) of the DBLP API"""
+        self.dblp_source.check_availability()
 
     def prepare(
         self, record: colrev.record.record_prep.PrepRecord

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -11,6 +11,7 @@ import requests
 from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
+import colrev.env.environment_manager
 import colrev.ops.search_api_feed
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
@@ -32,6 +33,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     ci_supported: bool = Field(default=True)
     heuristic_status = SearchSourceHeuristicStatus.oni
+    _availability_exception_message = "OpenAlex"
 
     def __init__(
         self,
@@ -69,10 +71,23 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
             f"Cannot add OpenAlex endpoint with query {params}"
         )
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check status (availability) of the OpenAlex API"""
+
+        try:
+            _, email = (
+                colrev.env.environment_manager.EnvironmentManager.get_name_mail_from_git()
+            )
+            api = open_alex_api.OpenAlexAPI(email=email)
+            retrieved_record = api.get_record(open_alex_id="W2741809807")
+            if not retrieved_record.data:
+                raise colrev_exceptions.ServiceNotAvailableException(
+                    self._availability_exception_message
+                )
+        except (requests.exceptions.RequestException, KeyError) as exc:
+            raise colrev_exceptions.ServiceNotAvailableException(
+                self._availability_exception_message
+            ) from exc
 
     def _get_masterdata_record(
         self, *, record: colrev.record.record.Record

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -10,8 +10,8 @@ from typing import Optional
 import requests
 from pydantic import Field
 
-import colrev.exceptions as colrev_exceptions
 import colrev.env.environment_manager
+import colrev.exceptions as colrev_exceptions
 import colrev.ops.search_api_feed
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record

--- a/colrev/packages/open_alex/src/open_alex_metadata_prep.py
+++ b/colrev/packages/open_alex/src/open_alex_metadata_prep.py
@@ -68,11 +68,9 @@ class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.endpoint == "colrev.open_alex"
         ]
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check status (availability) of the OpenAlex API"""
-        self.open_alex_source.check_availability(source_operation=source_operation)
+        self.open_alex_source.check_availability()
 
     def prepare(
         self, record: colrev.record.record_prep.PrepRecord

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -40,6 +40,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
     ci_supported: bool = Field(default=True)
     heuristic_status = SearchSourceHeuristicStatus.na
+    _availability_exception_message = "OPENLIBRARY"
 
     requests_headers = {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) "
@@ -63,9 +64,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         self.origin_prefix = self.search_source.get_origin_prefix()
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check the status (availability) of the OpenLibrary API"""
 
         test_rec = {
@@ -84,13 +83,13 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 timeout=30,
             )
             if ret.status_code != 200:
-                if not self.review_manager.force_mode:
-                    raise colrev_exceptions.ServiceNotAvailableException("OPENLIBRARY")
-        except requests.exceptions.RequestException as exc:
-            if not self.review_manager.force_mode:
                 raise colrev_exceptions.ServiceNotAvailableException(
-                    "OPENLIBRARY"
-                ) from exc
+                    self._availability_exception_message
+                )
+        except requests.exceptions.RequestException as exc:
+            raise colrev_exceptions.ServiceNotAvailableException(
+                self._availability_exception_message
+            ) from exc
 
     # pylint: disable=colrev-missed-constant-usage
     @classmethod

--- a/colrev/packages/open_library/src/open_library_prep.py
+++ b/colrev/packages/open_library/src/open_library_prep.py
@@ -62,13 +62,9 @@ class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
             source_operation=prep_operation, settings=search_source
         )
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
-        """Check status (availability) of the Crossref API"""
-        self.open_library_connector.check_availability(
-            source_operation=source_operation
-        )
+    def check_availability(self) -> None:
+        """Check status (availability) of the OpenLibrary API"""
+        self.open_library_connector.check_availability()
 
     def prepare(
         self, record: colrev.record.record_prep.PrepRecord

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -46,6 +46,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
     heuristic_status = SearchSourceHeuristicStatus.supported
 
     db_url = "https://pubmed.ncbi.nlm.nih.gov/"
+    _availability_exception_message = "Pubmed"
 
     def __init__(
         self,
@@ -163,9 +164,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         self.logger.debug("SearchSource %s validated", source.filename)
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check status (availability) of the Pubmed API"""
 
         try:
@@ -190,12 +189,13 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
                 assert returned_record.data[Fields.TITLE] == test_rec[Fields.TITLE]
                 assert returned_record.data[Fields.AUTHOR] == test_rec[Fields.AUTHOR]
             else:
-                if not self.review_manager.force_mode:
-                    raise colrev_exceptions.ServiceNotAvailableException("Pubmed")
+                raise colrev_exceptions.ServiceNotAvailableException(
+                    self._availability_exception_message
+                )
         except (requests.exceptions.RequestException, IndexError, KeyError) as exc:
-            print(exc)
-            if not self.review_manager.force_mode:
-                raise colrev_exceptions.ServiceNotAvailableException("Pubmed") from exc
+            raise colrev_exceptions.ServiceNotAvailableException(
+                self._availability_exception_message
+            ) from exc
 
     def _get_masterdata_record(
         self,

--- a/colrev/packages/pubmed/src/pubmed_metadata_prep.py
+++ b/colrev/packages/pubmed/src/pubmed_metadata_prep.py
@@ -71,11 +71,9 @@ class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.endpoint == "colrev.pubmed"
         ]
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check status (availability) of the Pubmed API"""
-        self.pubmed_source.check_availability(source_operation=source_operation)
+        self.pubmed_source.check_availability()
 
     def prepare(
         self, record: colrev.record.record_prep.PrepRecord

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -88,9 +88,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
             self.s2_lock = Lock()
 
-    def check_availability(
-        self, *, source_operation: colrev.process.operation.Operation
-    ) -> None:
+    def check_availability(self) -> None:
         """Check the availability of the Semantic Scholar API"""
 
         try:
@@ -109,16 +107,13 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
                 assert returned_record[Fields.TITLE] == test_record[Fields.TITLE]
                 assert returned_record[Fields.URL] == test_record[Fields.URL]
             else:
-                if not self.review_manager.force_mode:
-                    raise colrev_exceptions.ServiceNotAvailableException(
-                        self._availability_exception_message
-                    )
-        except (requests.exceptions.RequestException, IndexError) as exc:
-            print(exc)
-            if not self.review_manager.force_mode:
                 raise colrev_exceptions.ServiceNotAvailableException(
                     self._availability_exception_message
-                ) from exc
+                )
+        except (requests.exceptions.RequestException, IndexError) as exc:
+            raise colrev_exceptions.ServiceNotAvailableException(
+                self._availability_exception_message
+            ) from exc
 
     def _get_semantic_scholar_api(
         self, *, params: dict, rerun: bool


### PR DESCRIPTION
## Summary
- decouple package availability checks from operations
- raise ServiceNotAvailableException on API failures

## Testing
- `pre-commit run --files colrev/packages/arxiv/src/arxiv.py colrev/packages/crossref/src/crossref_prep.py colrev/packages/dblp/src/dblp.py colrev/packages/dblp/src/dblp_api.py colrev/packages/dblp/src/dblp_metadata_prep.py colrev/packages/open_alex/src/open_alex.py colrev/packages/open_alex/src/open_alex_metadata_prep.py colrev/packages/open_library/src/open_library.py colrev/packages/open_library/src/open_library_prep.py colrev/packages/pubmed/src/pubmed.py colrev/packages/pubmed/src/pubmed_metadata_prep.py colrev/packages/semanticscholar/src/semanticscholar_search_source.py` (failed: unable to access 'https://github.com/pre-commit/pre-commit-hooks/')
- `pip install -e .` (failed: Could not find a version that satisfies the requirement hatchling)
- `PYTHONPATH=$PWD pytest` (failed: PackageNotFoundError: No package metadata was found for colrev)

------
https://chatgpt.com/codex/tasks/task_e_6896ffee5884832a8caa6e1c89355b1d