### PR TITLE
refactor: extract Git operations into GitRepo

### DIFF
--- a/colrev/dataset.py
+++ b/colrev/dataset.py
@@ -4,14 +4,8 @@ from __future__ import annotations
 
 import os
 import tempfile
-import time
 import typing
 from pathlib import Path
-from random import randint
-
-import git
-from git import GitCommandError
-from git import InvalidGitRepositoryError
 
 import colrev.exceptions as colrev_exceptions
 import colrev.loader.bib
@@ -19,11 +13,9 @@ import colrev.loader.load_utils
 import colrev.ops.check
 import colrev.record.record_id_setter
 import colrev.record.record_prep
-from colrev.constants import ExitCodes
-from colrev.constants import Fields
-from colrev.constants import FileSets
-from colrev.constants import RecordState
+from colrev.constants import ExitCodes, Fields, RecordState
 from colrev.writer.write_utils import to_string
+from colrev.git_repo import GitRepo
 
 # pylint: disable=too-many-public-methods
 
@@ -31,46 +23,9 @@ from colrev.writer.write_utils import to_string
 class Dataset:
     """The CoLRev dataset (records and their history in git)"""
 
-    _git_repo: git.Repo
-
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
         self.review_manager = review_manager
-
-        try:
-            # In most cases, the repo should exist
-            # due to review_manager._get_project_home_dir()
-            self._git_repo = git.Repo(self.review_manager.path)
-        except InvalidGitRepositoryError as exc:
-            msg = "Not a CoLRev/git repository. Run\n    colrev init"
-            raise colrev_exceptions.RepoSetupError(msg) from exc
-
-        self.update_gitignore(
-            add=FileSets.DEFAULT_GIT_IGNORE_ITEMS,
-            remove=FileSets.DEPRECATED_GIT_IGNORE_ITEMS,
-        )
-
-    def update_gitignore(
-        self, *, add: typing.Optional[list] = None, remove: typing.Optional[list] = None
-    ) -> None:
-        """Update the gitignore file by adding or removing particular paths"""
-        # The following may print warnings...
-
-        git_ignore_file = self.review_manager.paths.git_ignore
-        if git_ignore_file.is_file():
-            gitignore_content = git_ignore_file.read_text(encoding="utf-8")
-        else:
-            gitignore_content = ""
-        ignored_items = gitignore_content.splitlines()
-        if remove:
-            ignored_items = [x for x in ignored_items if x not in remove]
-        if add:
-            ignored_items = ignored_items + [
-                str(a) for a in add if str(a) not in ignored_items
-            ]
-
-        with git_ignore_file.open("w", encoding="utf-8") as file:
-            file.write("\n".join(ignored_items) + "\n")
-        self.add_changes(git_ignore_file)
+        self.git_repo = GitRepo(review_manager=review_manager)
 
     def get_origin_state_dict(self, records_string: str = "") -> dict:
         """Get the origin_state_dict (to determine state transitions efficiently)
@@ -110,7 +65,7 @@ class Dataset:
                     commit.tree / self.review_manager.paths.RECORDS_FILE_GIT
                 ).data_stream.read(),
             )
-            for commit in self._git_repo.iter_commits(
+            for commit in self.git_repo.repo.iter_commits(
                 paths=self.review_manager.paths.RECORDS_FILE_GIT
             )
         )
@@ -138,7 +93,7 @@ class Dataset:
         """
 
         reached_target_commit = False  # if no commit_sha provided
-        for current_commit in self._git_repo.iter_commits(
+        for current_commit in self.git_repo.repo.iter_commits(
             paths=self.review_manager.paths.RECORDS_FILE_GIT
         ):
 
@@ -216,7 +171,7 @@ class Dataset:
         with open(self.review_manager.paths.records, "w", encoding="utf-8") as out:
             out.write(bibtex_str + "\n")
 
-        self._add_record_changes()
+        self.git_repo.add_changes(self.review_manager.paths.RECORDS_FILE)
 
     def _save_record_list_by_id(self, records: dict) -> None:
 
@@ -274,7 +229,7 @@ class Dataset:
                 for item in record_list:
                     m_refs.write(item["record"])
 
-        self._add_record_changes()
+        self.git_repo.add_changes(self.review_manager.paths.RECORDS_FILE)
 
     def save_records_dict(self, records: dict, *, partial: bool = False) -> None:
         """Save the records dict in RECORDS_FILE"""
@@ -304,7 +259,7 @@ class Dataset:
 
         if (
             not self.review_manager.paths.records.is_file()
-            or not self.records_changed()
+            or not self.git_repo.records_changed()
         ):
             return {"status": ExitCodes.SUCCESS, "msg": "Everything ok."}
 
@@ -329,7 +284,7 @@ class Dataset:
 
         self.save_records_dict(records)
         changed = self.review_manager.paths.RECORDS_FILE in [
-            r.a_path for r in self._git_repo.index.diff(None)
+            r.a_path for r in self.git_repo.repo.index.diff(None)
         ]
         self.review_manager.update_status_yaml()
         self.review_manager.load_settings()
@@ -367,263 +322,5 @@ class Dataset:
             selected_ids=selected_ids,
         )
         self.save_records_dict(records)
-        self.add_changes(self.review_manager.paths.RECORDS_FILE)
+        self.git_repo.add_changes(self.review_manager.paths.RECORDS_FILE)
         return updated_records
-
-    # GIT operations -----------------------------------------------
-
-    def get_repo(self) -> git.Repo:
-        """Get the git repository object"""
-
-        if self.review_manager.notified_next_operation is None:
-            raise colrev_exceptions.ReviewManagerNotNotifiedError()
-        return self._git_repo
-
-    def repo_initialized(self) -> bool:
-        """Check whether the repository is initialized"""
-        try:
-            self._git_repo.head.commit
-        except ValueError:
-            return False
-        return True
-
-    def has_record_changes(self, *, change_type: str = "all") -> bool:
-        """Check whether the records have changes"""
-        return self.has_changes(
-            Path(self.review_manager.paths.RECORDS_FILE_GIT), change_type=change_type
-        )
-
-    def has_changes(self, relative_path: Path, *, change_type: str = "all") -> bool:
-        """Check whether the relative path (or the git repository) has changes"""
-
-        assert change_type in [
-            "all",
-            "staged",
-            "unstaged",
-        ], "Invalid change_type specified"
-
-        # Check if the repository has at least one commit
-        try:
-            bool(self._git_repo.head.commit)
-        except ValueError:
-            return True  # Repository has no commit
-
-        diff_index = [item.a_path for item in self._git_repo.index.diff(None)]
-        diff_head = [item.a_path for item in self._git_repo.head.commit.diff()]
-        unstaged_changes = diff_index + self._git_repo.untracked_files
-
-        # Ensure the path uses forward slashes, which is compatible with Git's path handling
-        path_str = str(relative_path).replace("\\", "/")
-
-        if change_type == "all":
-            path_changed = path_str in diff_index + diff_head
-        elif change_type == "staged":
-            path_changed = path_str in diff_head
-        elif change_type == "unstaged":
-            path_changed = path_str in unstaged_changes
-        else:
-            return False
-        return path_changed
-
-    def _sleep_util_git_unlocked(self) -> None:
-        i = 0
-        while (
-            self.review_manager.path / Path(".git/index.lock")
-        ).is_file():  # pragma: no cover
-            i += 1
-            time.sleep(randint(1, 50) * 0.1)  # nosec
-            if i > 5:
-                print("Waiting for previous git operation to complete")
-            elif i > 30:
-                raise colrev_exceptions.GitNotAvailableError()
-
-    def add_changes(
-        self, path: Path, *, remove: bool = False, ignore_missing: bool = False
-    ) -> None:
-        """Add changed file to git"""
-
-        if path.is_absolute():
-            path = path.relative_to(self.review_manager.path)
-        path_str = str(path).replace("\\", "/")
-
-        self._sleep_util_git_unlocked()
-        try:
-            if remove:
-                self._git_repo.index.remove([path_str])
-            else:
-                self._git_repo.index.add([path_str])
-        except FileNotFoundError as exc:
-            if not ignore_missing:
-                raise exc
-
-    def get_untracked_files(self) -> list:
-        """Get the files that are untracked by git"""
-
-        return [Path(x) for x in self._git_repo.untracked_files]
-
-    def records_changed(self) -> bool:
-        """Check whether the records were changed"""
-        main_recs_changed = self.review_manager.paths.RECORDS_FILE_GIT in [
-            item.a_path for item in self._git_repo.index.diff(None)
-        ] + [x.a_path for x in self._git_repo.head.commit.diff()]
-        return main_recs_changed
-
-    # pylint: disable=too-many-arguments
-    def create_commit(
-        self,
-        *,
-        msg: str,
-        manual_author: bool = False,
-        script_call: str = "",
-        saved_args: typing.Optional[dict] = None,
-        skip_status_yaml: bool = False,
-        skip_hooks: bool = True,
-    ) -> bool:
-        """Create a commit (including a commit report)"""
-        # pylint: disable=import-outside-toplevel
-        # pylint: disable=redefined-outer-name
-        import colrev.ops.commit
-
-        if self.review_manager.exact_call and script_call == "":
-            script_call = self.review_manager.exact_call
-
-        commit = colrev.ops.commit.Commit(
-            review_manager=self.review_manager,
-            msg=msg,
-            manual_author=manual_author,
-            script_name=script_call,
-            saved_args=saved_args,
-            skip_hooks=skip_hooks,
-        )
-        ret = commit.create(skip_status_yaml=skip_status_yaml)
-        return ret
-
-    def file_in_history(self, filepath: Path) -> bool:
-        """Check whether a file is in the git history"""
-        return str(filepath) in [
-            o.path for o in self._git_repo.head.commit.tree.traverse()
-        ]
-
-    def get_commit_message(self, *, commit_nr: int) -> str:
-        """Get the commit message for commit #"""
-        master = self._git_repo.head.reference
-        assert commit_nr == 0  # extension : implement other cases
-        if commit_nr == 0:
-            cmsg = master.commit.message
-            return cmsg
-        return ""
-
-    def _add_record_changes(self) -> None:
-        """Add changes in records to git"""
-        self._sleep_util_git_unlocked()
-        self._git_repo.index.add([str(self.review_manager.paths.RECORDS_FILE)])
-
-    def add_setting_changes(self) -> None:
-        """Add changes in settings to git"""
-        self._sleep_util_git_unlocked()
-
-        self._git_repo.index.add([str(self.review_manager.paths.SETTINGS_FILE)])
-
-    def has_untracked_search_records(self) -> bool:
-        """Check whether there are untracked search records"""
-        return any(
-            str(self.review_manager.paths.SEARCH_DIR) in str(untracked_file)
-            for untracked_file in self.get_untracked_files()
-        )
-
-    def stash_unstaged_changes(self) -> bool:
-        """Stash unstaged changes"""
-        ret = self._git_repo.git.stash("push", "--keep-index")
-        return "No local changes to save" != ret
-
-    def reset_log_if_no_changes(self) -> None:
-        """Reset the report log file if there are not changes"""
-        if not self._git_repo.is_dirty():
-            self.review_manager.reset_report_logger()
-
-    def get_last_commit_sha(self) -> str:  # pragma: no cover
-        """Get the last commit sha"""
-        return str(self._git_repo.head.commit.hexsha)
-
-    def get_tree_hash(self) -> str:  # pragma: no cover
-        """Get the current tree hash"""
-        tree_hash = self._git_repo.git.execute(["git", "write-tree"])
-        return str(tree_hash)
-
-    def get_last_updated(self, feed_file: Path) -> str:
-        """Returns the date of the last update (if available) in YYYY-MM-DD format"""
-        if not feed_file.is_file():
-            return ""
-        return self.get_last_commit_date(feed_file)
-
-    def _get_remote_commit_differences(self) -> list:  # pragma: no cover
-        origin = self._git_repo.remotes.origin
-        if origin.exists():
-            try:
-                origin.fetch()
-            except GitCommandError:
-                return [-1, -1]
-
-        nr_commits_behind, nr_commits_ahead = -1, -1
-        if self._git_repo.active_branch.tracking_branch() is not None:
-            branch_name = str(self._git_repo.active_branch)
-            tracking_branch_name = str(self._git_repo.active_branch.tracking_branch())
-            # self.review_manager.logger.debug(f"{branch_name} - {tracking_branch_name}")
-
-            behind_operation = branch_name + ".." + tracking_branch_name
-            commits_behind = self._git_repo.iter_commits(behind_operation)
-            nr_commits_behind = sum(1 for c in commits_behind)
-
-            ahead_operation = tracking_branch_name + ".." + branch_name
-            commits_ahead = self._git_repo.iter_commits(ahead_operation)
-            nr_commits_ahead = sum(1 for c in commits_ahead)
-
-        return [nr_commits_behind, nr_commits_ahead]
-
-    def behind_remote(self) -> bool:  # pragma: no cover
-        """Check whether the repository is behind the remote"""
-        nr_commits_behind = 0
-        connected_remote = 0 != len(self._git_repo.remotes)
-        if connected_remote:
-            origin = self._git_repo.remotes.origin
-            if origin.exists():
-                (
-                    nr_commits_behind,
-                    _,
-                ) = self._get_remote_commit_differences()
-        if nr_commits_behind > 0:
-            return True
-        return False
-
-    def remote_ahead(self) -> bool:  # pragma: no cover
-        """Check whether the remote is ahead"""
-        connected_remote = 0 != len(self._git_repo.remotes)
-        if connected_remote:
-            origin = self._git_repo.remotes.origin
-            if origin.exists():
-                (
-                    _,
-                    nr_commits_ahead,
-                ) = self._get_remote_commit_differences()
-                if nr_commits_ahead > 0:
-                    return True
-        return False
-
-    def pull_if_repo_clean(self) -> None:  # pragma: no cover
-        """Pull project if repository is clean"""
-        if not self._git_repo.is_dirty():
-            origin = self._git_repo.remotes.origin
-            origin.pull()
-
-    def get_remote_url(self) -> str:  # pragma: no cover
-        """Get the remote url"""
-        remote_url = "NA"
-        for remote in self._git_repo.remotes:
-            if remote.name == "origin":
-                remote_url = remote.url
-        return remote_url
-
-    def get_last_commit_date(self, filename: Path) -> str:
-        """Get the last commit date for a file"""
-        last_commit = next(self._git_repo.iter_commits(paths=filename))
-        return last_commit.committed_datetime.isoformat()

