### PR TITLE
refactor: rename search source settings param

### DIFF
--- a/colrev/ops/load.py
+++ b/colrev/ops/load.py
@@ -440,7 +440,7 @@ class Load(colrev.process.operation.Operation):
                 )
                 endpoint = search_source_class(
                     source_operation=self,
-                    settings=source,
+                    search_file=source,
                 )
 
                 s_type = source.search_type  # type: ignore

--- a/colrev/ops/push.py
+++ b/colrev/ops/push.py
@@ -103,7 +103,7 @@ class Push(colrev.process.operation.Operation):
                 package_identifier=source.endpoint,
             )
             endpoint = search_source_class(
-                source_operation=self, settings=source.get_dict()
+                source_operation=self, search_file=source.get_dict()
             )
 
             correct_function = getattr(endpoint, "apply_correction", None)

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -518,7 +518,7 @@ class Search(colrev.process.operation.Operation):
                     package_type=EndpointType.search_source,
                     package_identifier=source.platform,
                 )
-                endpoint = search_source_class(source_operation=self, settings=source)
+                endpoint = search_source_class(source_operation=self, search_file=source)
 
                 endpoint.search(rerun=rerun)  # type: ignore
 

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -518,7 +518,9 @@ class Search(colrev.process.operation.Operation):
                     package_type=EndpointType.search_source,
                     package_identifier=source.platform,
                 )
-                endpoint = search_source_class(source_operation=self, search_file=source)
+                endpoint = search_source_class(
+                    source_operation=self, search_file=source
+                )
 
                 endpoint.search(rerun=rerun)  # type: ignore
 

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -78,7 +78,7 @@ class SearchSourcePackageBaseClass(ABC):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -37,12 +37,12 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
         self.quality_model = self.review_manager.get_qm()
 

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -35,11 +35,11 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.operation = source_operation
 
     @classmethod

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -69,13 +69,13 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
-        self.search_source = settings
+        self.search_source = search_file
         self.review_manager = source_operation.review_manager
         self.quality_model = self.review_manager.get_qm()
         self.source_operation = source_operation

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -45,14 +45,14 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
 
         self.arxiv_lock = Lock()
 

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -43,13 +43,13 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
-        self.search_source = settings
+        self.search_source = search_file
         self.review_manager = source_operation.review_manager
 
     # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/crossref/src/crossref_prep.py
+++ b/colrev/packages/crossref/src/crossref_prep.py
@@ -54,9 +54,9 @@ class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.search_history_path == crossref_md_filename
         ]
         if crossref_md_source_l:
-            settings = crossref_md_source_l[0]
+            search_file = crossref_md_source_l[0]
         else:
-            settings = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.crossref",
                 search_results_path=crossref_md_filename,
                 search_type=SearchType.MD,
@@ -66,7 +66,7 @@ class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
 
         self.crossref_source = crossref_connector.CrossrefSearchSource(
             source_operation=prep_operation,
-            settings=settings,
+            search_file=search_file,
         )
 
         self.crossref_prefixes = [

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -56,7 +56,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -64,7 +64,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.verbose_mode = verbose_mode
 
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
         self.crossref_lock = Lock()
         self.language_service = colrev.env.language_service.LanguageService()
 

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -74,14 +74,14 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
         self.dblp_lock = Lock()
         self.origin_prefix = self.search_source.get_origin_prefix()
         _, self.email = self.review_manager.get_committer()

--- a/colrev/packages/dblp/src/dblp_metadata_prep.py
+++ b/colrev/packages/dblp/src/dblp_metadata_prep.py
@@ -52,9 +52,9 @@ class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.filename == dblp_md_filename
         ]
         if dblp_md_source_l:
-            settings = dblp_md_source_l[0]
+            search_file = dblp_md_source_l[0]
         else:
-            settings = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.dblp",
                 search_results_path=dblp_md_filename,
                 search_type=SearchType.MD,
@@ -63,7 +63,7 @@ class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
             )
 
         self.dblp_source = dblp_connector.DBLPSearchSource(
-            source_operation=prep_operation, settings=settings
+            source_operation=prep_operation, search_file=search_file
         )
 
         self.dblp_prefixes = [

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -39,11 +39,11 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
 
     @classmethod

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -41,7 +41,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -50,7 +50,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.source_operation = source_operation
         if settings:
             # ERIC as a search_source
-            self.search_source = settings
+            self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
                 platform=self.endpoint,

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -71,14 +71,14 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
         self.europe_pmc_lock = Lock()
         self.source_operation = source_operation
 

--- a/colrev/packages/europe_pmc/src/europe_pmc_prep.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc_prep.py
@@ -49,9 +49,9 @@ class EuropePMCMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.filename == self._europe_pmc_md_filename
         ]
         if europe_pmc_md_source_l:
