### PR TITLE
refactor: centralize CI environment detection

### DIFF
--- a/colrev/env/tei_parser.py
+++ b/colrev/env/tei_parser.py
@@ -70,7 +70,7 @@ class TEIParser:
         if pdf_path is not None and not load_from_tei:
             # TODO / TBD:
             # Do not run in continuous-integration environment
-            # if not self.review_manager.in_ci_environment():
+            # if not utils.in_ci_environment():
             grobid_service = colrev.env.grobid_service.GrobidService()
             grobid_service.start()
             self._create_tei()

--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -13,7 +13,7 @@ import yaml
 from git.exc import InvalidGitRepositoryError
 
 import colrev.exceptions as colrev_exceptions
-import colrev.utils
+from colrev import utils
 from colrev.constants import ExitCodes
 from colrev.constants import Fields
 from colrev.constants import OperationsType
@@ -146,7 +146,7 @@ class Checker:
                 f"missing hooks in .pre-commit-config.yaml ({', '.join(missing_hooks)})"
             )
 
-        if not self.review_manager.in_ci_environment():
+        if not utils.in_ci_environment():
             pch_file = Path(".git/hooks/pre-commit")
             if pch_file.is_file():
                 with open(pch_file, encoding="utf8") as file:
@@ -706,7 +706,7 @@ class Checker:
             ):
                 prior = self._retrieve_prior()
                 self.review_manager.logger.debug("prior")
-                self.review_manager.logger.debug(colrev.utils.pformat(prior))
+                self.review_manager.logger.debug(utils.pformat(prior))
             else:  # if RECORDS_FILE not yet in git history
                 prior = {}
 

--- a/colrev/ops/data.py
+++ b/colrev/ops/data.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import colrev.env.tei_parser
 import colrev.packages.grobid_tei.src.grobid_tei
 import colrev.process.operation
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
@@ -188,7 +189,7 @@ class Data(colrev.process.operation.Operation):
             self.review_manager.logger.info(
                 f"{Colors.GREEN}Completed data operation{Colors.END}"
             )
-        if self.review_manager.in_ci_environment():
+        if utils.in_ci_environment():
             print("\n\n")
 
     @colrev.process.operation.Operation.decorate()

--- a/colrev/ops/pdf_get.py
+++ b/colrev/ops/pdf_get.py
@@ -11,6 +11,7 @@ import colrev.env.tei_parser
 import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.record.record_pdf
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
@@ -629,7 +630,7 @@ class PDFGet(colrev.process.operation.Operation):
         """Get PDFs (main entrypoint)"""
 
         if (
-            self.review_manager.in_ci_environment()
+            utils.in_ci_environment()
             and not self.review_manager.in_test_environment()
         ):
             raise colrev_exceptions.ServiceNotAvailableException(

--- a/colrev/ops/pdf_get_man.py
+++ b/colrev/ops/pdf_get_man.py
@@ -11,7 +11,7 @@ import pandas as pd
 import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.record.record
-import colrev.utils
+from colrev import utils
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
@@ -117,7 +117,7 @@ class PDFGetMan(colrev.process.operation.Operation):
             conditions=[{Fields.STATUS: RecordState.pdf_needs_manual_retrieval}]
         )
         pdf_get_man_data = {"nr_tasks": nr_tasks, "PAD": pad, "items": items}
-        self.review_manager.logger.debug(colrev.utils.pformat(pdf_get_man_data))
+        self.review_manager.logger.debug(utils.pformat(pdf_get_man_data))
         return pdf_get_man_data
 
     def pdfs_retrieved_manually(self) -> bool:
@@ -180,7 +180,7 @@ class PDFGetMan(colrev.process.operation.Operation):
         """Get PDFs manually (main entrypoint)"""
 
         if (
-            self.review_manager.in_ci_environment()
+            utils.in_ci_environment()
             and not self.review_manager.in_test_environment()
         ):
             raise colrev_exceptions.ServiceNotAvailableException(

--- a/colrev/ops/pdf_prep.py
+++ b/colrev/ops/pdf_prep.py
@@ -14,6 +14,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.packages.grobid_tei.src.grobid_tei
 import colrev.process.operation
 import colrev.record.record_pdf
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
@@ -398,7 +399,7 @@ class PDFPrep(colrev.process.operation.Operation):
         """Prepare PDFs (main entrypoint)"""
 
         if (
-            self.review_manager.in_ci_environment()
+            utils.in_ci_environment()
             and not self.review_manager.in_test_environment()
         ):
             raise colrev_exceptions.ServiceNotAvailableException(

--- a/colrev/ops/pdf_prep_man.py
+++ b/colrev/ops/pdf_prep_man.py
@@ -11,7 +11,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.record.record
 import colrev.record.record_pdf
-import colrev.utils
+from colrev import utils
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import Filepaths
@@ -75,7 +75,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
             conditions=[{Fields.STATUS: RecordState.pdf_needs_manual_preparation}]
         )
         pdf_prep_man_data = {"nr_tasks": nr_tasks, "PAD": pad, "items": items}
-        self.review_manager.logger.debug(colrev.utils.pformat(pdf_prep_man_data))
+        self.review_manager.logger.debug(utils.pformat(pdf_prep_man_data))
         return pdf_prep_man_data
 
     def pdfs_prepared_manually(self) -> bool:
@@ -290,7 +290,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
         """Prepare PDFs manually (main entrypoint)"""
 
         if (
-            self.review_manager.in_ci_environment()
+            utils.in_ci_environment()
             and not self.review_manager.in_test_environment()
         ):
             raise colrev_exceptions.ServiceNotAvailableException(

--- a/colrev/ops/prep.py
+++ b/colrev/ops/prep.py
@@ -24,6 +24,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.loader.load_utils
 import colrev.process.operation
 import colrev.record.record_prep
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import DefectCodes
 from colrev.constants import EndpointType
@@ -622,7 +623,7 @@ class Prep(colrev.process.operation.Operation):
         )
         if (
             self.polish
-            and self.review_manager.in_ci_environment()
+            and utils.in_ci_environment()
             and len(items) > 2000
         ):
             items = random.choices(items, k=2000)  # nosec
@@ -745,7 +746,7 @@ class Prep(colrev.process.operation.Operation):
             if x["endpoint"].lower() not in self.prep_package_endpoints
         ]
         if non_available_endpoints:
-            if self.review_manager.in_ci_environment():
+            if utils.in_ci_environment():
                 raise colrev_exceptions.ServiceNotAvailableException(
                     dep=f"colrev prep ({','.join(non_available_endpoints)})",
                     detailed_trace="prep not available in ci environment",
@@ -918,7 +919,7 @@ class Prep(colrev.process.operation.Operation):
         self.review_manager.logger.info(
             f"{Colors.GREEN}Completed prep operation{Colors.END}"
         )
-        if self.review_manager.in_ci_environment():
+        if utils.in_ci_environment():
             print("\n\n")
 
     def _nothing_to_prepare_condition(self, preparation_data: list) -> bool:

--- a/colrev/ops/prep_man.py
+++ b/colrev/ops/prep_man.py
@@ -12,7 +12,7 @@ import colrev.env.language_service
 import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.record.record_prep
-import colrev.utils
+from colrev import utils
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
@@ -93,10 +93,10 @@ class PrepMan(colrev.process.operation.Operation):
             )
 
         print("Entry type statistics overall:")
-        colrev.utils.p_print(overall_types[Fields.ENTRYTYPE])
+        utils.p_print(overall_types[Fields.ENTRYTYPE])
 
         print("Entry type statistics (needs_manual_preparation):")
-        colrev.utils.p_print(stats[Fields.ENTRYTYPE])
+        utils.p_print(stats[Fields.ENTRYTYPE])
 
         return pd.DataFrame(crosstab, columns=[Fields.ORIGIN, "hint"])
 
@@ -242,7 +242,7 @@ class PrepMan(colrev.process.operation.Operation):
             "all_ids": all_ids,
             "PAD": pad,
         }
-        self.review_manager.logger.debug(colrev.utils.pformat(md_prep_man_data))
+        self.review_manager.logger.debug(utils.pformat(md_prep_man_data))
         return md_prep_man_data
 
     def set_data(self, *, record_dict: dict) -> None:
@@ -267,7 +267,7 @@ class PrepMan(colrev.process.operation.Operation):
         """Manually prepare records (main entrypoint)"""
 
         if (
-            self.review_manager.in_ci_environment()
+            utils.in_ci_environment()
             and not self.review_manager.in_test_environment()
         ):
             raise colrev_exceptions.ServiceNotAvailableException(

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -10,6 +10,7 @@ import inquirer
 import colrev.exceptions as colrev_exceptions
 import colrev.process.operation
 import colrev.search_file
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
@@ -181,7 +182,7 @@ class Search(colrev.process.operation.Operation):
     ) -> None:
         """Interactively run a DB search"""
 
-        if self.review_manager.in_ci_environment():
+        if utils.in_ci_environment():
             raise colrev_exceptions.SearchNotAutomated("DB search not automated.")
 
         print("DB search (update)")
@@ -540,5 +541,5 @@ class Search(colrev.process.operation.Operation):
             except ModuleNotFoundError as exc:
                 self.review_manager.logger.warning(exc)
 
-        if self.review_manager.in_ci_environment():
+        if utils.in_ci_environment():
             print("\n\n")

--- a/colrev/packages/exclude_languages/src/exclude_languages.py
+++ b/colrev/packages/exclude_languages/src/exclude_languages.py
@@ -46,7 +46,7 @@ class ExcludeLanguagesPrep(base_classes.PrepPackageBaseClass):
         # class (not object) properties to keep parallel processing as
         # efficient as possible (the object is passed to each thread)
         languages_to_include = ["eng"]