--- a/colrev/env/environment_manager.py
+++ b/colrev/env/environment_manager.py
@@ -196,10 +196,10 @@ class EnvironmentManager:
                         2,
                     )
 
-                git_repo = check_operation.review_manager.dataset.get_repo()
+                git_repo = check_operation.review_manager.dataset.git_repo.get_repo()
                 repo["remote"] = bool(git_repo.remotes)
                 repo["behind_remote"] = (
-                    check_operation.review_manager.dataset.behind_remote()
+                    check_operation.review_manager.dataset.git_repo.behind_remote()
                 )
 
                 repos.append(repo)

--- a/colrev/env/local_index_builder.py
+++ b/colrev/env/local_index_builder.py
@@ -276,7 +276,7 @@ class LocalIndexBuilder:
 
             check_operation = colrev.ops.check.CheckOperation(review_manager)
 
-            if review_manager.dataset.get_repo().active_branch.name != "main":
+            if review_manager.dataset.git_repo.get_repo().active_branch.name != "main":
                 print(
                     f"{Colors.ORANGE}Warning: {repo_source_path} not on main branch{Colors.END}"
                 )

--- a/colrev/git_repo.py
+++ b/colrev/git_repo.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from pathlib import Path
+from random import randint
+import time
+import typing
+
+import git
+from git import GitCommandError, InvalidGitRepositoryError
+
+import colrev.exceptions as colrev_exceptions
+from colrev.constants import FileSets
+
+
+class GitRepo:
+    """Wrapper for Git repository interactions"""
+
+    def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
+        self.review_manager = review_manager
+        try:
+            self.repo = git.Repo(self.review_manager.path)
+        except InvalidGitRepositoryError as exc:
+            msg = "Not a CoLRev/git repository. Run\n    colrev init"
+            raise colrev_exceptions.RepoSetupError(msg) from exc
+
+        self.update_gitignore(
+            add=FileSets.DEFAULT_GIT_IGNORE_ITEMS,
+            remove=FileSets.DEPRECATED_GIT_IGNORE_ITEMS,
+        )
+
+    def get_repo(self) -> git.Repo:
+        """Get the git repository object"""
+        if self.review_manager.notified_next_operation is None:
+            raise colrev_exceptions.ReviewManagerNotNotifiedError()
+        return self.repo
+
+    def repo_initialized(self) -> bool:
+        """Check whether the repository is initialized"""
+        try:
+            self.repo.head.commit
+        except ValueError:
+            return False
+        return True
+
+    def has_record_changes(self, *, change_type: str = "all") -> bool:
+        """Check whether the records have changes"""
+        return self.has_changes(Path(self.review_manager.paths.RECORDS_FILE_GIT), change_type=change_type)
+
+    def has_changes(self, relative_path: Path, *, change_type: str = "all") -> bool:
+        """Check whether the relative path (or the git repository) has changes"""
+        assert change_type in ["all", "staged", "unstaged"], "Invalid change_type specified"
+        try:
+            bool(self.repo.head.commit)
+        except ValueError:
+            return True  # Repository has no commit
+
+        diff_index = [item.a_path for item in self.repo.index.diff(None)]
+        diff_head = [item.a_path for item in self.repo.head.commit.diff()]
+        unstaged_changes = diff_index + self.repo.untracked_files
+
+        path_str = str(relative_path).replace("\\", "/")
+
+        if change_type == "all":
+            path_changed = path_str in diff_index + diff_head
+        elif change_type == "staged":
+            path_changed = path_str in diff_head
+        elif change_type == "unstaged":
+            path_changed = path_str in unstaged_changes
+        else:
+            return False
+        return path_changed
+
+    def update_gitignore(
+        self, *, add: typing.Optional[list] = None, remove: typing.Optional[list] = None
+    ) -> None:
+        """Update the gitignore file by adding or removing particular paths"""
+        git_ignore_file = self.review_manager.paths.git_ignore
+        if git_ignore_file.is_file():
+            gitignore_content = git_ignore_file.read_text(encoding="utf-8")
+        else:
+            gitignore_content = ""
+        ignored_items = gitignore_content.splitlines()
+        if remove:
+            ignored_items = [x for x in ignored_items if x not in remove]
+        if add:
+            ignored_items += [str(a) for a in add if str(a) not in ignored_items]
+        with git_ignore_file.open("w", encoding="utf-8") as file:
+            file.write("\n".join(ignored_items) + "\n")
+        self.add_changes(git_ignore_file)
+
+    def _sleep_util_git_unlocked(self) -> None:
+        i = 0
+        while (self.review_manager.path / Path(".git/index.lock")).is_file():  # pragma: no cover
+            i += 1
+            time.sleep(randint(1, 50) * 0.1)  # nosec
+            if i > 5:
+                print("Waiting for previous git operation to complete")
+            elif i > 30:
+                raise colrev_exceptions.GitNotAvailableError()
+
+    def add_changes(
+        self, path: Path, *, remove: bool = False, ignore_missing: bool = False
+    ) -> None:
+        """Add changed file to git"""
+        if path.is_absolute():
+            path = path.relative_to(self.review_manager.path)
+        path_str = str(path).replace("\\", "/")
+
+        self._sleep_util_git_unlocked()
+        try:
+            if remove:
+                self.repo.index.remove([path_str])
+            else:
+                self.repo.index.add([path_str])
+        except FileNotFoundError as exc:
+            if not ignore_missing:
+                raise exc
+
+    def get_untracked_files(self) -> list[Path]:
+        """Get the files that are untracked by git"""
+        return [Path(x) for x in self.repo.untracked_files]
+
+    def records_changed(self) -> bool:
+        """Check whether the records were changed"""
+        main_recs_changed = self.review_manager.paths.RECORDS_FILE_GIT in [
+            item.a_path for item in self.repo.index.diff(None)
+        ] + [x.a_path for x in self.repo.head.commit.diff()]
+        return main_recs_changed
+
+    # pylint: disable=too-many-arguments
+    def create_commit(
+        self,
+        *,
+        msg: str,
+        manual_author: bool = False,
+        script_call: str = "",
+        saved_args: typing.Optional[dict] = None,
+        skip_status_yaml: bool = False,
+        skip_hooks: bool = True,
+    ) -> bool:
+        """Create a commit (including a commit report)"""
+        # pylint: disable=import-outside-toplevel
+        # pylint: disable=redefined-outer-name
+        import colrev.ops.commit
+
+        if self.review_manager.exact_call and script_call == "":
+            script_call = self.review_manager.exact_call
+
+        commit = colrev.ops.commit.Commit(
+            review_manager=self.review_manager,
+            msg=msg,
+            manual_author=manual_author,
+            script_name=script_call,
+            saved_args=saved_args,
+            skip_hooks=skip_hooks,
+        )
+        ret = commit.create(skip_status_yaml=skip_status_yaml)
+        return ret
+
+    def file_in_history(self, filepath: Path) -> bool:
+        """Check whether a file is in the git history"""
+        return str(filepath) in [
+            o.path for o in self.repo.head.commit.tree.traverse()
+        ]
+
+    def get_commit_message(self, *, commit_nr: int) -> str:
+        """Get the commit message for commit #"""
+        master = self.repo.head.reference
+        assert commit_nr == 0  # extension : implement other cases
+        if commit_nr == 0:
+            cmsg = master.commit.message
+            return cmsg
+        return ""
+
+    def add_setting_changes(self) -> None:
+        """Add changes in settings to git"""
+        self._sleep_util_git_unlocked()
+        self.repo.index.add([str(self.review_manager.paths.SETTINGS_FILE)])
+
+    def has_untracked_search_records(self) -> bool:
+        """Check whether there are untracked search records"""
+        return any(
+            str(self.review_manager.paths.SEARCH_DIR) in str(untracked_file)
+            for untracked_file in self.get_untracked_files()
+        )
+
+    def stash_unstaged_changes(self) -> bool:
+        """Stash unstaged changes"""
+        ret = self.repo.git.stash("push", "--keep-index")
+        return "No local changes to save" != ret
+
+    def reset_log_if_no_changes(self) -> None:
+        """Reset the report log file if there are not changes"""
+        if not self.repo.is_dirty():
+            self.review_manager.reset_report_logger()
+
+    def get_last_commit_sha(self) -> str:  # pragma: no cover
+        """Get the last commit sha"""
+        return str(self.repo.head.commit.hexsha)
+
+    def get_tree_hash(self) -> str:  # pragma: no cover
+        """Get the current tree hash"""
+        tree_hash = self.repo.git.execute(["git", "write-tree"])
+        return str(tree_hash)
+
+    def get_last_updated(self, feed_file: Path) -> str:
+        """Returns the date of the last update (if available) in YYYY-MM-DD format"""
+        if not feed_file.is_file():
+            return ""
+        return self.get_last_commit_date(feed_file)
+
+    def _get_remote_commit_differences(self) -> list:  # pragma: no cover
+        origin = self.repo.remotes.origin
+        if origin.exists():
+            try:
+                origin.fetch()
+            except GitCommandError:
+                return [-1, -1]
+
+        nr_commits_behind, nr_commits_ahead = -1, -1
+        if self.repo.active_branch.tracking_branch() is not None:
+            branch_name = str(self.repo.active_branch)
+            tracking_branch_name = str(self.repo.active_branch.tracking_branch())
+
+            behind_operation = branch_name + ".." + tracking_branch_name
+            commits_behind = self.repo.iter_commits(behind_operation)
+            nr_commits_behind = sum(1 for _ in commits_behind)
+
+            ahead_operation = tracking_branch_name + ".." + branch_name
+            commits_ahead = self.repo.iter_commits(ahead_operation)
+            nr_commits_ahead = sum(1 for _ in commits_ahead)
+
+        return [nr_commits_behind, nr_commits_ahead]
+
+    def behind_remote(self) -> bool:  # pragma: no cover
+        """Check whether the repository is behind the remote"""
+        nr_commits_behind = 0
+        connected_remote = 0 != len(self.repo.remotes)
+        if connected_remote:
+            origin = self.repo.remotes.origin
+            if origin.exists():
+                (
+                    nr_commits_behind,
+                    _,
+                ) = self._get_remote_commit_differences()
+        if nr_commits_behind > 0:
+            return True
+        return False
+
+    def remote_ahead(self) -> bool:  # pragma: no cover
+        """Check whether the remote is ahead"""
+        connected_remote = 0 != len(self.repo.remotes)
+        if connected_remote:
+            origin = self.repo.remotes.origin
+            if origin.exists():
+                (
+                    _,
+                    nr_commits_ahead,
+                ) = self._get_remote_commit_differences()
+                if nr_commits_ahead > 0:
+                    return True
+        return False
+
+    def pull_if_repo_clean(self) -> None:  # pragma: no cover
+        """Pull project if repository is clean"""
+        if not self.repo.is_dirty():
+            origin = self.repo.remotes.origin
+            origin.pull()
+
+    def get_remote_url(self) -> str:  # pragma: no cover
+        """Get the remote url"""
+        remote_url = "NA"
+        for remote in self.repo.remotes:
+            if remote.name == "origin":
+                remote_url = remote.url
+        return remote_url
+
+    def get_last_commit_date(self, filename: Path) -> str:
+        """Get the last commit date for a file"""
+        last_commit = next(self.repo.iter_commits(paths=filename))
+        return last_commit.committed_datetime.isoformat()

