### PR TITLE
refactor: remove ReviewManager factory methods

### DIFF
--- a/colrev/ops/advisor.py
+++ b/colrev/ops/advisor.py
@@ -16,6 +16,8 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
+from colrev.env.environment_manager import EnvironmentManager
+from colrev.package_manager.package_manager import PackageManager
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import colrev.review_manager
@@ -49,7 +51,7 @@ class Advisor:
         colrev.ops.check.CheckOperation(self.review_manager)
         self.records = self.review_manager.dataset.load_records_dict()
         self.status_stats = review_manager.get_status_stats(records=self.records)
-        self.environment_manager = self.review_manager.get_environment_manager()
+        self.environment_manager = EnvironmentManager()
 
     def _append_merge_conflict_warning(
         self, collaboration_instructions: dict, *, git_repo: git.Repo
@@ -387,7 +389,7 @@ class Advisor:
                         review_instructions.remove(item)
                         break
 
-                package_manager = self.review_manager.get_package_manager()
+                package_manager = PackageManager()
                 check_operation = colrev.ops.check.CheckOperation(self.review_manager)
                 for (
                     data_package_endpoint

--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -18,8 +18,8 @@ from colrev.constants import ExitCodes
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
-from colrev.process.model import ProcessModel
 from colrev.env.environment_manager import EnvironmentManager
+from colrev.process.model import ProcessModel
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import colrev.review_manager

--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -19,6 +19,7 @@ from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
 from colrev.process.model import ProcessModel
+from colrev.env.environment_manager import EnvironmentManager
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import colrev.review_manager
@@ -688,7 +689,7 @@ class Checker:
         # We work with exceptions because each issue may be raised in different checks.
         # Currently, linting is limited for the scripts.
 
-        environment_manager = self.review_manager.get_environment_manager()
+        environment_manager = EnvironmentManager()
         check_scripts: list[dict[str, typing.Any]] = [
             {
                 "script": environment_manager.check_git_installed,

--- a/colrev/ops/clone.py
+++ b/colrev/ops/clone.py
@@ -8,6 +8,7 @@ from git import Repo
 import colrev.env.local_index_builder
 import colrev.exceptions as colrev_exceptions
 import colrev.review_manager
+from colrev.env.environment_manager import EnvironmentManager
 
 
 class Clone:
@@ -35,7 +36,7 @@ class Clone:
         except colrev_exceptions.RepoSetupError:
             print("Not a CoLRev repository.")
             return
-        environment_manager = review_manager.get_environment_manager()
+        environment_manager = EnvironmentManager()
         environment_manager.register_repo(self.local_path)
         local_index_builder = colrev.env.local_index_builder.LocalIndexBuilder()
 

--- a/colrev/ops/data.py
+++ b/colrev/ops/data.py
@@ -13,6 +13,7 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 
 
 class Data(colrev.process.operation.Operation):
@@ -34,7 +35,7 @@ class Data(colrev.process.operation.Operation):
             notify_state_transition_operation=notify_state_transition_operation,
         )
 
-        self.package_manager = self.review_manager.get_package_manager()
+        self.package_manager = PackageManager()
 
     def get_record_ids_for_synthesis(self, records: dict) -> list:
         """Get the IDs of records for the synthesis"""

--- a/colrev/ops/dedupe.py
+++ b/colrev/ops/dedupe.py
@@ -20,6 +20,7 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 
 
 class Dedupe(colrev.process.operation.Operation):
@@ -679,7 +680,7 @@ class Dedupe(colrev.process.operation.Operation):
         if not self.review_manager.high_level_operation:
             print()
 
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
         for (
             dedupe_package_endpoint
         ) in self.review_manager.settings.dedupe.dedupe_package_endpoints:

--- a/colrev/ops/distribute.py
+++ b/colrev/ops/distribute.py
@@ -13,8 +13,8 @@ import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import SearchType
-from colrev.writer.write_utils import write_file
 from colrev.env.environment_manager import EnvironmentManager
+from colrev.writer.write_utils import write_file
 
 
 class Distribute(colrev.process.operation.Operation):

--- a/colrev/ops/distribute.py
+++ b/colrev/ops/distribute.py
@@ -14,6 +14,7 @@ from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import SearchType
 from colrev.writer.write_utils import write_file
+from colrev.env.environment_manager import EnvironmentManager
 
 
 class Distribute(colrev.process.operation.Operation):
@@ -32,7 +33,7 @@ class Distribute(colrev.process.operation.Operation):
 
     def get_environment_registry(self) -> list:
         """Get the environment registry (excluding curated_metadata)"""
-        environment_manager = self.review_manager.get_environment_manager()
+        environment_manager = EnvironmentManager()
         return [
             x
             for x in environment_manager.local_repos()

--- a/colrev/ops/init.py
+++ b/colrev/ops/init.py
@@ -18,17 +18,17 @@ import git
 from git.exc import InvalidGitRepositoryError
 
 import colrev.env.docker_manager
-import colrev.env.environment_manager
 import colrev.env.utils
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.check
-import colrev.package_manager.package_manager
 import colrev.review_manager
 import colrev.settings
 from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import SearchType
+from colrev.env.environment_manager import EnvironmentManager
+from colrev.package_manager.package_manager import PackageManager
 
 # pylint: disable=too-few-public-methods
 
@@ -49,7 +49,7 @@ class Initializer:
         light: bool = False,
         exact_call: str = "",
     ) -> None:
-        p_man = colrev.package_manager.package_manager.PackageManager()
+        p_man = PackageManager()
         self.review_type = self._format_review_type(review_type)
         if not p_man.is_installed(self.review_type):
             print(
@@ -199,7 +199,7 @@ class Initializer:
                 filepath=self.target_path, content=cur_content
             )
 
-        environment_manager = colrev.env.environment_manager.EnvironmentManager()
+        environment_manager = EnvironmentManager()
         environment_manager.get_name_mail_from_git()
 
         try:
@@ -220,7 +220,7 @@ class Initializer:
         git.Repo.init()
 
         # To check if git actors are set
-        environment_manager = colrev.env.environment_manager.EnvironmentManager()
+        environment_manager = EnvironmentManager()
         environment_manager.get_name_mail_from_git()
 
         logging.info("Install latest pre-commmit hooks")
@@ -360,7 +360,7 @@ class Initializer:
 
         # Principle: adapt values provided by the default SETTINGS_FILE
         # instead of creating a new SETTINGS_FILE
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
         review_type_class = package_manager.get_package_endpoint_class(
             package_type=EndpointType.review_type,
             package_identifier=self.review_type,
@@ -382,7 +382,7 @@ class Initializer:
                 new_string=project_title.rstrip(" ").capitalize(),
             )
         else:
-            package_manager = self.review_manager.get_package_manager()
+            package_manager = PackageManager()
             r_type_suffix = str(review_type_object)
 
             colrev.env.utils.inplace_change(
@@ -446,7 +446,7 @@ class Initializer:
         if example or "pytest" in os.getcwd():
             return
         self.review_manager.logger.info("Register CoLRev repository")
-        environment_manager = self.review_manager.get_environment_manager()
+        environment_manager = EnvironmentManager()
         environment_manager.register_repo(
             self.target_path, logger=self.review_manager.logger
         )

--- a/colrev/ops/load.py
+++ b/colrev/ops/load.py
@@ -20,6 +20,7 @@ from colrev.constants import FieldSet
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
 from colrev.constants import SearchType
+from colrev.package_manager.package_manager import PackageManager
 
 
 class Load(colrev.process.operation.Operation):
@@ -41,7 +42,7 @@ class Load(colrev.process.operation.Operation):
         )
 
         self.quality_model = review_manager.get_qm()
-        self.package_manager = self.review_manager.get_package_manager()
+        self.package_manager = PackageManager()
 
         self.load_formatter = colrev.loader.load_utils_formatter.LoadFormatter()
 

--- a/colrev/ops/pdf_get.py
+++ b/colrev/ops/pdf_get.py
@@ -18,6 +18,7 @@ from colrev.constants import OperationsType
 from colrev.constants import PDFPathType
 from colrev.constants import RecordState
 from colrev.writer.write_utils import write_file
+from colrev.package_manager.package_manager import PackageManager
 
 
 class PDFGet(colrev.process.operation.Operation):
@@ -41,7 +42,7 @@ class PDFGet(colrev.process.operation.Operation):
             notify_state_transition_operation=notify_state_transition_operation,
         )
 
-        self.package_manager = self.review_manager.get_package_manager()
+        self.package_manager = PackageManager()
 
         pdf_dir = self.review_manager.paths.pdf
         pdf_dir.mkdir(exist_ok=True, parents=True)

--- a/colrev/ops/pdf_get.py
+++ b/colrev/ops/pdf_get.py
@@ -17,8 +17,8 @@ from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import PDFPathType
 from colrev.constants import RecordState
-from colrev.writer.write_utils import write_file
 from colrev.package_manager.package_manager import PackageManager
+from colrev.writer.write_utils import write_file
 
 
 class PDFGet(colrev.process.operation.Operation):

--- a/colrev/ops/pdf_get_man.py
+++ b/colrev/ops/pdf_get_man.py
@@ -16,6 +16,7 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 
 
 class PDFGetMan(colrev.process.operation.Operation):
@@ -193,7 +194,7 @@ class PDFGetMan(colrev.process.operation.Operation):
             self.review_manager.settings.pdf_get.pdf_get_man_package_endpoints
         )
 
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
 
         for pdf_get_man_package_endpoint in pdf_get_man_package_endpoints:
             pdf_get_man_class = package_manager.get_package_endpoint_class(

--- a/colrev/ops/pdf_prep.py
+++ b/colrev/ops/pdf_prep.py
@@ -19,6 +19,7 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 
 
 class PDFPrep(colrev.process.operation.Operation):
@@ -426,7 +427,7 @@ class PDFPrep(colrev.process.operation.Operation):
 
         pdf_prep_data = self._get_data(batch_size=batch_size)
 
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
         self.pdf_prep_package_endpoints = {}
         for (
             pdf_prep_package_endpoint

--- a/colrev/ops/pdf_prep_man.py
+++ b/colrev/ops/pdf_prep_man.py
@@ -18,6 +18,7 @@ from colrev.constants import Filepaths
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
 from colrev.writer.write_utils import write_file
+from colrev.package_manager.package_manager import PackageManager
 
 
 class PDFPrepMan(colrev.process.operation.Operation):
@@ -300,7 +301,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
 
         records = self.review_manager.dataset.load_records_dict()
 
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
 
         pdf_prep_man_package_endpoints = (
             self.review_manager.settings.pdf_prep.pdf_prep_man_package_endpoints

--- a/colrev/ops/pdf_prep_man.py
+++ b/colrev/ops/pdf_prep_man.py
@@ -17,8 +17,8 @@ from colrev.constants import Fields
 from colrev.constants import Filepaths
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
-from colrev.writer.write_utils import write_file
 from colrev.package_manager.package_manager import PackageManager
+from colrev.writer.write_utils import write_file
 
 
 class PDFPrepMan(colrev.process.operation.Operation):

--- a/colrev/ops/prep.py
+++ b/colrev/ops/prep.py
@@ -31,9 +31,9 @@ from colrev.constants import Fields
 from colrev.constants import FieldSet
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 from colrev.writer.write_utils import to_string
 from colrev.writer.write_utils import write_file
-from colrev.package_manager.package_manager import PackageManager
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import colrev.package_manager.package_base_classes as base_classes

--- a/colrev/ops/prep.py
+++ b/colrev/ops/prep.py
@@ -33,6 +33,7 @@ from colrev.constants import OperationsType
 from colrev.constants import RecordState
 from colrev.writer.write_utils import to_string
 from colrev.writer.write_utils import write_file
+from colrev.package_manager.package_manager import PackageManager
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import colrev.package_manager.package_base_classes as base_classes
@@ -105,7 +106,7 @@ class Prep(colrev.process.operation.Operation):
         self.temp_records = self.review_manager.path / (Path(".colrev/temp_recs.bib"))
 
         self.quality_model = review_manager.get_qm()
-        self.package_manager = self.review_manager.get_package_manager()
+        self.package_manager = PackageManager()
 
         self.polish = polish
         self._cpu = cpu

--- a/colrev/ops/prep_man.py
+++ b/colrev/ops/prep_man.py
@@ -17,6 +17,7 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 
 
 class PrepMan(colrev.process.operation.Operation):
@@ -277,7 +278,7 @@ class PrepMan(colrev.process.operation.Operation):
 
         records = self.review_manager.dataset.load_records_dict()
 
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
 
         for (
             prep_man_package_endpoint

--- a/colrev/ops/prescreen.py
+++ b/colrev/ops/prescreen.py
@@ -14,6 +14,7 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 
 ConditionalPrescreen = (
     colrev.packages.conditional_prescreen.src.conditional_prescreen.ConditionalPrescreen
@@ -335,7 +336,7 @@ class Prescreen(colrev.process.operation.Operation):
 
         records = self.review_manager.dataset.load_records_dict()
 
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
 
         prescreen_package_endpoints = (
             self.review_manager.settings.prescreen.prescreen_package_endpoints

--- a/colrev/ops/push.py
+++ b/colrev/ops/push.py
@@ -11,6 +11,7 @@ from colrev.constants import Colors
 from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
+from colrev.package_manager.package_manager import PackageManager
 
 
 class Push(colrev.process.operation.Operation):
@@ -85,7 +86,7 @@ class Push(colrev.process.operation.Operation):
         """Push corrections of records"""
 
         change_sets = self._get_change_sets()
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
 
         for source_prefix, change_itemsets in change_sets.items():
             source_l = [

--- a/colrev/ops/screen.py
+++ b/colrev/ops/screen.py
@@ -14,6 +14,7 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import RecordState
+from colrev.package_manager.package_manager import PackageManager
 
 
 class Screen(colrev.process.operation.Operation):
@@ -468,7 +469,7 @@ class Screen(colrev.process.operation.Operation):
 
         records = self.review_manager.dataset.load_records_dict()
 
-        package_manager = self.review_manager.get_package_manager()
+        package_manager = PackageManager()
 
         if not self.review_manager.settings.screen.screen_package_endpoints:
             self._screen_include_all(records)

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -16,6 +16,7 @@ from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import SearchType
 from colrev.writer.write_utils import write_file
+from colrev.package_manager.package_manager import PackageManager
 
 
 class Search(colrev.process.operation.Operation):
@@ -36,7 +37,7 @@ class Search(colrev.process.operation.Operation):
         )
         self.review_manager = review_manager
         self.sources = review_manager.settings.sources
-        self.package_manager = self.review_manager.get_package_manager()
+        self.package_manager = PackageManager()
 
     def get_unique_filename(self, file_path_string: str, suffix: str = ".bib") -> Path:
         """Get a unique filename for a (new) SearchSource"""

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -15,8 +15,8 @@ from colrev.constants import EndpointType
 from colrev.constants import Fields
 from colrev.constants import OperationsType
 from colrev.constants import SearchType
-from colrev.writer.write_utils import write_file
 from colrev.package_manager.package_manager import PackageManager
+from colrev.writer.write_utils import write_file
 
 
 class Search(colrev.process.operation.Operation):

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -382,7 +382,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
 
         review_type = self.review_manager.settings.project.review_type
 
-        # package_manager = self.review_manager.get_package_manager()
+        # package_manager = PackageManager()
         # check_operation = colrev.ops.check.CheckOperation(self.review_manager)
 
         # review_type_class = package_manager.get_package_endpoint_class(

--- a/colrev/packages/source_specific_prep/src/source_specific_prep.py
+++ b/colrev/packages/source_specific_prep/src/source_specific_prep.py
@@ -14,6 +14,7 @@ import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import EndpointType
 from colrev.constants import Fields
+from colrev.package_manager.package_manager import PackageManager
 
 # pylint: disable=duplicate-code
 
@@ -40,8 +41,7 @@ class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = prep_operation.review_manager
-
-        self.package_manager = prep_operation.review_manager.get_package_manager()
+        self.package_manager = PackageManager()
 
     def prepare(
         self, record: colrev.record.record_prep.PrepRecord

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -29,6 +29,7 @@ import colrev.settings
 from colrev.constants import Colors
 from colrev.constants import OperationsType
 from colrev.paths import PathManager
+from colrev.env.environment_manager import EnvironmentManager
 
 
 class ReviewManager:
@@ -91,7 +92,7 @@ class ReviewManager:
             self.report_logger = report_logger
             self.logger = logger
 
-            self.environment_manager = self.get_environment_manager()
+            self.environment_manager = EnvironmentManager()
 
             # run update before settings/data (which may require changes/fail without update)
             if not skip_upgrade:  # pragma: no cover
@@ -312,30 +313,6 @@ class ReviewManager:
         return status_stats.completeness_condition
 
     @classmethod
-    def get_package_manager(
-        cls,
-    ) -> colrev.package_manager.package_manager.PackageManager:  # pragma: no cover
-        """Get a package manager object"""
-
-        import colrev.package_manager.package_manager
-
-        return colrev.package_manager.package_manager.PackageManager()
-
-    @classmethod
-    def get_environment_manager(
-        cls,
-    ) -> colrev.env.environment_manager.EnvironmentManager:  # pragma: no cover
-        """Get an environment manager"""
-        import colrev.env.environment_manager
-
-        return colrev.env.environment_manager.EnvironmentManager()
-
-    @classmethod
-    def get_resources(cls) -> colrev.env.resources.Resources:  # pragma: no cover
-        """Get a resources object"""
-        import colrev.env.resources
-
-        return colrev.env.resources.Resources()
 
     def get_search_operation(
         self, *, notify_state_transition_operation: bool = True

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -28,8 +28,8 @@ import colrev.record.qm.quality_model
 import colrev.settings
 from colrev.constants import Colors
 from colrev.constants import OperationsType
-from colrev.paths import PathManager
 from colrev.env.environment_manager import EnvironmentManager
+from colrev.paths import PathManager
 
 
 class ReviewManager:
@@ -313,7 +313,6 @@ class ReviewManager:
         return status_stats.completeness_condition
 
     @classmethod
-
     def get_search_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.search.Search:  # pragma: no cover

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -312,7 +312,6 @@ class ReviewManager:
         status_stats = self.get_status_stats()
         return status_stats.completeness_condition
 
-    @classmethod
     def get_search_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.search.Search:  # pragma: no cover

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -35,6 +35,8 @@ from colrev.constants import Filepaths
 from colrev.constants import IDPattern
 from colrev.constants import RecordState
 from colrev.constants import ScreenCriterionType
+from colrev.env.environment_manager import EnvironmentManager
+from colrev.env.resources import Resources
 
 # pylint: disable=too-many-lines
 # pylint: disable=redefined-outer-name
@@ -2282,7 +2284,7 @@ def distribute(ctx: click.core.Context, path: Path, verbose: bool, force: bool) 
 def _print_environment_status(
     review_manager: colrev.review_manager.ReviewManager,
 ) -> None:
-    environment_manager = review_manager.get_environment_manager()
+    environment_manager = EnvironmentManager()
     environment_details = environment_manager.get_environment_details()
 
     print("\nCoLRev environment status\n")
@@ -2437,7 +2439,7 @@ def env(
     )
 
     if install:
-        env_resources = review_manager.get_resources()
+        env_resources = Resources()
         if env_resources.install_curated_resource(curated_resource=install):
             print("Successfully installed curated resource.")
             print("To make it available to other projects, run")
@@ -2445,7 +2447,7 @@ def env(
         return
 
     if pull:
-        environment_manager = review_manager.get_environment_manager()
+        environment_manager = EnvironmentManager()
         for curated_resource in environment_manager.local_repos():
             try:
                 curated_resource_path = curated_resource["repo_source_path"]
@@ -2472,12 +2474,12 @@ def env(
         return
 
     if register:
-        environment_manager = review_manager.get_environment_manager()
+        environment_manager = EnvironmentManager()
         environment_manager.register_repo(Path.cwd())
         return
 
     if unregister is not None:
-        environment_manager = review_manager.get_environment_manager()
+        environment_manager = EnvironmentManager()
 
         local_repos = environment_manager.local_repos()
         if str(unregister) not in [x["source_url"] for x in local_repos]:

--- a/colrev/ui_cli/detect_and_add_source.py
+++ b/colrev/ui_cli/detect_and_add_source.py
@@ -9,6 +9,7 @@ import inquirer
 
 from colrev.constants import Colors
 from colrev.constants import EndpointType
+from colrev.package_manager.package_manager import PackageManager
 
 if typing.TYPE_CHECKING:
     import colrev.ops.search
@@ -22,7 +23,7 @@ class CLISourceAdder:
     def __init__(self, *, search_operation: colrev.ops.search.Search) -> None:
         self.search_operation = search_operation
         self.review_manager = search_operation.review_manager
-        self.package_manager = self.review_manager.get_package_manager()
+        self.package_manager = PackageManager()
 
     def _select_source(
         self,

--- a/docs/source/dev_docs/_autosummary/colrev.review_manager.ReviewManager.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.review_manager.ReviewManager.rst
@@ -28,11 +28,9 @@ colrev.review\_manager.ReviewManager
       ~ReviewManager.get_data_operation
       ~ReviewManager.get_dedupe_operation
       ~ReviewManager.get_distribute_operation
-      ~ReviewManager.get_environment_manager
       ~ReviewManager.get_load_operation
       ~ReviewManager.get_loggers
       ~ReviewManager.get_merge_operation
-      ~ReviewManager.get_package_manager
       ~ReviewManager.get_pdf_get_man_operation
       ~ReviewManager.get_pdf_get_operation
       ~ReviewManager.get_pdf_prep_man_operation
@@ -46,7 +44,6 @@ colrev.review\_manager.ReviewManager
       ~ReviewManager.get_qm
       ~ReviewManager.get_remove_operation
       ~ReviewManager.get_repare
-      ~ReviewManager.get_resources
       ~ReviewManager.get_screen_operation
       ~ReviewManager.get_search_operation
       ~ReviewManager.get_status_operation

--- a/docs/source/dev_docs/colrev.review_manager.ReviewManager.rst
+++ b/docs/source/dev_docs/colrev.review_manager.ReviewManager.rst
@@ -28,11 +28,9 @@ colrev.review\_manager.ReviewManager
       ~ReviewManager.get_data_operation
       ~ReviewManager.get_dedupe_operation
       ~ReviewManager.get_distribute_operation
-      ~ReviewManager.get_environment_manager
       ~ReviewManager.get_load_operation
       ~ReviewManager.get_loggers
       ~ReviewManager.get_merge_operation
-      ~ReviewManager.get_package_manager
       ~ReviewManager.get_pdf_get_man_operation
       ~ReviewManager.get_pdf_get_operation
       ~ReviewManager.get_pdf_prep_man_operation
@@ -46,7 +44,6 @@ colrev.review\_manager.ReviewManager
       ~ReviewManager.get_qm
       ~ReviewManager.get_remove_operation
       ~ReviewManager.get_repare
-      ~ReviewManager.get_resources
       ~ReviewManager.get_screen_operation
       ~ReviewManager.get_search_operation
       ~ReviewManager.get_status_operation

--- a/tests/1_env/packages_test.py
+++ b/tests/1_env/packages_test.py
@@ -37,7 +37,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the review_type_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     load_operation = base_repo_review_manager.get_load_operation()
 #     review_type_identifiers = package_manager.discover_packages(
 #         package_type=EndpointType.review_type,
@@ -58,7 +57,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the search_source_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     load_operation = base_repo_review_manager.get_load_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -86,7 +84,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the prep_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     prep_operation = base_repo_review_manager.get_prep_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -109,7 +106,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the prep_man_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     prep_man_operation = base_repo_review_manager.get_prep_man_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -132,7 +128,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the dedupe_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     dedupe_operation = base_repo_review_manager.get_dedupe_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -160,7 +155,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the prescreen_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     prescreen_operation = base_repo_review_manager.get_prescreen_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -185,7 +179,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the pdf_get_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     pdf_get_operation = base_repo_review_manager.get_pdf_get_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -208,7 +201,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the pdf_get_man_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     pdf_get_man_operation = base_repo_review_manager.get_pdf_get_man_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -231,7 +223,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the pdf_prep_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     pdf_prep_operation = base_repo_review_manager.get_pdf_prep_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -254,7 +245,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the pdf_prep_man_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     pdf_prep_man_operation = base_repo_review_manager.get_pdf_prep_man_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -277,7 +267,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the screen_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     screen_operation = base_repo_review_manager.get_screen_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -300,7 +289,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test the data_package_interfaces"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     data_operation = base_repo_review_manager.get_data_operation(
 #         notify_state_transition_operation=False
 #     )
@@ -338,7 +326,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     """Test update_package_list()"""
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     colrev_spec = importlib.util.find_spec("colrev")
 #     os.chdir(Path(colrev_spec.origin).parents[1])  # type: ignore
 #     package_manager.update_package_list()
@@ -352,7 +339,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
 #     dedupe_operation = base_repo_review_manager.get_dedupe_operation()
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     with pytest.raises(colrev_exceptions.MissingDependencyError):
 #         package_manager.add_package_to_settings(
 #             operation=dedupe_operation,
@@ -373,7 +359,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 # def test_dynamically_load_endpoints(
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     package_manager.dynamically_load_endpoints()
 #     assert EndpointType.search_source in package_manager.endpoints
 #     assert (
@@ -383,7 +368,6 @@ def test_generate_method_signatures(endpoint_type: str, helpers) -> None:  # typ
 # def test_pyproject_endpoints(
 #     base_repo_review_manager: colrev.review_manager.ReviewManager,
 # ) -> None:
-#     package_manager = base_repo_review_manager.get_package_manager()
 #     cls = package_manager.load_endpoints_pyproject_toml(
 #         "/home/gerit/ownCloud/projects/CoLRev/colrev/colrev/packages/crossref"
 #     )

--- a/tests/2_ops/search_operation_test.py
+++ b/tests/2_ops/search_operation_test.py
@@ -9,6 +9,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.review_manager
 from colrev.constants import EndpointType
 from colrev.constants import SearchType
+from colrev.package_manager.package_manager import PackageManager
 
 
 @patch("colrev.review_manager.ReviewManager.in_ci_environment")
@@ -54,7 +55,7 @@ def test_search_add_source(  # type: ignore
         comment="",
     )
 
-    package_manager = search_operation.review_manager.get_package_manager()
+    package_manager = PackageManager()
 
     search_source_class = package_manager.get_package_endpoint_class(
         package_type=EndpointType.search_source,
@@ -105,7 +106,7 @@ def test_search_get_unique_filename(
 #     search_operation = base_repo_review_manager.get_search_operation()
 
 #     base_repo_review_manager.settings.search.retrieve_forthcoming = False
-#     package_manager = search_operation.review_manager.get_package_manager()
+#     package_manager = PackageManager()
 
 #     search_source = package_manager.load_packages(
 #         package_type=EndpointType.search_source,


### PR DESCRIPTION
## Summary
- replace ReviewManager factory classmethods for package manager, environment manager, and resources with direct instantiation
- update operations, CLI utilities, docs, and tests to import and construct dependencies directly

## Testing
- `pre-commit run --files colrev/ops/advisor.py colrev/ops/checker.py colrev/ops/clone.py colrev/ops/data.py colrev/ops/dedupe.py colrev/ops/distribute.py colrev/ops/init.py colrev/ops/load.py colrev/ops/pdf_get.py colrev/ops/pdf_get_man.py colrev/ops/pdf_prep.py colrev/ops/pdf_prep_man.py colrev/ops/prep.py colrev/ops/prep_man.py colrev/ops/prescreen.py colrev/ops/push.py colrev/ops/screen.py colrev/ops/search.py colrev/packages/paper_md/src/paper_md.py colrev/packages/source_specific_prep/src/source_specific_prep.py colrev/review_manager.py colrev/ui_cli/cli.py colrev/ui_cli/detect_and_add_source.py docs/source/dev_docs/_autosummary/colrev.review_manager.ReviewManager.rst docs/source/dev_docs/colrev.review_manager.ReviewManager.rst tests/1_env/packages_test.py tests/2_ops/search_operation_test.py` *(failed: CalledProcessError: git fetch 403)*
- `PYTHONPATH=. pytest` *(failed: PackageNotFoundError: No package metadata was found for colrev)*

------
https://chatgpt.com/codex/tasks/task_e_68974f392edc832a8b6ec8a8b4360bf7