-            settings = europe_pmc_md_source_l[0]
+            search_file = europe_pmc_md_source_l[0]
         else:
-            settings = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.europe_pmc",
                 search_results_path=self._europe_pmc_md_filename,
                 search_type=SearchType.MD,
@@ -61,7 +61,7 @@ class EuropePMCMetadataPrep(base_classes.PrepPackageBaseClass):
 
         self.epmc_source = europe_pmc_connector.EuropePMCSearchSource(
             source_operation=self.prep_operation,
-            settings=settings,
+            search_file=search_file,
         )
 
     def prepare(

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -56,7 +56,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -66,7 +66,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.source_operation = source_operation
 
         # TODO : files_dir: subdir_pattern etc. should be prep_parameters
-        self.search_source = settings
+        self.search_source = search_file
 
         if not self.review_manager.in_ci_environment():
             self.pdf_preparation_operation = self.review_manager.get_pdf_prep_operation(

--- a/colrev/packages/github/src/github_prep.py
+++ b/colrev/packages/github/src/github_prep.py
@@ -52,9 +52,9 @@ class GithubMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.filename == self._github_md_filename
         ]
         if github_md_source_l:
-            settings = github_md_source_l[0]
+            search_file = github_md_source_l[0]
         else:
-            settings = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.github",
                 search_results_path=self._github_md_filename,
                 search_type=SearchType.MD,
@@ -63,7 +63,7 @@ class GithubMetadataPrep(base_classes.PrepPackageBaseClass):
             )
 
         self.github_search_source = github_connector.GitHubSearchSource(
-            source_operation=self.prep_operation, settings=settings
+            source_operation=self.prep_operation, search_file=search_file
         )
 
     def prepare(

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -58,13 +58,13 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
-        self.search_source = settings
+        self.search_source = search_file
         self.github_lock = Lock()
 
     @classmethod

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -36,11 +36,11 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
 
     @classmethod

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -47,7 +47,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -56,7 +56,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.review_manager = source_operation.review_manager
 
         if settings:
-            self.search_source = settings
+            self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
                 platform=self.endpoint,

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -36,11 +36,11 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.operation = source_operation
 
     @classmethod

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -64,14 +64,14 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
 
         self.local_index_lock = Lock()
 

--- a/colrev/packages/local_index/src/local_index_prep.py
+++ b/colrev/packages/local_index/src/local_index_prep.py
@@ -54,9 +54,9 @@ class LocalIndexPrep(base_classes.PrepPackageBaseClass):
             if s.filename == self._local_index_md_filename
         ]
         if li_md_source_l:
-            settings = li_md_source_l[0]
+            search_file = li_md_source_l[0]
         else:
-            settings = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.local_index",
                 search_results_path=self._local_index_md_filename,
                 search_type=SearchType.MD,
@@ -66,7 +66,7 @@ class LocalIndexPrep(base_classes.PrepPackageBaseClass):
 
         self.local_index_source = local_index_connector.LocalIndexSearchSource(
             source_operation=prep_operation,
-            settings=settings,
+            search_file=search_file,
         )
         self.prep_operation = prep_operation
 

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -39,7 +39,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -47,7 +47,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
 
-        self.search_source = settings
+        self.search_source = search_file
 
         self.open_alex_lock = Lock()
 

--- a/colrev/packages/open_alex/src/open_alex_metadata_prep.py
+++ b/colrev/packages/open_alex/src/open_alex_metadata_prep.py
@@ -48,9 +48,9 @@ class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.filename == self._open_alex_md_filename
         ]
         if open_alex_md_source_l:
-            settings = open_alex_md_source_l[0]
+            search_file = open_alex_md_source_l[0]
         else:
-            settings = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.open_alex",
                 search_results_path=self._open_alex_md_filename,
                 search_type=SearchType.MD,