--- a/colrev/hooks/report.py
+++ b/colrev/hooks/report.py
@@ -38,7 +38,7 @@ def main() -> int:
 
     if (
         not review_manager.settings.is_curated_masterdata_repo()
-        and review_manager.dataset.records_changed()
+        and review_manager.dataset.git_repo.records_changed()
     ):  # pragma: no cover
         colrev.ops.check.CheckOperation(review_manager)  # to notify
         corrections_operation = colrev.ops.correct.Corrections(

--- a/colrev/ops/advisor.py
+++ b/colrev/ops/advisor.py
@@ -100,7 +100,7 @@ class Advisor:
         share_stat_req = self.review_manager.settings.project.share_stat_req
         collaboration_instructions["SHARE_STAT_REQ"] = share_stat_req
 
-        if self.review_manager.dataset.behind_remote():
+        if self.review_manager.dataset.git_repo.behind_remote():
             item = {
                 "title": "Remote changes available on the server",
                 "level": "WARNING",
@@ -111,7 +111,7 @@ class Advisor:
             }
             collaboration_instructions["items"].append(item)
 
-        if self.review_manager.dataset.remote_ahead():
+        if self.review_manager.dataset.git_repo.remote_ahead():
             item = {
                 "title": "Local changes not yet on the server",
                 "level": "WARNING",
@@ -197,7 +197,7 @@ class Advisor:
         """Get instructions related to collaboration"""
 
         collaboration_instructions: dict = {"items": []}
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         remote_connected = 0 != len(git_repo.remotes)
         if remote_connected:
@@ -254,7 +254,7 @@ class Advisor:
         self, review_instructions: list
     ) -> None:
         # If changes in RECORDS_FILE are staged, we need to detect the process type
-        if self.review_manager.dataset.records_changed():
+        if self.review_manager.dataset.git_repo.records_changed():
             # Detect and validate transitions
             transitioned_records = self.status_stats.get_transitioned_records(
                 self.review_manager
@@ -469,7 +469,7 @@ class Advisor:
             self.status_stats.completeness_condition
             and self.status_stats.currently.md_retrieved > 0
         ):
-            if not self.review_manager.dataset.has_untracked_search_records():
+            if not self.review_manager.dataset.git_repo.has_untracked_search_records():
                 instruction = {
                     "info": "Review iteration completed.",
                     "msg": "To start the next iteration of the review, run the search",
@@ -499,7 +499,7 @@ class Advisor:
             return nr_commits_behind > 0 and nr_commits_ahead > 0
 
         try:
-            # Note : registered_path are other repositories (don't load from dataset.get_repo())
+            # Note : registered_path are other repositories (don't load from dataset.git_repo.get_repo())
             git_repo = git.Repo(registered_path)
             # https://github.com/gitpython-developers/GitPython/issues/652#issuecomment-610511311
             origin = git_repo.remotes.origin

--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -95,7 +95,7 @@ class Checker:
         # Note: when check is called directly from the command line.
         # pre-commit hooks automatically notify on merge conflicts
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         unmerged_blobs = git_repo.index.unmerged_blobs()
 
         for path, list_of_blobs in unmerged_blobs.items():
@@ -107,7 +107,7 @@ class Checker:
         try:
             if not (self.review_manager.path / Path(".git")).is_dir():
                 return False
-            _ = self.review_manager.dataset.get_repo().git_dir
+            _ = self.review_manager.dataset.git_repo.get_repo().git_dir
             return True
         except InvalidGitRepositoryError:
             return False
@@ -228,7 +228,7 @@ class Checker:
             )
 
         # if (
-        #     self.review_manager.dataset.records_changed()
+        #     self.review_manager.dataset.git_repo.records_changed()
         #     or self.review_manager.verbose_mode
         # ):
         #     # Check for broken origins
@@ -702,7 +702,7 @@ class Checker:
         ]
 
         if self.review_manager.paths.records.is_file():