-        # if not prep_operation.review_manager.in_ci_environment():
+        # if not utils.in_ci_environment():
         self.language_service = colrev.env.language_service.LanguageService()
 
         prescreen_package_endpoints = (

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -31,6 +31,7 @@ from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.packages.crossref.src import crossref_api
 from colrev.writer.write_utils import write_file
+from colrev import utils
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -68,7 +69,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         # TODO : files_dir: subdir_pattern etc. should be prep_parameters
         self.search_source = search_file
 
-        if not self.review_manager.in_ci_environment():
+        if not utils.in_ci_environment():
             self.pdf_preparation_operation = self.review_manager.get_pdf_prep_operation(
                 notify_state_transition_operation=False
             )
@@ -694,7 +695,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         # Do not run in continuous-integration environment
-        if self.review_manager.in_ci_environment():
+        if utils.in_ci_environment():
             raise colrev_exceptions.SearchNotAutomated("PDFs Dir Search not automated.")
 
         if self.review_manager.force_mode:  # i.e., reindex all

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -15,6 +15,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import RecordState
@@ -245,7 +246,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
 
         # pylint: disable=too-many-branches
 
-        if self.review_manager.in_ci_environment():
+        if utils.in_ci_environment():
             self.logger.error(
                 "Running in CI environment. Skipping github-pages generation."
             )

--- a/colrev/packages/grobid_tei/src/grobid_tei.py
+++ b/colrev/packages/grobid_tei/src/grobid_tei.py
@@ -13,6 +13,7 @@ import colrev.env.tei_parser
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
+from colrev import utils
 
 if typing.TYPE_CHECKING:
     import colrev.record.record_pdf
@@ -39,7 +40,7 @@ class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager
 
-        if not pdf_prep_operation.review_manager.in_ci_environment():
+        if not utils.in_ci_environment():
             self.tei_path = (
                 pdf_prep_operation.review_manager.path / self.TEI_PATH_RELATIVE
             )

--- a/colrev/packages/ocrmypdf/src/ocrmypdf.py
+++ b/colrev/packages/ocrmypdf/src/ocrmypdf.py
@@ -17,6 +17,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+from colrev import utils
 from colrev.constants import Fields
 from colrev.constants import PDFDefectCodes
 
@@ -42,7 +43,7 @@ class OCRMyPDF(base_classes.PDFPrepPackageBaseClass):
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager
 
-        if not self.review_manager.in_ci_environment():
+        if not utils.in_ci_environment():
             colrev.env.docker_manager.DockerManager.build_docker_image(
                 imagename=self.OCRMYPDF_IMAGE
             )

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -233,7 +233,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of OpenLibrary"""
 
         # if self.search_source.search_type == SearchType.DB:
-        #     if self.review_manager.in_ci_environment():
+        #     if utils.in_ci_environment():
         #         raise colrev_exceptions.SearchNotAutomated(
         #             "DB search for OpenLibrary not automated."
         #         )

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -27,6 +27,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import Filepaths
@@ -125,7 +126,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
 
         self._create_non_sample_references_bib()
 
-        if not self.review_manager.in_ci_environment():
+        if not utils.in_ci_environment():
             self.pandoc_image = "pandoc/latex:3.2.0"
             colrev.env.docker_manager.DockerManager.build_docker_image(
                 imagename=self.pandoc_image
@@ -779,7 +780,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                 silent_mode=silent_mode,
             )
 
-        if not self.review_manager.in_ci_environment() and not silent_mode:
+        if not utils.in_ci_environment() and not silent_mode:
             self.build_paper()
 
     def _get_to_synthesize(self, *, paper: Path, records_for_synthesis: list) -> list:

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -27,6 +27,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
 import colrev.search_file
+from colrev import utils
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import RecordState
@@ -369,7 +370,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         self._validate_source()
 
         # Do not run in continuous-integration environment
-        if self.review_manager.in_ci_environment():
+        if utils.in_ci_environment():
             raise colrev_exceptions.SearchNotAutomated(
                 "PDF Backward Search not automated."
             )

--- a/colrev/packages/prisma/src/prisma.py
+++ b/colrev/packages/prisma/src/prisma.py
@@ -19,6 +19,7 @@ import colrev.env.utils
 import colrev.exceptions as colrev_exceptions
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_settings
+from colrev import utils
 from colrev.constants import Colors
 
 if typing.TYPE_CHECKING:
@@ -73,7 +74,7 @@ class PRISMA(base_classes.DataPackageBaseClass):
             output_dir / path for path in self.settings.diagram_path
         ]
 
-        if not self.review_manager.in_ci_environment():
+        if not utils.in_ci_environment():
             colrev.env.docker_manager.DockerManager.build_docker_image(
                 imagename=self.PRISMA_IMAGE
             )

--- a/colrev/process/operation.py
+++ b/colrev/process/operation.py
@@ -9,6 +9,7 @@ import git
 from docker.errors import DockerException
 
 import colrev.exceptions as colrev_exceptions
+from colrev import utils
 from colrev.constants import OperationsType
 from colrev.process.model import ProcessModel
 
@@ -51,7 +52,7 @@ class Operation:
                 retval = func(self, *args, **kwargs)
                 # Conclude the operation
                 self.conclude()
-                if self.review_manager.in_ci_environment():
+                if utils.in_ci_environment():
                     print("\n\n")
                 return retval
 

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -552,17 +552,3 @@ class ReviewManager:
         """Check whether CoLRev runs in a test environment"""
 
         return "pytest" in os.getcwd()
-
-    @classmethod
-    def in_ci_environment(
-        cls,
-    ) -> bool:
-        """Check whether CoLRev runs in a continuous-integration environment"""
-
-        identifier_list = [
-            "GITHUB_ACTIONS",
-            "CIRCLECI",
-            "TRAVIS",
-            "GITLAB_CI",
-        ]
-        return any("true" == os.getenv(x) for x in identifier_list)

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -27,7 +27,7 @@ import colrev.ui_cli.add_package_to_settings
 import colrev.ui_cli.cli_status_printer
 import colrev.ui_cli.cli_validation
 import colrev.ui_cli.dedupe_errors
-import colrev.utils
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
@@ -564,7 +564,7 @@ def search(
 
     if view:
         for source in search_operation.sources:
-            colrev.utils.p_print(source)
+            utils.p_print(source)
         return
 
     if add:
@@ -2061,12 +2061,12 @@ def data(
             data_operation.review_manager.settings.data.data_package_endpoints
         )
         for data_endpoint in data_endpoints:
-            colrev.utils.p_print(data_endpoint)
+            utils.p_print(data_endpoint)
         return
 
     if reading_heuristics:
         heuristic_results = data_operation.reading_heuristics()
-        colrev.utils.p_print(heuristic_results)
+        utils.p_print(heuristic_results)
         return
     if setup_custom_script:
         data_operation.setup_custom_script()
@@ -2087,7 +2087,7 @@ def data(
         return
 
     ret = data_operation.main()
-    if data_operation.review_manager.in_ci_environment():
+    if utils.in_ci_environment():
         if ret["ask_to_commit"]:
             review_manager.dataset.create_commit(
                 msg="Data and synthesis", manual_author=True

--- a/colrev/utils.py
+++ b/colrev/utils.py
@@ -2,6 +2,7 @@
 """Utility helpers for CoLRev."""
 from __future__ import annotations
 
+import os
 import pprint
 import typing
 from datetime import timedelta
@@ -31,3 +32,10 @@ def get_cached_session() -> requests_cache.CachedSession:  # pragma: no cover
         backend="sqlite",
         expire_after=timedelta(days=30),
     )
+
+
+def in_ci_environment() -> bool:
+    """Return True if running in a CI environment (e.g., GitHub Actions)."""
+
+    identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
+    return any("true" == os.getenv(x) for x in identifier_list)

--- a/tests/2_loader/md_test.py
+++ b/tests/2_loader/md_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 import colrev.review_manager
+from colrev import utils
 from colrev.constants import SearchType
 
 
@@ -32,7 +33,7 @@ def test_load_md(  # type: ignore
             empty_if_file_not_exists=False,
         )
 
-    if base_repo_review_manager.in_ci_environment():
+    if utils.in_ci_environment():
         return
 
     search_source = colrev.search_file.ExtendedSearchFile(

--- a/tests/2_ops/search_operation_test.py
+++ b/tests/2_ops/search_operation_test.py
@@ -11,7 +11,7 @@ from colrev.constants import EndpointType
 from colrev.constants import SearchType
 
 
-@patch("colrev.review_manager.ReviewManager.in_ci_environment")
+@patch("colrev.utils.in_ci_environment")
 def test_search(  # type: ignore
     ci_env_patcher, base_repo_review_manager: colrev.review_manager.ReviewManager
 ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.ops.init
 import colrev.record.record_pdf
 import colrev.review_manager
+from colrev import utils
 from colrev.constants import Colors
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
@@ -137,7 +138,7 @@ def fixture_base_repo_review_manager(session_mocker, tmp_path_factory, helpers):
 
     review_manager.get_load_operation()
     git_repo = review_manager.dataset.get_repo()
-    if review_manager.in_ci_environment():
+    if utils.in_ci_environment():
         git_repo.config_writer().set_value("user", "name", "Tester").release()
         git_repo.config_writer().set_value("user", "email", "tester@mail.com").release()
 


### PR DESCRIPTION
## Summary
- move CI environment check to `colrev.utils`
- update all modules to call `utils.in_ci_environment`
- drop `ReviewManager.in_ci_environment` and adjust tests

## Testing
- `pre-commit run --files colrev/utils.py colrev/review_manager.py colrev/ops/prep_man.py colrev/ops/pdf_prep_man.py tests/2_ops/search_operation_test.py colrev/ops/prep.py colrev/ops/pdf_get_man.py colrev/ops/pdf_get.py tests/2_loader/md_test.py colrev/env/tei_parser.py colrev/ops/search.py colrev/ops/data.py colrev/ops/checker.py colrev/ui_cli/cli.py colrev/ops/pdf_prep.py colrev/process/operation.py colrev/packages/pdf_backward_search/src/pdf_backward_search.py colrev/packages/exclude_languages/src/exclude_languages.py colrev/packages/github_pages/src/github_pages.py colrev/packages/paper_md/src/paper_md.py colrev/packages/prisma/src/prisma.py colrev/packages/ocrmypdf/src/ocrmypdf.py colrev/packages/open_library/src/open_library.py colrev/packages/grobid_tei/src/grobid_tei.py colrev/packages/files_dir/src/files_dir.py tests/conftest.py` *(failed: unable to access 'https://github.com/pre-commit/pre-commit-hooks/' - CONNECT tunnel failed)*
- `pytest` *(failed: PackageNotFoundError: No package metadata was found for colrev)*

------
https://chatgpt.com/codex/tasks/task_e_68974d68959c832ab68b365ec5adecc5