@@ -59,7 +59,7 @@ class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
             )
 
         self.open_alex_source = open_alex_connector.OpenAlexSearchSource(
-            source_operation=prep_operation, settings=settings
+            source_operation=prep_operation, search_file=search_file
         )
 
         self.open_alex_prefixes = [

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -42,13 +42,13 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
-        self.search_source = settings
+        self.search_source = search_file
         self.review_manager = source_operation.review_manager
         self.crossref_api = crossref_api.CrossrefAPI(url="")
 

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -51,14 +51,14 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
 
         self.open_library_lock = Lock()
 

--- a/colrev/packages/open_library/src/open_library_prep.py
+++ b/colrev/packages/open_library/src/open_library_prep.py
@@ -48,9 +48,9 @@ class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.filename == self._open_library_md_filename
         ]
         if open_library_md_source_l:
-            search_source = open_library_md_source_l[0]
+            search_file = open_library_md_source_l[0]
         else:
-            search_source = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.open_library",
                 search_results_path=self._open_library_md_filename,
                 search_type=SearchType.MD,
@@ -59,7 +59,7 @@ class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
             )
 
         self.open_library_connector = open_library_connector.OpenLibrarySearchSource(
-            source_operation=prep_operation, settings=search_source
+            source_operation=prep_operation, search_file=search_file
         )
 
     def check_availability(self) -> None:

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -46,7 +46,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -55,7 +55,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.review_manager = source_operation.review_manager
 
         if settings:
-            self.search_source = settings
+            self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
                 platform=self.endpoint,

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -56,7 +56,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -66,7 +66,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         if "min_intext_citations" not in settings["search_string"]:
             settings["search_string"]["min_intext_citations"] = 3
 
-        self.search_source = settings
+        self.search_source = search_file
         self.crossref_api = crossref_api.CrossrefAPI(url="")
 
     @classmethod
@@ -488,7 +488,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         return all_references
 
     @classmethod
-    def _get_settings_from_ui(
+    def _get_params_from_ui(
         cls, *, params: dict, review_manager: colrev.review_manager.ReviewManager
     ) -> None:
 
@@ -555,7 +555,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
                 params_dict[key] = value
 
         if "min_intext_citations" not in params_dict:
-            cls._get_settings_from_ui(
+            cls._get_params_from_ui(
                 params=params_dict, review_manager=operation.review_manager
             )
         else:

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -41,14 +41,14 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
         self.plos_lock = Lock()
         self.language_service = colrev.env.language_service.LanguageService()
 

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -41,7 +41,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -49,7 +49,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
-        self.search_source = settings
+        self.search_source = search_file
         self.search_word: typing.Optional[str] = None
 
     @classmethod

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -36,11 +36,11 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
 
     @classmethod

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -52,14 +52,14 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
 
         self.pubmed_lock = Lock()
 

--- a/colrev/packages/pubmed/src/pubmed_metadata_prep.py
+++ b/colrev/packages/pubmed/src/pubmed_metadata_prep.py
@@ -51,9 +51,9 @@ class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
             if s.filename == self._pubmed_md_filename
         ]
         if pubmed_md_source_l:
-            settings = pubmed_md_source_l[0]
+            search_file = pubmed_md_source_l[0]
         else:
-            settings = colrev.search_file.ExtendedSearchFile(
+            search_file = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.pubmed",
                 search_results_path=self._pubmed_md_filename,
                 search_type=SearchType.MD,
@@ -62,7 +62,7 @@ class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
             )
 
         self.pubmed_source = pubmed_connector.PubMedSearchSource(
-            source_operation=prep_operation, settings=settings
+            source_operation=prep_operation, search_file=search_file
         )
 
         self.pubmed_prefixes = [

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -39,11 +39,11 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.operation = source_operation
 
     @classmethod

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -68,7 +68,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -77,7 +77,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.review_manager = source_operation.review_manager
         if settings:
             # Semantic Scholar as a search source
-            self.search_source = settings
+            self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.semanticscholar",

--- a/colrev/packages/source_specific_prep/src/source_specific_prep.py
+++ b/colrev/packages/source_specific_prep/src/source_specific_prep.py
@@ -67,7 +67,7 @@ class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
                     package_type=EndpointType.search_source,
                     package_identifier=source.platform,
                 )
-                endpoint = search_source_class(source_operation=self, settings=source)
+                endpoint = search_source_class(source_operation=self, search_file=source)
 
                 if callable(endpoint.prepare):
                     record = endpoint.prepare(record, source)

--- a/colrev/packages/source_specific_prep/src/source_specific_prep.py
+++ b/colrev/packages/source_specific_prep/src/source_specific_prep.py
@@ -67,7 +67,9 @@ class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
                     package_type=EndpointType.search_source,
                     package_identifier=source.platform,
                 )