-            if self.review_manager.dataset.file_in_history(
+            if self.review_manager.dataset.git_repo.file_in_history(
                 self.review_manager.paths.RECORDS_FILE
             ):
                 prior = self._retrieve_prior()

--- a/colrev/ops/commit.py
+++ b/colrev/ops/commit.py
@@ -145,7 +145,7 @@ class Commit:
     def create(self, *, skip_status_yaml: bool = False) -> bool:
         """Create a commit (including the commit message and details)"""
         status_operation = self.review_manager.get_status_operation()
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         try:
             if not git_repo.index.diff("HEAD"):
                 self.review_manager.logger.debug(
@@ -161,7 +161,7 @@ class Commit:
         if not skip_status_yaml:
             status_yml = self.review_manager.paths.status
             self.review_manager.update_status_yaml()
-            self.review_manager.dataset.add_changes(status_yml)
+            self.review_manager.dataset.git_repo.add_changes(status_yml)
 
         committer, email = self.review_manager.get_committer()
 
@@ -172,9 +172,9 @@ class Commit:
 
         # Note : this should run as the last command before creating the commit
         # to ensure that the git tree_hash is up-to-date.
-        self.tree_hash = self.review_manager.dataset.get_tree_hash()
+        self.tree_hash = self.review_manager.dataset.git_repo.get_tree_hash()
         try:
-            self.last_commit_sha = self.review_manager.dataset.get_last_commit_sha()
+            self.last_commit_sha = self.review_manager.dataset.git_repo.get_last_commit_sha()
         except ValueError:
             pass
 
@@ -197,7 +197,7 @@ class Commit:
         self.review_manager.logger.info("Created commit")
         self.review_manager.reset_report_logger()
 
-        if self.review_manager.dataset.has_record_changes():
+        if self.review_manager.dataset.git_repo.has_record_changes():
             if not self.review_manager.force_mode:
                 raise colrev_exceptions.DirtyRepoAfterProcessingError(
                     "A clean repository is expected."

--- a/colrev/ops/custom_scripts/custom_prescreen_script.py
+++ b/colrev/ops/custom_scripts/custom_prescreen_script.py
@@ -47,7 +47,7 @@ class CustomPrescreen(base_classes.PrescreenPackageBaseClass):
                 )
 
         self.prescreen_operation.review_manager.dataset.save_records_dict(records)
-        self.prescreen_operation.review_manager.dataset.create_commit(
+        self.prescreen_operation.review_manager.dataset.git_repo.create_commit(
             msg="Pre-screen (random)",
             manual_author=False,
             script_call="colrev prescreen",

--- a/colrev/ops/custom_scripts/custom_screen_script.py
+++ b/colrev/ops/custom_scripts/custom_screen_script.py
@@ -70,7 +70,7 @@ class CustomScreen(base_classes.ScreenPackageBaseClass):
 
         self.screen_operation.review_manager.dataset.save_records_dict(records)
         self.screen_operation.review_manager.dataset.add_record_changes()
-        self.screen_operation.review_manager.dataset.create_commit(
+        self.screen_operation.review_manager.dataset.git_repo.create_commit(
             msg="Screen (random)", manual_author=False, script_call="colrev screen"
         )
         return records

--- a/colrev/ops/data.py
+++ b/colrev/ops/data.py
@@ -106,7 +106,7 @@ class Data(colrev.process.operation.Operation):
             with open("custom_data_script.py", "w", encoding="utf-8") as file:
                 file.write(filedata.decode("utf-8"))
 
-        self.review_manager.dataset.add_changes(Path("custom_data_script.py"))
+        self.review_manager.dataset.git_repo.add_changes(Path("custom_data_script.py"))
 
         new_data_endpoint = {"endpoint": "custom_data_script"}
 
@@ -264,6 +264,6 @@ class Data(colrev.process.operation.Operation):
         )
 
         return {
-            "ask_to_commit": self.review_manager.dataset.has_record_changes(),
+            "ask_to_commit": self.review_manager.dataset.git_repo.has_record_changes(),
             "no_endpoints_registered": no_endpoints_registered,
         }

--- a/colrev/ops/dedupe.py
+++ b/colrev/ops/dedupe.py
@@ -581,8 +581,8 @@ class Dedupe(colrev.process.operation.Operation):
         self.unmerge_records(current_record_ids=false_positives)
         self.apply_merges(id_sets=false_negatives, complete_dedupe=False)
 
-        if self.review_manager.dataset.records_changed():
-            self.review_manager.dataset.create_commit(
+        if self.review_manager.dataset.git_repo.records_changed():
+            self.review_manager.dataset.git_repo.create_commit(
                 msg="Validate and correct duplicates",
                 manual_author=True,
             )
@@ -648,7 +648,7 @@ class Dedupe(colrev.process.operation.Operation):
 
         if apply:
             self.apply_merges(id_sets=id_sets)
-            self.review_manager.dataset.create_commit(
+            self.review_manager.dataset.git_repo.create_commit(
                 msg="Merge records (identical global IDs)"
             )
 
@@ -699,7 +699,7 @@ class Dedupe(colrev.process.operation.Operation):
             if not self.review_manager.high_level_operation:
                 print()
 
-        dedupe_commit_id = self.review_manager.dataset.get_repo().head.commit.hexsha
+        dedupe_commit_id = self.review_manager.dataset.git_repo.get_repo().head.commit.hexsha
         self.review_manager.logger.info("To validate the changes, use")
 
         self.review_manager.logger.info(
@@ -720,4 +720,4 @@ class Dedupe(colrev.process.operation.Operation):
                     record.set_status(RecordState.rev_prescreen_included)
 
             self.review_manager.dataset.save_records_dict(records)
-            self.review_manager.dataset.create_commit(msg="Skip prescreen/include all")
+            self.review_manager.dataset.git_repo.create_commit(msg="Skip prescreen/include all")

--- a/colrev/ops/distribute.py
+++ b/colrev/ops/distribute.py
@@ -132,4 +132,4 @@ class Distribute(colrev.process.operation.Operation):
 
                 write_file(records_dict=import_records_dict, filename=target_bib_file)
 
-                self.review_manager.dataset.add_changes(target_bib_file)
+                self.review_manager.dataset.git_repo.add_changes(target_bib_file)

--- a/colrev/ops/init.py
+++ b/colrev/ops/init.py
@@ -101,13 +101,13 @@ class Initializer:
 
         self._git_rm_settings()
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Init: Create CoLRev repository",
             manual_author=True,
             skip_hooks=True,
         )
         self._add_colrev_project_details()
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Init: Create CoLRev project",
             manual_author=True,
             skip_hooks=True,
@@ -123,7 +123,7 @@ class Initializer:
 
     def _git_rm_settings(self) -> None:
         colrev.ops.check.CheckOperation(self.review_manager)
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         git_repo.index.remove([self.review_manager.paths.settings])
 
     def _add_colrev_project_details(self) -> None:
@@ -134,7 +134,7 @@ class Initializer:
         )
         data_operation.main(silent_mode=True)
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         git_repo.git.add(all=True)
 
     def _format_review_type(self, review_type: str) -> str:
@@ -439,7 +439,7 @@ class Initializer:
 
         self._fix_pre_commit_hooks_windows()
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         git_repo.git.add(all=True)
 
     def _register_repo(self, *, example: bool) -> None:
@@ -501,7 +501,7 @@ class Initializer:
             target=Path("data/search/30_example_records.bib"),
         )
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         git_repo.index.add(["data/search/30_example_records.bib"])
 
         with open(self.review_manager.paths.settings, encoding="utf-8") as file:

--- a/colrev/ops/load.py
+++ b/colrev/ops/load.py
@@ -76,7 +76,7 @@ class Load(colrev.process.operation.Operation):
         This method must be called for all packages that work
         with an ex-post assignment of incremental IDs."""
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         # Ensure the path uses forward slashes, which is compatible with Git's path handling
         search_file_path = str(Path("data/search") / filename.name).replace("\\", "/")
@@ -238,12 +238,12 @@ class Load(colrev.process.operation.Operation):
             shutil.move(
                 str(source.search_source.search_results_path), str(new_filename)
             )
-            self.review_manager.dataset.add_changes(
+            self.review_manager.dataset.git_repo.add_changes(
                 source.search_source.search_results_path, remove=True
             )
             source.search_source.search_results_path = new_filename
-            self.review_manager.dataset.add_changes(new_filename)
-            self.review_manager.dataset.create_commit(
+            self.review_manager.dataset.git_repo.add_changes(new_filename)
+            self.review_manager.dataset.git_repo.create_commit(
                 msg=f"Rename {source.search_source.search_results_path}"
             )
             return
@@ -259,12 +259,12 @@ class Load(colrev.process.operation.Operation):
             shutil.move(
                 str(source.search_source.search_history_path), str(new_filename)
             )
-            self.review_manager.dataset.add_changes(
+            self.review_manager.dataset.git_repo.add_changes(
                 source.search_source.search_history_path, remove=True
             )
             source.search_source.search_history_path = new_filename
-            self.review_manager.dataset.add_changes(new_filename)
-            self.review_manager.dataset.create_commit(
+            self.review_manager.dataset.git_repo.add_changes(new_filename)
+            self.review_manager.dataset.git_repo.create_commit(
                 msg=f"Rename {source.search_source.search_history_path}"
             )
 
@@ -390,8 +390,8 @@ class Load(colrev.process.operation.Operation):
         self.review_manager.logger.info(
             "New records loaded".ljust(38) + f"{source.search_source.to_import} records"
         )
-        self.review_manager.dataset.add_setting_changes()
-        self.review_manager.dataset.add_changes(
+        self.review_manager.dataset.git_repo.add_setting_changes()
+        self.review_manager.dataset.git_repo.add_changes(
             source.search_source.search_results_path
         )
 
@@ -409,13 +409,13 @@ class Load(colrev.process.operation.Operation):
         self.review_manager.logger.debug(
             f"Add source to settings {source.search_source.search_history_path}"
         )
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         self.review_manager.settings.sources.append(source.search_source)
         self.review_manager.save_settings()
         # Add files that were renamed (removed)
         for obj in git_repo.index.diff(None).iter_change_type("D"):
             if source.search_source.search_history_path.stem in obj.b_path:
-                self.review_manager.dataset.add_changes(Path(obj.b_path), remove=True)
+                self.review_manager.dataset.git_repo.add_changes(Path(obj.b_path), remove=True)
 
     def load_active_sources(self, *, include_md: bool = False) -> list:
         """
@@ -506,7 +506,7 @@ class Load(colrev.process.operation.Operation):
     def _create_load_commit(
         self, source: colrev.search_file.ExtendedSearchFile
     ) -> None:
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         stashed = "No local changes to save" != git_repo.git.stash(
             "push", "--keep-index"
         )
@@ -514,7 +514,7 @@ class Load(colrev.process.operation.Operation):
         # self.review_manager.exact_call = (
         #     f"{part_exact_call} -s {source.search_source.search_results_path.name}"
         # )
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg=f"Load: data/search/{source.search_source.search_results_path.name} → "
             f"{self.review_manager.paths.RECORDS_FILE_GIT}",
             skip_hooks=True,

--- a/colrev/ops/merge.py
+++ b/colrev/ops/merge.py
@@ -90,7 +90,7 @@ class Merge(colrev.process.operation.Operation):
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-statements
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         # our_index  = git_repo.index
 
         for remote in git_repo.remotes:

--- a/colrev/ops/pdf_get.py
+++ b/colrev/ops/pdf_get.py
@@ -326,7 +326,7 @@ class PDFGet(colrev.process.operation.Operation):
             )
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.add_changes(source.search_history_path)
+        self.review_manager.dataset.git_repo.add_changes(source.search_history_path)
 
     def relink_pdfs(self) -> None:
         """Relink record files to the corresponding PDFs (if available)"""
@@ -341,7 +341,7 @@ class PDFGet(colrev.process.operation.Operation):
         for source in sources:
             self._relink_pdfs_in_source(source)
 
-        self.review_manager.dataset.create_commit(msg="Relink PDFs")
+        self.review_manager.dataset.git_repo.create_commit(msg="Relink PDFs")
 
     def check_existing_unlinked_pdfs(
         self,
@@ -506,7 +506,7 @@ class PDFGet(colrev.process.operation.Operation):
         self.review_manager.dataset.save_records_dict(records)
 
         if pdfs_search_file.is_file():
-            self.review_manager.dataset.add_changes(pdfs_search_file)
+            self.review_manager.dataset.git_repo.add_changes(pdfs_search_file)
 
     def _get_data(self) -> dict:
         # pylint: disable=duplicate-code
@@ -618,7 +618,7 @@ class PDFGet(colrev.process.operation.Operation):
             with open("custom_pdf_get_script.py", "w", encoding="utf-8") as file:
                 file.write(filedata.decode("utf-8"))
 
-        self.review_manager.dataset.add_changes(Path("custom_pdf_get_script.py"))
+        self.review_manager.dataset.git_repo.add_changes(Path("custom_pdf_get_script.py"))
 
         self.review_manager.settings.pdf_get.pdf_get_man_package_endpoints.append(
             {"endpoint": "custom_pdf_get_script"}
@@ -677,7 +677,7 @@ class PDFGet(colrev.process.operation.Operation):
         if self.review_manager.settings.pdf_get.rename_pdfs:
             self.rename_pdfs()
 
-        self.review_manager.dataset.create_commit(msg="PDFs: get and prepare")
+        self.review_manager.dataset.git_repo.create_commit(msg="PDFs: get and prepare")
         self.review_manager.logger.info(
             f"{Colors.GREEN}Completed pdf-get operation{Colors.END}"
         )

--- a/colrev/ops/pdf_get_man.py
+++ b/colrev/ops/pdf_get_man.py
@@ -91,7 +91,7 @@ class PDFGetMan(colrev.process.operation.Operation):
             if record.data[Fields.STATUS] == RecordState.pdf_needs_manual_retrieval:
                 record.set_status(RecordState.pdf_not_available)
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Discard missing PDFs", manual_author=True
         )
 
@@ -123,7 +123,7 @@ class PDFGetMan(colrev.process.operation.Operation):
 
     def pdfs_retrieved_manually(self) -> bool:
         """Check whether PDFs were retrieved manually"""
-        return self.review_manager.dataset.has_record_changes()
+        return self.review_manager.dataset.git_repo.has_record_changes()
 
     def pdf_get_man_record(
         self,

--- a/colrev/ops/pdf_prep.py
+++ b/colrev/ops/pdf_prep.py
@@ -299,7 +299,7 @@ class PDFPrep(colrev.process.operation.Operation):
         pool.join()
         records = {r[Fields.ID]: r for r in records_list}
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(msg="Update colrev_pdf_ids")
+        self.review_manager.dataset.git_repo.create_commit(msg="Update colrev_pdf_ids")
 
     def _print_stats(self, *, pdf_prep_record_list: list) -> None:
         self.pdf_prepared = len(
@@ -355,7 +355,7 @@ class PDFPrep(colrev.process.operation.Operation):
             with open("custom_pdf_prep_script.py", "w", encoding="utf-8") as file:
                 file.write(filedata.decode("utf-8"))
 
-        self.review_manager.dataset.add_changes(Path("custom_pdf_prep_script.py"))
+        self.review_manager.dataset.git_repo.add_changes(Path("custom_pdf_prep_script.py"))
 
         self.review_manager.settings.pdf_prep.pdf_prep_package_endpoints.append(
             {"endpoint": "custom_pdf_prep_script"}
@@ -472,7 +472,7 @@ class PDFPrep(colrev.process.operation.Operation):
 
             self._print_stats(pdf_prep_record_list=pdf_prep_record_list)
 
-        self.review_manager.dataset.create_commit(msg="PDFs: prepare")
+        self.review_manager.dataset.git_repo.create_commit(msg="PDFs: prepare")
         self.review_manager.logger.info(
             f"{Colors.GREEN}Completed pdf-prep operation{Colors.END}"
         )

--- a/colrev/ops/pdf_prep_man.py
+++ b/colrev/ops/pdf_prep_man.py
@@ -49,7 +49,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
                 record = colrev.record.record.Record(record_dict)
                 record.set_status(RecordState.pdf_not_available)
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Discard man-prep PDFs", manual_author=True
         )
 
@@ -81,7 +81,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
 
     def pdfs_prepared_manually(self) -> bool:
         """Check whether PDFs were prepared manually"""
-        return self.review_manager.dataset.has_record_changes()
+        return self.review_manager.dataset.git_repo.has_record_changes()
 
     def pdf_prep_man_stats(self) -> None:
         """Determine PDF prep man statistics"""
@@ -284,7 +284,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
         self.review_manager.dataset.save_records_dict(
             {record_dict[Fields.ID]: record_dict}, partial=True
         )
-        self.review_manager.dataset.add_changes(self.review_manager.paths.RECORDS_FILE)
+        self.review_manager.dataset.git_repo.add_changes(self.review_manager.paths.RECORDS_FILE)
 
     @colrev.process.operation.Operation.decorate()
     def main(self) -> None:

--- a/colrev/ops/prep.py
+++ b/colrev/ops/prep.py
@@ -570,7 +570,7 @@ class Prep(colrev.process.operation.Operation):
                     old_string=old_filename,
                     new_string=str(new_filename),
                 )
-                self.review_manager.dataset.add_changes(pdfs_origin_file)
+                self.review_manager.dataset.git_repo.add_changes(pdfs_origin_file)
 
     def set_ids(self) -> None:
         """Set IDs (regenerate). In force-mode, all IDs are regenerated and PDFs are renamed"""
@@ -580,7 +580,7 @@ class Prep(colrev.process.operation.Operation):
         records = self.review_manager.dataset.set_ids()
         self._rename_files(records)
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(msg="Set IDs")
+        self.review_manager.dataset.git_repo.create_commit(msg="Set IDs")
 
     def setup_custom_script(self) -> None:
         """Setup a custom prep script"""
@@ -592,7 +592,7 @@ class Prep(colrev.process.operation.Operation):
             with open("custom_prep_script.py", "w", encoding="utf-8") as file:
                 file.write(filedata.decode("utf-8"))
 
-        self.review_manager.dataset.add_changes(Path("custom_prep_script.py"))
+        self.review_manager.dataset.git_repo.add_changes(Path("custom_prep_script.py"))
 
         prep_round = self.review_manager.settings.prep.prep_rounds[-1]
         prep_round.prep_package_endpoints.append({"endpoint": "custom_prep_script"})
@@ -893,10 +893,10 @@ class Prep(colrev.process.operation.Operation):
             {r[Fields.ID]: r for r in prepared_records}, partial=True
         )
         self._log_commit_details(prepared_records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Prep: improve record metadata",
         )
-        self._prep_commit_id = self.review_manager.dataset.get_repo().head.commit.hexsha
+        self._prep_commit_id = self.review_manager.dataset.git_repo.get_repo().head.commit.hexsha
         if not self.review_manager.high_level_operation:
             print()
         self.review_manager.reset_report_logger()
@@ -990,6 +990,6 @@ class Prep(colrev.process.operation.Operation):
         if not keep_ids and not self.polish:
             self.review_manager.logger.info("Set record IDs")
             self.review_manager.dataset.set_ids()
-            self.review_manager.dataset.create_commit(msg="Set IDs")
+            self.review_manager.dataset.git_repo.create_commit(msg="Set IDs")
 
         self._post_prep()

--- a/colrev/ops/prep_debug.py
+++ b/colrev/ops/prep_debug.py
@@ -82,7 +82,7 @@ class PrepDebug(colrev.ops.prep.Prep):
         print("\n")
 
     def _retrieve_records_from_history(self, original_records: list[dict]) -> list:
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         if self.commit_sha == "":
             self.commit_sha = git_repo.git.rev_parse("HEAD")

--- a/colrev/ops/prescreen.py
+++ b/colrev/ops/prescreen.py
@@ -143,7 +143,7 @@ class Prescreen(colrev.process.operation.Operation):
         if include:
             msg = f"Prescreen: include {ids}"
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg=msg,
             manual_author=False,
         )
@@ -207,7 +207,7 @@ class Prescreen(colrev.process.operation.Operation):
             with open("custom_prescreen_script.py", "w", encoding="utf8") as file:
                 file.write(filedata.decode("utf-8"))
 
-        self.review_manager.dataset.add_changes(Path("custom_prescreen_script.py"))
+        self.review_manager.dataset.git_repo.add_changes(Path("custom_prescreen_script.py"))
 
         self.review_manager.settings.prescreen.prescreen_package_endpoints.append(
             {"endpoint": "custom_prescreen_script"}
@@ -222,7 +222,7 @@ class Prescreen(colrev.process.operation.Operation):
                 record = colrev.record.record.Record(record_dict)
                 record.set_status(RecordState.rev_prescreen_included)
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Prescreen: include all",
             manual_author=False,
         )

--- a/colrev/ops/pull.py
+++ b/colrev/ops/pull.py
@@ -30,7 +30,7 @@ class Pull(colrev.process.operation.Operation):
 
     def _pull_project(self) -> None:
         try:
-            git_repo = self.review_manager.dataset.get_repo()
+            git_repo = self.review_manager.dataset.git_repo.get_repo()
             origin = git_repo.remotes.origin
             self.review_manager.logger.info(
                 f"Pull project changes from {git_repo.remotes.origin}"

--- a/colrev/ops/push.py
+++ b/colrev/ops/push.py
@@ -42,7 +42,7 @@ class Push(colrev.process.operation.Operation):
             self._push_record_corrections(all_records)
 
     def _push_project(self) -> None:
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         origin = git_repo.remotes.origin
         self.review_manager.logger.info(f"Push changes to {git_repo.remotes.origin}")
         origin.push()

--- a/colrev/ops/remove.py
+++ b/colrev/ops/remove.py
@@ -55,9 +55,9 @@ class Remove(colrev.process.operation.Operation):
 
                     write_file(records_dict=origin_records, filename=filepath)
 
-                    self.review_manager.dataset.add_changes(filepath)
+                    self.review_manager.dataset.git_repo.add_changes(filepath)
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Remove records", manual_author=False
         )

--- a/colrev/ops/repare.py
+++ b/colrev/ops/repare.py
@@ -410,7 +410,7 @@ class Repare(colrev.process.operation.Operation):
             write_file(
                 records_dict=curation_recs, filename=search_source.search_history_path
             )
-            self.review_manager.dataset.add_changes(search_source.search_history_path)
+            self.review_manager.dataset.git_repo.add_changes(search_source.search_history_path)
 
     def _update_field_names(self, records: dict) -> None:
         for record_dict in records.values():

--- a/colrev/ops/screen.py
+++ b/colrev/ops/screen.py
@@ -109,7 +109,7 @@ class Screen(colrev.process.operation.Operation):
 
         self.review_manager.dataset.save_records_dict(records)
         self._print_stats(selected_record_ids)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Screen: include all",
             manual_author=False,
         )
@@ -155,7 +155,7 @@ class Screen(colrev.process.operation.Operation):
 
         self.review_manager.settings.screen.criteria[criterion_name] = criterion
         self.review_manager.save_settings()
-        self.review_manager.dataset.add_setting_changes()
+        self.review_manager.dataset.git_repo.add_setting_changes()
 
         records = self.review_manager.dataset.load_records_dict()
         counter = 0
@@ -193,7 +193,7 @@ class Screen(colrev.process.operation.Operation):
         print()
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg=f"Screen: add criterion: {criterion_name}",
         )
         print()
@@ -205,7 +205,7 @@ class Screen(colrev.process.operation.Operation):
         if criterion_to_delete in self.review_manager.settings.screen.criteria:
             del self.review_manager.settings.screen.criteria[criterion_to_delete]
             self.review_manager.save_settings()
-            self.review_manager.dataset.add_setting_changes()
+            self.review_manager.dataset.git_repo.add_setting_changes()
         else:
             print(f"Error: criterion {criterion_to_delete} not in settings")
             return
@@ -246,7 +246,7 @@ class Screen(colrev.process.operation.Operation):
                     record.set_status(RecordState.rev_included)
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg=f"Screen: remove criterion {criterion_to_delete}",
         )
 