-                endpoint = search_source_class(source_operation=self, search_file=source)
+                endpoint = search_source_class(
+                    source_operation=self, search_file=source
+                )
 
                 if callable(endpoint.prepare):
                     record = endpoint.prepare(record, source)

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -107,9 +107,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
                 comment="",
             )
             # params_dict.update(vars(search_source))
-            instance = cls(
-                source_operation=operation, search_file=search_source
-            )
+            instance = cls(source_operation=operation, search_file=search_source)
             instance.api_ui()
             search_source.search_string = instance._add_constraints()
 

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -52,14 +52,14 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
         self.language_service = colrev.env.language_service.LanguageService()
 
@@ -107,7 +107,9 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
                 comment="",
             )
             # params_dict.update(vars(search_source))
-            instance = cls(source_operation=operation, settings=search_source)
+            instance = cls(
+                source_operation=operation, search_file=search_source
+            )
             instance.api_ui()
             search_source.search_string = instance._add_constraints()
 

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -54,14 +54,14 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.review_manager = source_operation.review_manager
-        self.search_source = settings
+        self.search_source = search_file
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -32,11 +32,11 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
 
     @classmethod

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -39,11 +39,11 @@ class TransportResearchInternationalDocumentation(
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
         self.review_manager = source_operation.review_manager
 

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -54,11 +54,11 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.review_manager = source_operation.review_manager
         self.language_service = colrev.env.language_service.LanguageService()
         self.operation = source_operation

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -39,7 +39,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
@@ -48,7 +48,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if settings:
             # Unpaywall as a search_source
-            self.search_source = settings
+            self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
                 platform=self.endpoint,

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -36,11 +36,11 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
 
     @classmethod

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -34,11 +34,11 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         *,
         source_operation: colrev.process.operation.Operation,
-        settings: colrev.search_file.ExtendedSearchFile,
+        search_file: colrev.search_file.ExtendedSearchFile,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-        self.search_source = settings
+        self.search_source = search_file
         self.source_operation = source_operation
 
     @classmethod

--- a/colrev/ui_cli/detect_and_add_source.py
+++ b/colrev/ui_cli/detect_and_add_source.py
@@ -74,7 +74,7 @@ class CLISourceAdder:
         )
         endpoint = search_source_class(
             source_operation=self,
-            settings=candidate.model_dump(),
+            search_file=candidate.model_dump(),
         )
 
         params = f"search_file={filename}"

--- a/tests/2_ops/search_operation_test.py
+++ b/tests/2_ops/search_operation_test.py
@@ -62,7 +62,7 @@ def test_search_add_source(  # type: ignore
     )
 
     endpoint = search_source_class(
-        source_operation=search_operation, settings=add_source
+        source_operation=search_operation, search_file=add_source
     )
     query = "issn=1234-5678"
     endpoint.add_endpoint(search_operation, query)  # type: ignore

--- a/tests/data/package_init/search_source.py
+++ b/tests/data/package_init/search_source.py
@@ -10,7 +10,7 @@ from colrev.package_manager.package_base_classes import SearchSourcePackageBaseC
 
 class CustomName(SearchSourcePackageBaseClass):
 
-    def __init__(self, *, source_operation: 'colrev.process.operation.Operation', settings: 'colrev.search_file.ExtendedSearchFile', logger: 'Optional[logging.Logger]' = None, verbose_mode: 'bool' = False) -> 'None':
+    def __init__(self, *, source_operation: 'colrev.process.operation.Operation', search_file: 'colrev.search_file.ExtendedSearchFile', logger: 'Optional[logging.Logger]' = None, verbose_mode: 'bool' = False) -> 'None':
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def prep_link_md(self, prep_operation: 'colrev.ops.prep.Prep', record: 'colrev.record.record.Record', save_feed: 'bool' = True, timeout: 'int' = 10) -> 'colrev.record.record.Record':


### PR DESCRIPTION
## Summary
- rename `settings` parameter to `search_file` in search source packages
- update SearchSourcePackageBaseClass and related call sites for `search_file`

## Testing
- `pre-commit run --files $(git ls-files -m)` *(fails: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'colrev')*

------
https://chatgpt.com/codex/tasks/task_e_68971ca7b74c832ab1948775bdac978b