@@ -282,7 +282,7 @@ class Screen(colrev.process.operation.Operation):
             with open("custom_screen_script.py", "w", encoding="utf-8") as file:
                 file.write(filedata.decode("utf-8"))
 
-        self.review_manager.dataset.add_changes(Path("custom_screen_script.py"))
+        self.review_manager.dataset.git_repo.add_changes(Path("custom_screen_script.py"))
 
         self.review_manager.settings.screen.screen_package_endpoints.append(
             {"endpoint": "custom_screen_script"}
@@ -296,7 +296,7 @@ class Screen(colrev.process.operation.Operation):
                 record = colrev.record.record.Record(record_dict)
                 record.set_status(RecordState.rev_included)
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Screen: include all",
             manual_author=False,
         )
@@ -415,7 +415,7 @@ class Screen(colrev.process.operation.Operation):
             )
             record.remove_field(key="include_flag")
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg=f"Screen: include records {','.join(selected_auto_include_ids)}",
             manual_author=True,
         )
@@ -445,7 +445,7 @@ class Screen(colrev.process.operation.Operation):
             except colrev_exceptions.TEIException:
                 pass
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(msg="Add abstracts from TEI")
+        self.review_manager.dataset.git_repo.create_commit(msg="Add abstracts from TEI")
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, split_str: str = "NA") -> None:

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -77,7 +77,7 @@ class Search(colrev.process.operation.Operation):
                     f"Created {Colors.ORANGE}{query_filename}{Colors.END}. "
                     "Please store your query in the file and press Enter to continue."
                 )
-            self.review_manager.dataset.add_changes(query_filename)
+            self.review_manager.dataset.git_repo.add_changes(query_filename)
         return query_filename
 
     def create_db_source(  # type: ignore
@@ -117,8 +117,8 @@ class Search(colrev.process.operation.Operation):
             )
             input("Press Enter to complete")
 
-        self.review_manager.dataset.add_changes(filename, ignore_missing=True)
-        self.review_manager.dataset.add_changes(query_file)
+        self.review_manager.dataset.git_repo.add_changes(filename, ignore_missing=True)
+        self.review_manager.dataset.git_repo.add_changes(query_file)
 
         add_source = colrev.search_file.ExtendedSearchFile(
             platform=search_source_cls.endpoint,
@@ -204,7 +204,7 @@ class Search(colrev.process.operation.Operation):
         )
         input("Press enter to continue")
         if source.search_results_path.is_file():
-            self.review_manager.dataset.add_changes(source.search_results_path)
+            self.review_manager.dataset.git_repo.add_changes(source.search_results_path)
         else:
             print("Search results not found.")
 
@@ -438,7 +438,7 @@ class Search(colrev.process.operation.Operation):
 
                 self.review_manager.settings.sources.append(source["source_candidate"])
         self.review_manager.save_settings()
-        self.review_manager.dataset.create_commit(msg="Add new search sources")
+        self.review_manager.dataset.git_repo.create_commit(msg="Add new search sources")
 
     def get_new_source_heuristic(self, filename: Path) -> list:
         """Get the heuristic result list of SearchSources candidates
@@ -472,9 +472,9 @@ class Search(colrev.process.operation.Operation):
 
         search_file.save()
         # TODO : get_filepath()?
-        self.review_manager.dataset.add_changes(search_file.search_history_path)
+        self.review_manager.dataset.git_repo.add_changes(search_file.search_history_path)
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg=f"Search: add {search_file.platform}:{search_file.search_type} → "
             f"data/search/{search_file.search_history_path.name}"
         )
@@ -527,9 +527,9 @@ class Search(colrev.process.operation.Operation):
                 endpoint.search(rerun=rerun)  # type: ignore
 
                 self._remove_forthcoming(source)
-                self.review_manager.dataset.add_changes(source.search_results_path)
+                self.review_manager.dataset.git_repo.add_changes(source.search_results_path)
                 if not skip_commit:
-                    self.review_manager.dataset.create_commit(
+                    self.review_manager.dataset.git_repo.create_commit(
                         msg=f"Search: run {source.platform}:{source.search_type} → "
                         f"data/search/{source.search_results_path.name}"
                     )

--- a/colrev/ops/status.py
+++ b/colrev/ops/status.py
@@ -28,7 +28,7 @@ class Status(colrev.process.operation.Operation):
         """Get status analytics"""
 
         analytics_dict = {}
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         revlist = list(
             (

--- a/colrev/ops/trace.py
+++ b/colrev/ops/trace.py
@@ -79,7 +79,7 @@ class Trace(colrev.process.operation.Operation):
         self.review_manager.logger.info(f"Trace record by ID: {record_id}")
         # Ensure the path uses forward slashes, which is compatible with Git's path handling
 
-        revlist = self.review_manager.dataset.get_repo().iter_commits(
+        revlist = self.review_manager.dataset.git_repo.get_repo().iter_commits(
             paths=self.review_manager.paths.RECORDS_FILE_GIT
         )
 

--- a/colrev/ops/upgrade.py
+++ b/colrev/ops/upgrade.py
@@ -263,7 +263,7 @@ class Upgrade(colrev.process.operation.Operation):
             if not migrator["released"]:
                 msg += " (pre-release)"
             review_manager = colrev.review_manager.ReviewManager()
-            review_manager.dataset.create_commit(
+            review_manager.dataset.git_repo.create_commit(
                 msg=msg,
             )
 

--- a/colrev/ops/validate.py
+++ b/colrev/ops/validate.py
@@ -33,7 +33,7 @@ class Validate(colrev.process.operation.Operation):
 
     def _load_prior_records_dict(self, *, commit_sha: str) -> dict:
         """If commit is "": return the last committed version of records"""
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         # Ensure the path uses forward slashes, which is compatible with Git's path handling
         records_file_path = self.review_manager.paths.RECORDS_FILE_GIT
         revlist = (
@@ -280,7 +280,7 @@ class Validate(colrev.process.operation.Operation):
         """Get the records that changed in a selected commit"""
 
         dataset = self.review_manager.dataset
-        git_repo = dataset.get_repo()
+        git_repo = dataset.git_repo.get_repo()
         revlist = (
             (
                 commit.hexsha,
@@ -348,7 +348,7 @@ class Validate(colrev.process.operation.Operation):
 
         # option: --history: check all preceding commits (create a list...)
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         cur_sha = git_repo.head.commit.hexsha
         cur_branch = git_repo.active_branch.name
@@ -397,9 +397,9 @@ class Validate(colrev.process.operation.Operation):
         # pylint: disable=too-many-branches
 
         if not commit_sha:
-            commit_sha = self.review_manager.dataset.get_last_commit_sha()
+            commit_sha = self.review_manager.dataset.git_repo.get_last_commit_sha()
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         revlist = list(
             (
@@ -514,7 +514,7 @@ class Validate(colrev.process.operation.Operation):
 
         merge_validation = []
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         revlist = git_repo.iter_commits(
             paths=str(self.review_manager.paths.RECORDS_FILE)
@@ -579,7 +579,7 @@ class Validate(colrev.process.operation.Operation):
         if filter_setting == "contributor":
             return commit
 
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         if scope in ["HEAD", "."]:
             scope = "HEAD~0"
         if scope.startswith("HEAD~"):
@@ -628,7 +628,7 @@ class Validate(colrev.process.operation.Operation):
     def _get_contributor_validation(self, *, scope: str) -> dict:
         report: typing.Dict[str, typing.Any] = {"contributor_commits": []}
         valid_options = []
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         for commit in git_repo.iter_commits():
             if any(
                 x == scope
@@ -670,7 +670,7 @@ class Validate(colrev.process.operation.Operation):
         return report
 
     def _get_relative_commit(self, commit_sha: str) -> str:
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
 
         relative_to_head = 0
         for commit_i in git_repo.iter_commits():
@@ -709,7 +709,7 @@ class Validate(colrev.process.operation.Operation):
                         origin_records.pop(identifier)
                 write_file(records_dict=origin_records, filename=filename)
 
-            self.review_manager.dataset.add_changes(filename)
+            self.review_manager.dataset.git_repo.add_changes(filename)
 
     @colrev.process.operation.Operation.decorate()
     def main(

--- a/colrev/packages/bibliography_export/src/bibliography_export.py
+++ b/colrev/packages/bibliography_export/src/bibliography_export.py
@@ -108,8 +108,8 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
 
         write_file(records_dict=selected_records, filename=export_filepath)
 
-        self.review_manager.dataset.add_changes(export_filepath)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.add_changes(export_filepath)
+        self.review_manager.dataset.git_repo.create_commit(
             msg=f"Create {self.settings.bib_format.name} bibliography",
         )
 
@@ -144,7 +144,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
             add_package
         )
         operation.review_manager.save_settings()
-        operation.review_manager.dataset.create_commit(
+        operation.review_manager.dataset.git_repo.create_commit(
             msg=f"Add colrev.bibliography_export: {add_package['bib_format']}"
         )
 

--- a/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
@@ -299,9 +299,9 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
 
             self._pdf_get_man_record_cli(record=record)
 
-        if self.review_manager.dataset.has_record_changes():
+        if self.review_manager.dataset.git_repo.has_record_changes():
             if input("Create commit (y/n)?") == "y":
-                self.review_manager.dataset.create_commit(
+                self.review_manager.dataset.git_repo.create_commit(
                     msg="Retrieve PDFs manually",
                     manual_author=True,
                 )

--- a/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
@@ -371,7 +371,7 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
 
         if self.pdf_prep_man_operation.pdfs_prepared_manually():
             if input("Create commit (y/n)?") == "y":
-                self.review_manager.dataset.create_commit(
+                self.review_manager.dataset.git_repo.create_commit(
                     msg="Prepare PDFs manually",
                     manual_author=True,
                 )

--- a/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
+++ b/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
@@ -157,7 +157,7 @@ class CoLRevCLIPrescreen(base_classes.PrescreenPackageBaseClass):
         #     if input("Create commit (y/n)?") != "y":
         #         return records
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Pre-screen: manual screen (cli)", manual_author=True
         )
         return records

--- a/colrev/packages/colrev_cli_screen/src/screen_cli.py
+++ b/colrev/packages/colrev_cli_screen/src/screen_cli.py
@@ -281,7 +281,7 @@ class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
             if input("Create commit (y/n)?") != "y":
                 return records
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Screen: manual (cli)", manual_author=True
         )
         return records

--- a/colrev/packages/colrev_curation/src/colrev_curation.py
+++ b/colrev/packages/colrev_curation/src/colrev_curation.py
@@ -254,7 +254,7 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
         stats = self._get_stats(records=records, sources=sources)
         markdown_output = self._get_stats_markdown_table(stats=stats, sources=sources)
         self._update_table_in_readme(markdown_output=markdown_output)
-        self.review_manager.dataset.add_changes(self.review_manager.paths.README_FILE)
+        self.review_manager.dataset.git_repo.add_changes(self.review_manager.paths.README_FILE)
 
     def _source_comparison(self, *, silent_mode: bool) -> None:
         """Exports a table to support analyses of records that are not

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -107,7 +107,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
                 f"Error retrieving records from colrev project {project_url} ({exc})"
             ) from exc
 
-        # remote_url = project_review_manager.dataset.get_remote_url()
+        # remote_url = project_review_manager.dataset.git_repo.get_remote_url()
         # if remote_url != "NA":
         #     project_identifier = remote_url.rstrip(".git")
 

--- a/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
+++ b/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
@@ -55,7 +55,7 @@ class ConditionalPrescreen(base_classes.PrescreenPackageBaseClass):
             record.update(colrev_status=RecordState.rev_prescreen_included)
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Prescreen: include all",
             manual_author=False,
         )

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -346,7 +346,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
     ) -> None:
 
         self.api.rerun = rerun
-        self.api.last_updated = self.review_manager.dataset.get_last_updated(
+        self.api.last_updated = self.review_manager.dataset.git_repo.get_last_updated(
             crossref_feed.feed_file
         )
 

--- a/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
+++ b/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
@@ -278,9 +278,9 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
             record.pop(Fields.CONTAINER_TITLE)
         self.review_manager.dataset.save_records_dict(records)
 
-        if self.review_manager.dataset.has_record_changes():
+        if self.review_manager.dataset.git_repo.has_record_changes():
             self.logger.info(f"{Colors.GREEN}Commit changes{Colors.END}")
-            self.review_manager.dataset.create_commit(
+            self.review_manager.dataset.git_repo.create_commit(
                 msg=(
                     "Merge duplicate records (set unique records from "
                     f"{self.settings.selected_source} "
@@ -573,6 +573,6 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
             id_sets=decision_list,
             preferred_masterdata_sources=preferred_masterdata_sources,
         )
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Merge duplicate records",
         )

--- a/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
+++ b/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
@@ -334,7 +334,7 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
             self.review_manager.dataset.save_records_dict(records)
 
         if len(ret["decision_list"]) > 0 or len(ret["records_to_prepare"]) > 0:
-            self.review_manager.dataset.create_commit(
+            self.review_manager.dataset.git_repo.create_commit(
                 msg="Merge duplicate records",
             )
 
@@ -353,7 +353,7 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
             self.review_manager.dataset.save_records_dict(records)
             input("Edit records (if any), add to git, and press Enter")
 
-            self.review_manager.dataset.create_commit(
+            self.review_manager.dataset.git_repo.create_commit(
                 msg="Add non-duplicate records",
             )
 

--- a/colrev/packages/dedupe/src/dedupe.py
+++ b/colrev/packages/dedupe/src/dedupe.py
@@ -103,7 +103,7 @@ class Dedupe(base_classes.DedupePackageBaseClass):
             id_sets=duplicate_id_sets, complete_dedupe=True
         )
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Dedupe: merge duplicate records",
         )
 

--- a/colrev/packages/export_man_prep/src/prep_man_export.py
+++ b/colrev/packages/export_man_prep/src/prep_man_export.py
@@ -342,9 +342,9 @@ class ExportManPrep(base_classes.PrepManPackageBaseClass):
             )
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(msg="Prep-man (ExportManPrep)")
+        self.review_manager.dataset.git_repo.create_commit(msg="Prep-man (ExportManPrep)")
         self.review_manager.dataset.set_ids(selected_ids=imported_records)
-        self.review_manager.dataset.create_commit(msg="Set IDs")
+        self.review_manager.dataset.git_repo.create_commit(msg="Set IDs")
 
     def _print_export_prep_man_instructions(self) -> None:
         print("Created two files:")

--- a/colrev/packages/genai/src/genai_prescreen.py
+++ b/colrev/packages/genai/src/genai_prescreen.py
@@ -147,7 +147,7 @@ class GenAIPrescreen(base_classes.PrescreenPackageBaseClass):
         )
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Pre-screen (GenAI)",
             manual_author=False,
         )

--- a/colrev/packages/genai/src/genai_screen.py
+++ b/colrev/packages/genai/src/genai_screen.py
@@ -50,6 +50,6 @@ class GenAIScreen(base_classes.ScreenPackageBaseClass):
             # record.data[Fields.SCREENING_CRITERIA] = screening_criteria_field
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(msg="Screen (GenAI)")
+        self.review_manager.dataset.git_repo.create_commit(msg="Screen (GenAI)")
 
         return records

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -67,7 +67,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
 
         self.settings = self.settings_class(**settings)
         self.review_manager = data_operation.review_manager
-        self.git_repo = self.review_manager.dataset.get_repo()
+        self.git_repo = self.review_manager.dataset.git_repo.get_repo()
 
     # pylint: disable=unused-argument
     @classmethod
@@ -98,13 +98,13 @@ class GithubPages(base_classes.DataPackageBaseClass):
             old_string="{{project_title}}",
             new_string=project_title.rstrip(" ").capitalize(),
         )
-        self.review_manager.dataset.add_changes(Path("README.md"))
+        self.review_manager.dataset.git_repo.add_changes(Path("README.md"))
 
         colrev.env.utils.retrieve_package_file(
             template_file=Path("packages/github_pages/github_pages/index.html"),
             target=Path("index.html"),
         )
-        self.review_manager.dataset.add_changes(Path("index.html"))
+        self.review_manager.dataset.git_repo.add_changes(Path("index.html"))
 
         colrev.env.utils.retrieve_package_file(
             template_file=Path("packages/github_pages/github_pages/_config.yml"),
@@ -115,15 +115,15 @@ class GithubPages(base_classes.DataPackageBaseClass):
             old_string="{{project_title}}",
             new_string=project_title,
         )
-        self.review_manager.dataset.add_changes(Path("_config.yml"))
+        self.review_manager.dataset.git_repo.add_changes(Path("_config.yml"))
 
         colrev.env.utils.retrieve_package_file(
             template_file=Path("packages/github_pages/github_pages/about.md"),
             target=Path("about.md"),
         )
-        self.review_manager.dataset.add_changes(Path("about.md"))
+        self.review_manager.dataset.git_repo.add_changes(Path("about.md"))
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Setup gh-pages branch", skip_status_yaml=True
         )
 
@@ -155,7 +155,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
                 ),
                 target=self.review_manager.paths.PRE_COMMIT_CONFIG,
             )
-            self.review_manager.dataset.add_changes(
+            self.review_manager.dataset.git_repo.add_changes(
                 self.review_manager.paths.PRE_COMMIT_CONFIG
             )
 
@@ -170,9 +170,9 @@ class GithubPages(base_classes.DataPackageBaseClass):
         data_file = Path("data.bib")
         write_file(records_dict=included_records, filename=data_file)
 
-        self.review_manager.dataset.add_changes(data_file)
+        self.review_manager.dataset.git_repo.add_changes(data_file)
 
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Update sample", skip_status_yaml=True
         )
 
@@ -252,7 +252,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
             )
             return
 
-        if self.review_manager.dataset.has_record_changes():
+        if self.review_manager.dataset.git_repo.has_record_changes():
             self.logger.error(
                 "Cannot update github pages because there are uncommitted changes."
             )
@@ -352,7 +352,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
         data_endpoint = "Data operation [github pages data endpoint]: "
 
         advice = {"msg": f"{data_endpoint}", "detailed_msg": "TODO"}
-        if self.review_manager.dataset.get_remote_url() == "NA":
+        if self.review_manager.dataset.git_repo.get_remote_url() == "NA":
             advice["msg"] += (
                 "\n    - To make the repository available on Github pages, "
                 + "push it to a Github repository\nhttps://github.com/new"

--- a/colrev/packages/obsidian/src/obsidian.py
+++ b/colrev/packages/obsidian/src/obsidian.py
@@ -78,7 +78,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
             self.review_manager.path / self.OBSIDIAN_INBOX_PATH_RELATIVE
         )
         if hasattr(self.review_manager, "dataset"):
-            self.review_manager.dataset.update_gitignore(add=self.GITIGNORE_LIST)
+            self.review_manager.dataset.git_repo.update_gitignore(add=self.GITIGNORE_LIST)
 
     # pylint: disable=unused-argument
     @classmethod
@@ -205,7 +205,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
         # later : export to csl-json (based on bibliography_export)
         # (absolute PDF paths, read-only/hidden/gitignored, no provenance fields)
 
-        # self.review_manager.dataset.add_changes(self.OBSIDIAN_INBOX_PATH_RELATIVE)
+        # self.review_manager.dataset.git_repo.add_changes(self.OBSIDIAN_INBOX_PATH_RELATIVE)
 
     def update_data(
         self,

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -178,8 +178,8 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         forward_search_feed.save()
 
-        if self.review_manager.dataset.has_record_changes():
-            self.review_manager.dataset.create_commit(
+        if self.review_manager.dataset.git_repo.has_record_changes():
+            self.review_manager.dataset.git_repo.create_commit(
                 msg="Forward search", script_call="colrev search"
             )
 

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -169,7 +169,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         else:
             self.logger.error("Could not retrieve %s from the package", template_name)
             return False
-        self.review_manager.dataset.add_changes(template_name)
+        self.review_manager.dataset.git_repo.add_changes(template_name)
         return True
 
     def _retrieve_default_csl(self) -> None:
@@ -190,8 +190,8 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                 old_string=f'csl: "{csl_link}"',
                 new_string=f'csl: "{csl_filename}"',
             )
-            self.review_manager.dataset.add_changes(self.settings.paper_path)
-            self.review_manager.dataset.add_changes(Path(csl_filename))
+            self.review_manager.dataset.git_repo.add_changes(self.settings.paper_path)
+            self.review_manager.dataset.git_repo.add_changes(Path(csl_filename))
             self.logger.debug("Downloaded csl file for offline use")
 
     def _check_new_record_source_tag(
@@ -206,7 +206,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         )
 
     def _authorship_heuristic(self) -> str:
-        git_repo = self.review_manager.dataset.get_repo()
+        git_repo = self.review_manager.dataset.git_repo.get_repo()
         try:
             commits_list = list(git_repo.iter_commits())
             commits_authors = []
@@ -567,7 +567,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                 records_dict=non_sample_records, filename=self.non_sample_references
             )
 
-            self.review_manager.dataset.add_changes(
+            self.review_manager.dataset.git_repo.add_changes(
                 Path("data/data/") / self.NON_SAMPLE_REFERENCES_RELATIVE
             )
 
@@ -640,7 +640,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
 
         self._add_prisma_if_available(silent_mode=silent_mode)
 
-        review_manager.dataset.add_changes(self.settings.paper_path)
+        review_manager.dataset.git_repo.add_changes(self.settings.paper_path)
 
         return records
 
@@ -655,7 +655,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
                     template_file=retrieval_path,
                     target=self.non_sample_references,
                 )
-                self.review_manager.dataset.add_changes(self.non_sample_references)
+                self.review_manager.dataset.git_repo.add_changes(self.non_sample_references)
             except AttributeError:
                 pass
 
@@ -666,7 +666,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             records[record_id] = record_dict
 
         write_file(records_dict=records, filename=self.sample_references)
-        self.review_manager.dataset.add_changes(self.sample_references)
+        self.review_manager.dataset.git_repo.add_changes(self.sample_references)
 
     def _call_docker_build_process(self, *, script: str) -> None:
         try:
@@ -734,7 +734,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         )
 
         if (
-            not self.review_manager.dataset.has_changes(self.paper_relative_path)
+            not self.review_manager.dataset.git_repo.has_changes(self.paper_relative_path)
             and self.settings.paper_output.is_file()
         ):
             self.logger.debug("Skipping paper build (no changes)")
@@ -764,8 +764,8 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         """Update the data/paper"""
 
         if (
-            self.review_manager.dataset.repo_initialized()
-            and self.review_manager.dataset.has_changes(
+            self.review_manager.dataset.git_repo.repo_initialized()
+            and self.review_manager.dataset.git_repo.has_changes(
                 self.paper_relative_path, change_type="unstaged"
             )
         ):

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -438,8 +438,8 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         pdf_backward_search_feed.save()
 
-        if self.review_manager.dataset.has_record_changes():
-            self.review_manager.dataset.create_commit(
+        if self.review_manager.dataset.git_repo.has_record_changes():
+            self.review_manager.dataset.git_repo.create_commit(
                 msg="Backward search", script_call="colrev search"
             )
 

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -190,7 +190,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         rerun: bool,
     ) -> None:
         self.api.rerun = rerun
-        self.api.last_updated = self.review_manager.dataset.get_last_updated(
+        self.api.last_updated = self.review_manager.dataset.git_repo.get_last_updated(
             plos_feed.feed_file
         )
 

--- a/colrev/packages/prescreen_table/src/prescreen_table.py
+++ b/colrev/packages/prescreen_table/src/prescreen_table.py
@@ -235,9 +235,9 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         if input("import prescreen table [y,n]?") == "y":
             self.import_table(records=records)
 
-        if self.review_manager.dataset.has_record_changes():
+        if self.review_manager.dataset.git_repo.has_record_changes():
             if input("create commit [y,n]?") == "y":
-                self.review_manager.dataset.create_commit(
+                self.review_manager.dataset.git_repo.create_commit(
                     msg="Pre-screen (table)",
                     manual_author=True,
                 )

--- a/colrev/packages/scope_prescreen/src/scope_prescreen.py
+++ b/colrev/packages/scope_prescreen/src/scope_prescreen.py
@@ -341,7 +341,7 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
             )
 
         self.review_manager.dataset.save_records_dict(records)
-        self.review_manager.dataset.create_commit(
+        self.review_manager.dataset.git_repo.create_commit(
             msg="Pre-screen (scope)",
             manual_author=False,
         )

--- a/colrev/packages/screen_table/src/screen_table.py
+++ b/colrev/packages/screen_table/src/screen_table.py
@@ -209,9 +209,9 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
         if input("import screen table [y,n]?") == "y":
             self.import_table(records)
 
-        if self.review_manager.dataset.has_record_changes():
+        if self.review_manager.dataset.git_repo.has_record_changes():
             if input("create commit [y,n]?") == "y":
-                self.review_manager.dataset.create_commit(
+                self.review_manager.dataset.git_repo.create_commit(
                     msg="Screen", manual_author=True
                 )
         return records

--- a/colrev/packages/structured/src/structured.py
+++ b/colrev/packages/structured/src/structured.py
@@ -138,7 +138,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
     def _set_fields(self) -> None:
         self.logger.info("Add fields for data extraction")
         try:
-            _ = self.review_manager.dataset.get_repo()
+            _ = self.review_manager.dataset.git_repo.get_repo()
         except GitCommandError:
             return
 
@@ -247,7 +247,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
             synthesized_record_status_matrix=synthesized_record_status_matrix,
         )
 
-        self.review_manager.dataset.add_changes(
+        self.review_manager.dataset.git_repo.add_changes(
             self.settings.data_path_relative, ignore_missing=True
         )
 

--- a/colrev/process/operation.py
+++ b/colrev/process/operation.py
@@ -165,4 +165,4 @@ class Operation:
         if state_transition:
             self.check_precondition()
         if hasattr(self.review_manager, "dataset"):
-            self.review_manager.dataset.reset_log_if_no_changes()
+            self.review_manager.dataset.git_repo.reset_log_if_no_changes()

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -232,7 +232,7 @@ class ReviewManager:
         with open(self.paths.status, "w", encoding="utf8") as file:
             yaml.dump(exported_dict, file, allow_unicode=True)
         if add_to_git:
-            self.dataset.add_changes(self.paths.STATUS_FILE)
+            self.dataset.git_repo.add_changes(self.paths.STATUS_FILE)
 
     def get_upgrade(self) -> colrev.ops.upgrade.Upgrade:  # pragma: no cover
         """Get an upgrade object"""

--- a/colrev/settings.py
+++ b/colrev/settings.py
@@ -528,4 +528,4 @@ def save_settings(*, review_manager: colrev.review_manager.ReviewManager) -> Non
     for source in sources:
         source.save(filepath=review_manager.paths.search / source.search_history_path)
     review_manager.settings.sources = sources
-    review_manager.dataset.add_changes(review_manager.paths.settings)
+    review_manager.dataset.git_repo.add_changes(review_manager.paths.settings)

--- a/colrev/ui_cli/add_package_to_settings.py
+++ b/colrev/ui_cli/add_package_to_settings.py
@@ -89,6 +89,6 @@ def add_package_to_settings(
         endpoints_in_settings.append(add_package)  # type: ignore
 
     operation.review_manager.save_settings()
-    operation.review_manager.dataset.create_commit(
+    operation.review_manager.dataset.git_repo.create_commit(
         msg=f"Add {operation.type} {package_identifier}",
     )

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -2091,13 +2091,13 @@ def data(
     ret = data_operation.main()
     if utils.in_ci_environment():
         if ret["ask_to_commit"]:
-            review_manager.dataset.create_commit(
+            review_manager.dataset.git_repo.create_commit(
                 msg="Data and synthesis", manual_author=True
             )
     else:
         if ret["ask_to_commit"]:
             if input("Create commit (y/n)?") == "y":
-                review_manager.dataset.create_commit(
+                review_manager.dataset.git_repo.create_commit(
                     msg="Data and synthesis", manual_author=True
                 )
         if ret["no_endpoints_registered"]:
@@ -2463,7 +2463,7 @@ def env(
                     },
                 )
 
-                review_manager.dataset.pull_if_repo_clean()
+                review_manager.dataset.git_repo.pull_if_repo_clean()
                 print(f"Pulled {curated_resource_path}")
             except GitCommandError as exc:
                 print(exc)
@@ -2612,7 +2612,7 @@ def settings(
     if update_hooks:
         print("Update pre-commit hooks")
 
-        if review_manager.dataset.has_record_changes():
+        if review_manager.dataset.git_repo.has_record_changes():
             print("Clean repo required. Commit or stash changes.")
             ctx.exit(1)
 
@@ -2627,8 +2627,8 @@ def settings(
         for script_to_call in scripts_to_call:
             check_call(script_to_call, stdout=DEVNULL, stderr=STDOUT)  # nosec
 
-        review_manager.dataset.add_changes(review_manager.paths.PRE_COMMIT_CONFIG)
-        review_manager.dataset.create_commit(msg="Update pre-commit hooks")
+        review_manager.dataset.git_repo.add_changes(review_manager.paths.PRE_COMMIT_CONFIG)
+        review_manager.dataset.git_repo.create_commit(msg="Update pre-commit hooks")
         print("Successfully updated pre-commit hooks")
         return
 
@@ -2660,8 +2660,8 @@ def settings(
         with open(review_manager.paths.settings, "w", encoding="utf-8") as outfile:
             json.dump(project_settings, outfile, indent=4)
 
-        review_manager.dataset.add_changes(review_manager.paths.SETTINGS_FILE)
-        review_manager.dataset.create_commit(msg="Change settings", manual_author=True)
+        review_manager.dataset.git_repo.add_changes(review_manager.paths.SETTINGS_FILE)
+        review_manager.dataset.git_repo.create_commit(msg="Change settings", manual_author=True)
 
     # import colrev_ui.ui_web.settings_editor
 
@@ -2835,7 +2835,7 @@ def show(  # type: ignore
     elif keyword == "cmd_history":
         cmds = []
         colrev.ops.check.CheckOperation(review_manager)
-        revlist = review_manager.dataset.get_repo().iter_commits()
+        revlist = review_manager.dataset.git_repo.get_repo().iter_commits()
 
         for commit in reversed(list(revlist)):
             try:
@@ -2915,7 +2915,7 @@ def upgrade(
 
         review_manager.settings.project.auto_upgrade = False
         review_manager.save_settings()
-        review_manager.dataset.create_commit(msg="Disable auto-upgrade")
+        review_manager.dataset.git_repo.create_commit(msg="Disable auto-upgrade")
         return
     review_manager = colrev.review_manager.ReviewManager(
         force_mode=True, verbose_mode=verbose
@@ -3060,7 +3060,7 @@ def merge(
 
     if not branch:
         colrev.ops.check.CheckOperation(review_manager)
-        git_repo = review_manager.dataset.get_repo()
+        git_repo = review_manager.dataset.git_repo.get_repo()
         print(f"possible branches: {','.join([b.name for b in git_repo.heads])}")
         return
 
@@ -3101,7 +3101,7 @@ def undo(
 
     if selection == "commit":
         colrev.ops.check.CheckOperation(review_manager)
-        git_repo = review_manager.dataset.get_repo()
+        git_repo = review_manager.dataset.git_repo.get_repo()
         git_repo.git.reset("--hard", "HEAD~1")
 
 

--- a/colrev/ui_cli/cli_validation.py
+++ b/colrev/ui_cli/cli_validation.py
@@ -421,5 +421,5 @@ def validate(
             print("Not yet implemented")
             print(validation_details)
 
-    if validate_operation.review_manager.dataset.records_changed():
-        validate_operation.review_manager.dataset.create_commit(msg="validate")
+    if validate_operation.review_manager.dataset.git_repo.records_changed():
+        validate_operation.review_manager.dataset.git_repo.create_commit(msg="validate")

--- a/colrev/ui_cli/setup_custom_scripts.py
+++ b/colrev/ui_cli/setup_custom_scripts.py
@@ -25,7 +25,7 @@ def setup_custom_search_script(
         with open("custom_search_source_script.py", "w", encoding="utf-8") as file:
             file.write(filedata.decode("utf-8"))
 
-    review_manager.dataset.add_changes(Path("custom_search_source_script.py"))
+    review_manager.dataset.git_repo.add_changes(Path("custom_search_source_script.py"))
 
     new_source = colrev.search_file.ExtendedSearchFile(
         platform="custom_search_source_script",

--- a/tests/0_process/operation_test.py
+++ b/tests/0_process/operation_test.py
@@ -20,7 +20,7 @@ def test_check_precondition_load(  # type: ignore
     with pytest.raises(colrev_exceptions.UnstagedGitChangesError):
         load_operation.check_precondition()
 
-    base_repo_review_manager.dataset.add_changes(base_repo_review_manager.paths.readme)
+    base_repo_review_manager.dataset.git_repo.add_changes(base_repo_review_manager.paths.readme)
     with pytest.raises(colrev_exceptions.CleanRepoRequiredError):
         load_operation.check_precondition()
 

--- a/tests/2_ops/correction_test.py
+++ b/tests/2_ops/correction_test.py
@@ -22,7 +22,7 @@ def get_correction_fixture(base_repo_review_manager):  # type: ignore
         "CURATED": {"source": "url...", "note": ""}
     }
     base_repo_review_manager.dataset.save_records_dict(records)
-    base_repo_review_manager.dataset.create_commit(msg="switch to curated")
+    base_repo_review_manager.dataset.git_repo.create_commit(msg="switch to curated")
 
     records["SrivastavaShainesh2015"]["title"] = "Changed-title"
     base_repo_review_manager.dataset.save_records_dict(records)
@@ -50,7 +50,7 @@ def test_corrections_pre_commit_hooks(  # type: ignore
         ["git", "commit", "-m", "test"]
     )
     print(ret)
-    base_repo_review_manager.dataset.get_repo().git.log(p=True)
+    base_repo_review_manager.dataset.git_repo.get_repo().git.log(p=True)
     corrections_path = base_repo_review_manager.paths.corrections
 
     expected = (

--- a/tests/2_ops/dedupe_operation_test.py
+++ b/tests/2_ops/dedupe_operation_test.py
@@ -20,8 +20,8 @@ def fixture_dedupe_test_setup(  # type: ignore
         source=Path("data/dedupe/records.bib"),
         target=Path("data/records.bib"),
     )
-    base_repo_review_manager.dataset.add_changes(Path("data/records.bib"))
-    base_repo_review_manager.dataset.create_commit(
+    base_repo_review_manager.dataset.git_repo.add_changes(Path("data/records.bib"))
+    base_repo_review_manager.dataset.git_repo.create_commit(
         msg="Import dedupe test cases", manual_author=True
     )
 
@@ -46,13 +46,13 @@ def test_dedupe_utilities(  # type: ignore
     assert "Staehr2010" in records.keys()
     assert "Staehr2010a" in records.keys()
 
-    dedupe_test_setup.dataset.add_changes(Path("data/records.bib"))
-    dedupe_test_setup.dataset.create_commit(
+    dedupe_test_setup.dataset.git_repo.add_changes(Path("data/records.bib"))
+    dedupe_test_setup.dataset.git_repo.create_commit(
         msg="Unmerge Staehr2010-Staehr2010a", manual_author=True, skip_hooks=True
     )
     dedupe_operation.merge_records(merge=[["Staehr2010", "Staehr2010a"]])
-    dedupe_test_setup.dataset.add_changes(Path("data/records.bib"))
-    dedupe_test_setup.dataset.create_commit(
+    dedupe_test_setup.dataset.git_repo.add_changes(Path("data/records.bib"))
+    dedupe_test_setup.dataset.git_repo.create_commit(
         msg="Merge Staehr2010-Staehr2010a", manual_author=True, skip_hooks=True
     )
     records = dedupe_test_setup.dataset.load_records_dict()

--- a/tests/2_ops/validate_test.py
+++ b/tests/2_ops/validate_test.py
@@ -210,11 +210,11 @@ def test_get_changed_records(
     base_repo_review_manager.dataset.save_records_dict(changed_record_dict)
     base_repo_review_manager.dataset._add_record_changes()
     commit_message = "Test commit for changed records"
-    base_repo_review_manager.dataset.create_commit(
+    base_repo_review_manager.dataset.git_repo.create_commit(
         msg=commit_message, manual_author=True
     )
     # Retrieve the last commit SHA
-    last_commit_sha = base_repo_review_manager.dataset.get_last_commit_sha()
+    last_commit_sha = base_repo_review_manager.dataset.git_repo.get_last_commit_sha()
 
     base_repo_review_manager.notified_next_operation = OperationsType.check
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ def fixture_base_repo_review_manager(session_mocker, tmp_path_factory, helpers):
     )
 
     review_manager.get_load_operation()
-    git_repo = review_manager.dataset.get_repo()
+    git_repo = review_manager.dataset.git_repo.get_repo()
     if utils.in_ci_environment():
         git_repo.config_writer().set_value("user", "name", "Tester").release()
         git_repo.config_writer().set_value("user", "email", "tester@mail.com").release()
@@ -215,16 +215,16 @@ def fixture_base_repo_review_manager(session_mocker, tmp_path_factory, helpers):
     review_manager.settings.data.data_package_endpoints = []
     review_manager.save_settings()
 
-    review_manager.dataset.create_commit(msg="change settings", manual_author=True)
+    review_manager.dataset.git_repo.create_commit(msg="change settings", manual_author=True)
     review_manager.changed_settings_commit = (
-        review_manager.dataset.get_last_commit_sha()
+        review_manager.dataset.git_repo.get_last_commit_sha()
     )
 
     helpers.retrieve_test_file(
         source=Path("data/search_files/test_records.bib"),
         target=Path("data/search/test_records.bib"),
     )
-    review_manager.dataset.add_changes(Path("data/search/test_records.bib"))
+    review_manager.dataset.git_repo.add_changes(Path("data/search/test_records.bib"))
     test_bib_source = colrev.search_file.ExtendedSearchFile(
         platform="colrev.unknown_source",
         search_results_path=Path("data/search/test_records.bib"),
@@ -236,11 +236,11 @@ def fixture_base_repo_review_manager(session_mocker, tmp_path_factory, helpers):
     # TODO : should the saving be done by settings.save()?
     search_history_file_path = Path("data/search/test_records_search_history.json")
     test_bib_source.save(search_history_file_path)
-    review_manager.dataset.add_changes(search_history_file_path)
+    review_manager.dataset.git_repo.add_changes(search_history_file_path)
     review_manager.load_settings()
-    review_manager.dataset.create_commit(msg="add test_records.bib", manual_author=True)
+    review_manager.dataset.git_repo.create_commit(msg="add test_records.bib", manual_author=True)
     review_manager.add_test_records_commit = (
-        review_manager.dataset.get_last_commit_sha()
+        review_manager.dataset.git_repo.get_last_commit_sha()
     )
 
     search_operation = review_manager.get_search_operation()
@@ -248,40 +248,40 @@ def fixture_base_repo_review_manager(session_mocker, tmp_path_factory, helpers):
 
     load_operation = review_manager.get_load_operation()
     load_operation.main(keep_ids=False)
-    review_manager.load_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.load_commit = review_manager.dataset.git_repo.get_last_commit_sha()
 
     prep_operation = review_manager.get_prep_operation()
     prep_operation.main(keep_ids=True)
-    review_manager.prep_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.prep_commit = review_manager.dataset.git_repo.get_last_commit_sha()
 
     dedupe_operation = review_manager.get_dedupe_operation(
         notify_state_transition_operation=True
     )
     dedupe_operation.main()
-    review_manager.dedupe_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.dedupe_commit = review_manager.dataset.git_repo.get_last_commit_sha()
 
     prescreen_operation = review_manager.get_prescreen_operation()
     prescreen_operation.main(split_str="NA")
-    review_manager.prescreen_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.prescreen_commit = review_manager.dataset.git_repo.get_last_commit_sha()
 
     pdf_get_operation = review_manager.get_pdf_get_operation(
         notify_state_transition_operation=True
     )
     pdf_get_operation.main()
-    review_manager.pdf_get_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.pdf_get_commit = review_manager.dataset.git_repo.get_last_commit_sha()
 
     pdf_prep_operation = review_manager.get_pdf_prep_operation(reprocess=False)
     pdf_prep_operation.main(batch_size=0)
-    review_manager.pdf_prep_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.pdf_prep_commit = review_manager.dataset.git_repo.get_last_commit_sha()
 
     screen_operation = review_manager.get_screen_operation()
     screen_operation.main(split_str="NA")
-    review_manager.screen_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.screen_commit = review_manager.dataset.git_repo.get_last_commit_sha()
 
     data_operation = review_manager.get_data_operation()
     data_operation.main()
-    review_manager.dataset.create_commit(msg="Data and synthesis", manual_author=True)
-    review_manager.data_commit = review_manager.dataset.get_last_commit_sha()
+    review_manager.dataset.git_repo.create_commit(msg="Data and synthesis", manual_author=True)
+    review_manager.data_commit = review_manager.dataset.git_repo.get_last_commit_sha()
     review_manager.logger.info(
         f"{Colors.RED}Test repository in {test_repo_dir}{Colors.END}"
     )


### PR DESCRIPTION
## Summary
- encapsulate repository functionality in new `GitRepo` module
- expose repository through `dataset.git_repo`
- adjust internal calls to use `dataset.git_repo.*`

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'search_query')*


------
https://chatgpt.com/codex/tasks/task_e_68977c141acc832a8b795d42e43fd097