### PR TITLE
refactor: move db source helpers

### DIFF
--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -40,7 +40,6 @@ class Search(colrev.process.operation.Operation):
         self.sources = review_manager.settings.sources
         self.package_manager = PackageManager()
 
-
     def create_api_source(
         self, *, platform: str
     ) -> colrev.search_file.ExtendedSearchFile:

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -51,7 +51,7 @@ class Search(colrev.process.operation.Operation):
         keywords = input("Enter the keywords:")
 
         filename = utils.get_unique_filename(
-            review_manager=self.review_manager,
+            base_path=self.review_manager.path,
             file_path_string=f"{platform.replace('colrev.', '')}",
         )
         add_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/ops/search_db.py
+++ b/colrev/ops/search_db.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
+from typing import Optional
 
 import colrev.exceptions as colrev_exceptions
 import colrev.search_file

--- a/colrev/ops/search_db.py
+++ b/colrev/ops/search_db.py
@@ -111,7 +111,7 @@ def create_db_source(
         filename = Path(params["search_file"])
     else:
         filename = colrev.utils.get_unique_filename(
-            review_manager=review_manager,
+            base_path=review_manager.path,
             file_path_string=search_source_cls.endpoint.replace("colrev.", ""),
         )
     review_manager.logger.debug(f"Add new DB source: {filename}")

--- a/colrev/ops/search_db.py
+++ b/colrev/ops/search_db.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Any, Optional
+
+import colrev.exceptions as colrev_exceptions
+import colrev.search_file
+import colrev.utils
+from colrev.constants import Colors
+from colrev.constants import SearchType
+from colrev.git_repo import GitRepo
+
+
+class _Paths:
+    def __init__(self, root: Path) -> None:
+        self.git_ignore = root / ".gitignore"
+
+
+class _ReviewManagerStub:
+    def __init__(self, root: Path) -> None:
+        self.path = root
+        self.paths = _Paths(root)
+
+
+def run_db_search(
+    *,
+    search_source_cls,
+    source: colrev.search_file.ExtendedSearchFile,
+    add_to_git: bool = False,
+    project_root: Optional[Path] = None,
+    **kwargs: Any,
+) -> None:
+    """Run the database search.
+
+    add_to_git: when True, stage changes via a locally instantiated GitRepo.
+    project_root: optional explicit root path; if not provided, derive from the source.
+    """
+    root = project_root or source.search_results_path.resolve().parents[2]
+    review_manager = _ReviewManagerStub(root)
+    git = GitRepo(review_manager=review_manager)
+
+    if colrev.utils.in_ci_environment():
+        raise colrev_exceptions.SearchNotAutomated("DB search not automated.")
+
+    print("DB search (update)")
+    print(
+        f"- Go to {Colors.ORANGE}{search_source_cls.db_url}{Colors.END} "
+        "and run the following query:"
+    )
+    print()
+    try:
+        print(f"{Colors.ORANGE}{source.get_query()}{Colors.END}")
+        print()
+    except KeyError:
+        pass
+    print(
+        f"- Replace search results in {Colors.ORANGE}"
+        + str(source.search_results_path)
+        + Colors.END
+    )
+    input("Press enter to continue")
+    if source.search_results_path.is_file():
+        if add_to_git:
+            git.add_changes(source.search_results_path)
+    else:
+        print("Search results not found.")
+
+
+def get_query_filename(
+    *,
+    filename: Path,
+    instantiate: bool = False,
+    interactive: bool = False,
+    add_to_git: bool = False,
+    project_root: Optional[Path] = None,
+) -> Path:
+    """Get the corresponding filename for the search query"""
+
+    query_filename = Path("data/search/") / Path(f"{filename.stem}_query.txt")
+    root = project_root or filename.resolve().parents[2]
+    review_manager = _ReviewManagerStub(root)
+    git = GitRepo(review_manager=review_manager)
+
+    if instantiate:
+        with open(query_filename, "w", encoding="utf-8") as file:
+            file.write("")
+        if interactive:
+            input(
+                f"Created {Colors.ORANGE}{query_filename}{Colors.END}. "
+                "Please store your query in the file and press Enter to continue.",
+            )
+        if add_to_git:
+            git.add_changes(query_filename)
+    return query_filename
+
+
+def create_db_source(
+    *,
+    review_manager,
+    search_source_cls,
+    params: dict,
+    add_to_git: bool = True,
+) -> colrev.search_file.ExtendedSearchFile:
+    """Interactively add a DB SearchSource"""
+
+    if not all(x in ["search_file"] for x in list(params)):
+        raise NotImplementedError  # or parameter error
+
+    if "search_file" in params:
+        filename = Path(params["search_file"])
+    else:
+        filename = colrev.utils.get_unique_filename(
+            review_manager=review_manager,
+            file_path_string=search_source_cls.endpoint.replace("colrev.", ""),
+        )
+    review_manager.logger.debug(f"Add new DB source: {filename}")
+
+    query_file = get_query_filename(
+        filename=filename,
+        instantiate=True,
+        add_to_git=add_to_git,
+        project_root=review_manager.path,
+    )
+    review_manager.logger.info(f"Created query-file: {query_file}")
+    input(
+        f"{Colors.ORANGE}Store query in query-file and press Enter to continue{Colors.END}"
+    )
+
+    if not filename.is_file():
+        review_manager.logger.info(
+            f"- Go to {Colors.ORANGE}{search_source_cls.db_url}{Colors.END}"
+        )
+        query_file = get_query_filename(
+            filename=filename,
+            instantiate=True,
+            interactive=False,
+            add_to_git=add_to_git,
+            project_root=review_manager.path,
+        )
+        review_manager.logger.info(
+            f"- Search for your query and store it in {Colors.ORANGE}{query_file}{Colors.END}"
+        )
+        review_manager.logger.info(
+            f"- Save search results in {Colors.ORANGE}{filename}{Colors.END}"
+        )
+        input("Press Enter to complete")
+
+    git = GitRepo(review_manager=review_manager)
+    if add_to_git:
+        git.add_changes(filename, ignore_missing=True)
+
+    add_source = colrev.search_file.ExtendedSearchFile(
+        platform=search_source_cls.endpoint,
+        search_results_path=filename,
+        search_type=SearchType.DB,
+        # TODO : save in json instead of separate text file
+        search_string="TODO",
+        comment="",
+    )
+    print()
+    return add_source

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -16,6 +16,7 @@ from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.writer.write_utils import write_file
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -70,9 +71,11 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -81,9 +84,10 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of ABI/INFORM"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
 
     @classmethod

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -15,8 +15,9 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 from colrev.writer.write_utils import write_file
-from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -13,6 +13,7 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -73,9 +74,11 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         if search_type == SearchType.DB:
-            search_source = operation.create_db_source(
+            search_source = create_db_source(
+                review_manager=operation.review_manager,
                 search_source_cls=cls,
                 params=params_dict,
+                add_to_git=True,
             )
         else:
             raise NotImplementedError
@@ -88,9 +91,10 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if self.search_source.search_type == SearchType.DB:
             if self.search_source.filename.suffix in [".bib"]:
-                self.operation.run_db_search(  # type: ignore
+                run_db_search(
                     search_source_cls=self.__class__,
                     source=self.search_source,
+                    add_to_git=True,
                 )
                 return
 

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -13,7 +13,8 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -18,11 +18,13 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.packages.ais_library.src import ais_load_utils
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -179,9 +181,11 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         if search_type == SearchType.DB:
-            search_source = operation.create_db_source(
+            search_source = create_db_source(
+                review_manager=operation.review_manager,
                 search_source_cls=cls,
                 params=params_dict,
+                add_to_git=True,
             )
 
         # pylint: disable=colrev-missed-constant-usage
@@ -190,7 +194,10 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 host = urlparse(params_dict["url"]).hostname
                 assert host and host.endswith("aisel.aisnet.org")
                 q_params = cls._parse_query(query=params_dict["url"])
-                filename = operation.get_unique_filename(file_path_string="ais")
+                filename = colrev.utils.get_unique_filename(
+                    review_manager=operation.review_manager,
+                    file_path_string="ais",
+                )
                 search_source = colrev.search_file.ExtendedSearchFile(
                     platform=cls.endpoint,
                     search_results_path=filename,
@@ -331,9 +338,10 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 rerun=rerun,
             )
         elif self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
 
     def prep_link_md(

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -196,7 +196,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 assert host and host.endswith("aisel.aisnet.org")
                 q_params = cls._parse_query(query=params_dict["url"])
                 filename = colrev.utils.get_unique_filename(
-                    review_manager=operation.review_manager,
+                    base_path=operation.review_manager.path,
                     file_path_string="ais",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -23,8 +23,9 @@ from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 from colrev.packages.ais_library.src import ais_load_utils
-from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -19,6 +19,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
@@ -98,7 +99,10 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
             query = params_dict["url"].replace("https://arxiv.org/search/?query=", "")
             query = query[: query.find("&searchtype")]
 
-            filename = operation.get_unique_filename(file_path_string="arxiv")
+            filename = colrev.utils.get_unique_filename(
+                review_manager=operation.review_manager,
+                file_path_string="arxiv",
+            )
 
             search_source = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.arxiv",

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -100,7 +100,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
             query = query[: query.find("&searchtype")]
 
             filename = colrev.utils.get_unique_filename(
-                review_manager=operation.review_manager,
+                base_path=operation.review_manager.path,
                 file_path_string="arxiv",
             )
 

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -83,7 +83,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         # Always API search
 
         filename = colrev.utils.get_unique_filename(
-            review_manager=operation.review_manager,
+            base_path=operation.review_manager.path,
             file_path_string=params.split("/")[-1],
         )
         search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -20,6 +20,7 @@ import colrev.exceptions as colrev_exceptions
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import FieldSet
 from colrev.constants import SearchSourceHeuristicStatus
@@ -81,7 +82,10 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         # Always API search
 
-        filename = operation.get_unique_filename(file_path_string=params.split("/")[-1])
+        filename = colrev.utils.get_unique_filename(
+            review_manager=operation.review_manager,
+            file_path_string=params.split("/")[-1],
+        )
         search_source = colrev.search_file.ExtendedSearchFile(
             platform=cls.endpoint,
             search_results_path=filename,

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -21,6 +21,7 @@ import colrev.record.record
 import colrev.record.record_prep
 import colrev.record.record_similarity
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
@@ -133,7 +134,10 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         answers = inquirer.prompt(questions)
         issn = list(answers[Fields.JOURNAL].values())[0][0]
 
-        filename = operation.get_unique_filename(f"crossref_issn_{issn}")
+        filename = colrev.utils.get_unique_filename(
+            review_manager=operation.review_manager,
+            file_path_string=f"crossref_issn_{issn}",
+        )
         add_source = colrev.search_file.ExtendedSearchFile(
             platform="colrev.crossref",
             search_results_path=filename,
@@ -172,7 +176,10 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
                 else:
                     query = params_dict
 
-                filename = operation.get_unique_filename(file_path_string="crossref")
+                filename = colrev.utils.get_unique_filename(
+                    review_manager=operation.review_manager,
+                    file_path_string="crossref",
+                )
                 search_source = colrev.search_file.ExtendedSearchFile(
                     platform="colrev.crossref",
                     search_results_path=filename,
@@ -185,7 +192,10 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
             if len(params_dict) == 0:
                 search_source = cls._add_toc_interactively(operation=operation)
             else:
-                filename = operation.get_unique_filename(file_path_string="crossref")
+                filename = colrev.utils.get_unique_filename(
+                    review_manager=operation.review_manager,
+                    file_path_string="crossref",
+                )
                 search_source = colrev.search_file.ExtendedSearchFile(
                     platform="colrev.crossref",
                     search_results_path=filename,

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -135,7 +135,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         issn = list(answers[Fields.JOURNAL].values())[0][0]
 
         filename = colrev.utils.get_unique_filename(
-            review_manager=operation.review_manager,
+            base_path=operation.review_manager.path,
             file_path_string=f"crossref_issn_{issn}",
         )
         add_source = colrev.search_file.ExtendedSearchFile(
@@ -177,7 +177,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
                     query = params_dict
 
                 filename = colrev.utils.get_unique_filename(
-                    review_manager=operation.review_manager,
+                    base_path=operation.review_manager.path,
                     file_path_string="crossref",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(
@@ -193,7 +193,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
                 search_source = cls._add_toc_interactively(operation=operation)
             else:
                 filename = colrev.utils.get_unique_filename(
-                    review_manager=operation.review_manager,
+                    base_path=operation.review_manager.path,
                     file_path_string="crossref",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -137,7 +137,10 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                     .replace("https://dblp.org/search/publ?q=", api_url)
                 )
 
-                filename = operation.get_unique_filename(file_path_string="dblp")
+                filename = colrev.utils.get_unique_filename(
+                    review_manager=operation.review_manager,
+                    file_path_string="dblp",
+                )
                 search_source = colrev.search_file.ExtendedSearchFile(
                     platform=cls.endpoint,
                     search_results_path=filename,

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -138,7 +138,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
                 )
 
                 filename = colrev.utils.get_unique_filename(
-                    review_manager=operation.review_manager,
+                    base_path=operation.review_manager.path,
                     file_path_string="dblp",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -15,6 +15,7 @@ from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -68,9 +69,11 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Add SearchSource as an endpoint"""
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -79,9 +82,10 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of EbscoHost"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
         else:
             raise NotImplementedError

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -15,7 +15,8 @@ from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -14,11 +14,13 @@ import colrev.ops.search_api_feed
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.search_file
+import colrev.utils
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.packages.eric.src import eric_api
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -113,8 +115,11 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         # all API searches
 
         if len(params_dict) == 0:
-            search_source = operation.create_db_source(
-                search_source_cls=cls, params=params_dict
+            search_source = create_db_source(
+                review_manager=operation.review_manager,
+                search_source_cls=cls,
+                params=params_dict,
+                add_to_git=True,
             )
 
         # pylint: disable=colrev-missed-constant-usage
@@ -126,7 +131,10 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
             rows = new_query.get("rows", ["2000"])[0]
             if ":" in search:
                 search = ERICSearchSource._search_split(search)
-            filename = operation.get_unique_filename(file_path_string=f"eric_{search}")
+            filename = colrev.utils.get_unique_filename(
+                review_manager=operation.review_manager,
+                file_path_string=f"eric_{search}",
+            )
             search_source = colrev.search_file.ExtendedSearchFile(
                 platform=cls.endpoint,
                 search_results_path=filename,
@@ -168,9 +176,10 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         if self.search_source.search_type == SearchType.API:
             self._run_api_search(eric_feed=eric_feed, rerun=rerun)
         elif self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
         else:
             raise NotImplementedError

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -50,7 +50,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
-        self.source_operation = source_operation
+
         if search_file:
             # ERIC as a search_source
             self.search_source = search_file

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -133,7 +133,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
             if ":" in search:
                 search = ERICSearchSource._search_split(search)
             filename = colrev.utils.get_unique_filename(
-                review_manager=operation.review_manager,
+                base_path=operation.review_manager.path,
                 file_path_string=f"eric_{search}",
             )
             search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -19,8 +19,9 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 from colrev.packages.eric.src import eric_api
-from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -29,8 +29,8 @@ from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.packages.europe_pmc.src import europe_pmc_api
 from colrev.ops.search_db import run_db_search
+from colrev.packages.europe_pmc.src import europe_pmc_api
 
 # pylint: disable=duplicate-code
 # pylint: disable=unused-argument

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -209,7 +209,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                 search_source=self.search_source,
                 update_only=False,
                 prep_mode=True,
-                records=self.review_manager.dataset.load_records_dict(),
+                records=prep_operation.review_manager.dataset.load_records_dict(),
                 logger=self.logger,
                 verbose_mode=self.verbose_mode,
             )
@@ -222,11 +222,11 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
 
             record.set_masterdata_complete(
                 source=retrieved_record.data[Fields.ORIGIN][0],
-                masterdata_repository=self.review_manager.settings.is_curated_repo(),
+                masterdata_repository=prep_operation.review_manager.settings.is_curated_repo(),
             )
             record.set_status(RecordState.md_prepared)
 
-            self.review_manager.dataset.save_records_dict(
+            prep_operation.review_manager.dataset.save_records_dict(
                 europe_pmc_feed.get_records(),
             )
             europe_pmc_feed.save()

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -379,7 +379,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                     "https://europepmc.org/search?query=", ""
                 )
                 filename = colrev.utils.get_unique_filename(
-                    review_manager=operation.review_manager,
+                    base_path=operation.review_manager.path,
                     file_path_string="europepmc",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -30,6 +30,7 @@ from colrev.constants import RecordState
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.packages.europe_pmc.src import europe_pmc_api
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=duplicate-code
 # pylint: disable=unused-argument
@@ -279,9 +280,10 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
         elif self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
 
         # if self.search_source.search_type == colrev.search_file.ExtendedSearchFile.MD:
@@ -376,7 +378,10 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                 query = params_dict["url"].replace(
                     "https://europepmc.org/search?query=", ""
                 )
-                filename = operation.get_unique_filename(file_path_string="europepmc")
+                filename = colrev.utils.get_unique_filename(
+                    review_manager=operation.review_manager,
+                    file_path_string="europepmc",
+                )
                 search_source = colrev.search_file.ExtendedSearchFile(
                     platform=cls.endpoint,
                     search_results_path=filename,

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -748,7 +748,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
         filename = utils.get_unique_filename(
-            review_manager=operation.review_manager,
+            base_path=operation.review_manager.path,
             file_path_string="files",
         )
         # pylint: disable=no-value-for-parameter

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -747,7 +747,10 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
     ) -> colrev.search_file.ExtendedSearchFile:
         """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
 
-        filename = operation.get_unique_filename(file_path_string="files")
+        filename = utils.get_unique_filename(
+            review_manager=operation.review_manager,
+            file_path_string="files",
+        )
         # pylint: disable=no-value-for-parameter
         search_source = colrev.search_file.ExtendedSearchFile(
             platform="colrev.files_dir",

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -18,6 +18,7 @@ import colrev.ops.search
 import colrev.ops.search_api_feed
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
@@ -129,7 +130,10 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
             else:
                 query = params_dict
 
-            filename = operation.get_unique_filename(file_path_string="github")
+            filename = colrev.utils.get_unique_filename(
+                review_manager=operation.review_manager,
+                file_path_string="github",
+            )
             search_source = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.github",
                 search_results_path=filename,

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -131,7 +131,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
                 query = params_dict
 
             filename = colrev.utils.get_unique_filename(
-                review_manager=operation.review_manager,
+                base_path=operation.review_manager.path,
                 file_path_string="github",
             )
             search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -14,6 +14,7 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -78,9 +79,11 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -89,9 +92,10 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of GoogleScholar"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -14,7 +14,8 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -21,7 +21,8 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -130,7 +130,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
                 last_value = list(search_parameters.values())[-1]
 
                 filename = colrev.utils.get_unique_filename(
-                    review_manager=operation.review_manager,
+                    base_path=operation.review_manager.path,
                     file_path_string=f"ieee_{last_value}",
                 )
 

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -16,10 +16,12 @@ import colrev.packages.ieee.src.ieee_api
 import colrev.record.record
 import colrev.record.record_prep
 import colrev.search_file
+import colrev.utils
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -126,8 +128,9 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
 
                 last_value = list(search_parameters.values())[-1]
 
-                filename = operation.get_unique_filename(
-                    file_path_string=f"ieee_{last_value}"
+                filename = colrev.utils.get_unique_filename(
+                    review_manager=operation.review_manager,
+                    file_path_string=f"ieee_{last_value}",
                 )
 
                 search_source = colrev.search_file.ExtendedSearchFile(
@@ -142,9 +145,11 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
                 raise NotImplementedError
 
         elif search_type == SearchType.DB:
-            search_source = operation.create_db_source(
+            search_source = create_db_source(
+                review_manager=operation.review_manager,
                 search_source_cls=cls,
                 params=params_dict,
+                add_to_git=True,
             )
         else:
             raise NotImplementedError
@@ -166,9 +171,10 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
             self._run_api_search(ieee_feed=ieee_feed, rerun=rerun)
 
         elif self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
 
         else:

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -14,6 +14,7 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -67,9 +68,11 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -78,9 +81,10 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of JSTOR"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -14,7 +14,8 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -235,7 +235,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
             search_source = operation.create_api_source(platform=cls.endpoint)
         else:
             filename = colrev.utils.get_unique_filename(
-                review_manager=operation.review_manager,
+                base_path=operation.review_manager.path,
                 file_path_string=f"local_index_{params}".replace("%", "").replace(
                     "'", ""
                 ),

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -234,10 +234,11 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         if len(params) == 0:
             search_source = operation.create_api_source(platform=cls.endpoint)
         else:
-            filename = operation.get_unique_filename(
+            filename = colrev.utils.get_unique_filename(
+                review_manager=operation.review_manager,
                 file_path_string=f"local_index_{params}".replace("%", "").replace(
                     "'", ""
-                )
+                ),
             )
             search_source = colrev.search_file.ExtendedSearchFile(
                 platform=cls.endpoint,

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -18,6 +18,7 @@ import colrev.process.operation
 import colrev.record.record
 import colrev.record.record_prep
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
@@ -111,8 +112,9 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
                     for key, value in (pair.split("=") for pair in parameter_pairs)
                 }
                 last_value = list(search_parameters.values())[-1]
-                filename = operation.get_unique_filename(
-                    file_path_string=f"osf_{last_value}"
+                filename = colrev.utils.get_unique_filename(
+                    review_manager=operation.review_manager,
+                    file_path_string=f"osf_{last_value}",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(
                     platform=cls.endpoint,

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -113,7 +113,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
                 }
                 last_value = list(search_parameters.values())[-1]
                 filename = colrev.utils.get_unique_filename(
-                    review_manager=operation.review_manager,
+                    base_path=operation.review_manager.path,
                     file_path_string=f"osf_{last_value}",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -18,6 +18,7 @@ import colrev.process.operation
 import colrev.record.record
 import colrev.record.record_prep
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import FieldValues
 from colrev.constants import RecordState
@@ -112,7 +113,10 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
             else:
                 query = params_dict
 
-            filename = operation.get_unique_filename(file_path_string="plos")
+            filename = colrev.utils.get_unique_filename(
+                review_manager=operation.review_manager,
+                file_path_string="plos",
+            )
 
             search_source = colrev.search_file.ExtendedSearchFile(
                 platform="colrev.plos",

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -114,7 +114,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
                 query = params_dict
 
             filename = colrev.utils.get_unique_filename(
-                review_manager=operation.review_manager,
+                base_path=operation.review_manager.path,
                 file_path_string="plos",
             )
 

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -20,11 +20,11 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.packages.prospero.src.prospero_api
 import colrev.process
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.ops.search import Search
-import colrev.utils
 
 
 class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -69,7 +69,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
             return search_source
 
         filename = colrev.utils.get_unique_filename(
-            review_manager=operation.review_manager,
+            base_path=operation.review_manager.path,
             file_path_string="prospero_results",
         )
 

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -24,6 +24,7 @@ from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.ops.search import Search
+import colrev.utils
 
 
 class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
@@ -67,7 +68,10 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
             operation.add_source_and_search(search_source)
             return search_source
 
-        filename = operation.get_unique_filename(file_path_string="prospero_results")
+        filename = colrev.utils.get_unique_filename(
+            review_manager=operation.review_manager,
+            file_path_string="prospero_results",
+        )
 
         new_search_source = colrev.search_file.ExtendedSearchFile(
             platform=cls.endpoint,

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -14,7 +14,8 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -14,6 +14,7 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -68,9 +69,11 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -79,9 +82,10 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of Psycinfo"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -25,8 +25,9 @@ from colrev.constants import Fields
 from colrev.constants import RecordState
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 from colrev.packages.pubmed.src import pubmed_api
-from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -128,7 +128,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
                 if host and host.endswith("pubmed.ncbi.nlm.nih.gov"):
 
                     filename = colrev.utils.get_unique_filename(
-                        review_manager=operation.review_manager,
+                        base_path=operation.review_manager.path,
                         file_path_string="pubmed",
                     )
                     # params = (

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -26,6 +26,7 @@ from colrev.constants import RecordState
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
 from colrev.packages.pubmed.src import pubmed_api
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -108,9 +109,11 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         if search_type == SearchType.DB:
-            search_source = operation.create_db_source(
+            search_source = create_db_source(
+                review_manager=operation.review_manager,
                 search_source_cls=cls,
                 params=params_dict,
+                add_to_git=True,
             )
 
         elif search_type == SearchType.API:
@@ -123,7 +126,10 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
 
                 if host and host.endswith("pubmed.ncbi.nlm.nih.gov"):
 
-                    filename = operation.get_unique_filename(file_path_string="pubmed")
+                    filename = colrev.utils.get_unique_filename(
+                        review_manager=operation.review_manager,
+                        file_path_string="pubmed",
+                    )
                     # params = (
                     # "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term="
                     #     + params
@@ -407,9 +413,10 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
         elif self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
         else:

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -17,6 +17,7 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -71,9 +72,11 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -82,9 +85,10 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of Scopus"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -17,7 +17,8 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -20,6 +20,7 @@ import colrev.package_manager.package_base_classes as base_classes
 import colrev.process.operation
 import colrev.record.record
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
@@ -352,7 +353,10 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             if len(short_search_params["query"]) > 50:
                 short_search_params["query"] = short_search_params["query"][0:50]
 
-        filename = operation.get_unique_filename(file_path_string="semanticscholar")
+        filename = colrev.utils.get_unique_filename(
+            review_manager=operation.review_manager,
+            file_path_string="semanticscholar",
+        )
 
         search_source = colrev.search_file.ExtendedSearchFile(
             platform="colrev.semanticscholar",

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -354,7 +354,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
                 short_search_params["query"] = short_search_params["query"][0:50]
 
         filename = colrev.utils.get_unique_filename(
-            review_manager=operation.review_manager,
+            base_path=operation.review_manager.path,
             file_path_string="semanticscholar",
         )
 

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -19,11 +19,13 @@ import colrev.ops.search_api_feed
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -92,13 +94,18 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         if search_type == SearchType.DB:
-            search_source = operation.create_db_source(
+            search_source = create_db_source(
+                review_manager=operation.review_manager,
                 search_source_cls=cls,
                 params=params_dict,
+                add_to_git=True,
             )
 
         elif search_type == SearchType.API:
-            filename = operation.get_unique_filename(file_path_string="springer_link")
+            filename = colrev.utils.get_unique_filename(
+                review_manager=operation.review_manager,
+                file_path_string="springer_link",
+            )
             search_source = colrev.search_file.ExtendedSearchFile(
                 platform=cls.endpoint,
                 search_results_path=filename,
@@ -121,9 +128,10 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of SpringerLink"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -104,7 +104,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         elif search_type == SearchType.API:
             filename = colrev.utils.get_unique_filename(
-                review_manager=operation.review_manager,
+                base_path=operation.review_manager.path,
                 file_path_string="springer_link",
             )
             search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -25,7 +25,8 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -19,6 +19,7 @@ import colrev.ops.search_api_feed
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Colors
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
@@ -137,8 +138,9 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         assert "dataset" in params_dict
         dataset = params_dict["dataset"]
-        filename = operation.get_unique_filename(
-            file_path_string=f"SYNERGY_{dataset.replace('/', '_').replace('_ids.csv', '')}"
+        filename = colrev.utils.get_unique_filename(
+            review_manager=operation.review_manager,
+            file_path_string=f"SYNERGY_{dataset.replace('/', '_').replace('_ids.csv', '')}",
         )
         search_source = colrev.search_file.ExtendedSearchFile(
             platform="colrev.synergy_datasets",

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -139,7 +139,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         assert "dataset" in params_dict
         dataset = params_dict["dataset"]
         filename = colrev.utils.get_unique_filename(
-            review_manager=operation.review_manager,
+            base_path=operation.review_manager.path,
             file_path_string=f"SYNERGY_{dataset.replace('/', '_').replace('_ids.csv', '')}",
         )
         search_source = colrev.search_file.ExtendedSearchFile(

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -14,7 +14,8 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -14,6 +14,7 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -61,9 +62,11 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -72,9 +75,10 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of TaylorAndFrancis"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -16,7 +16,8 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -16,6 +16,7 @@ from colrev.constants import ENTRYTYPES
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -68,9 +69,11 @@ class TransportResearchInternationalDocumentation(
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -79,9 +82,10 @@ class TransportResearchInternationalDocumentation(
         """Run a search of TRID"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -23,6 +23,7 @@ from colrev.constants import FieldSet
 from colrev.constants import FieldValues
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -84,9 +85,11 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
             for item in params.split(";"):
                 key, value = item.split("=")
                 params_dict[key] = value
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -95,8 +98,10 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of Crossref"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.operation.run_db_search(  # type: ignore
-                search_source_cls=self.__class__, source=self.search_source
+            run_db_search(
+                search_source_cls=self.__class__,
+                source=self.search_source,
+                add_to_git=True,
             )
 
     def prep_link_md(

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -23,7 +23,8 @@ from colrev.constants import FieldSet
 from colrev.constants import FieldValues
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -99,7 +99,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
                 search_parameters[key] = value
 
             filename = colrev.utils.get_unique_filename(
-                review_manager=operation.review_manager,
+                base_path=operation.review_manager.path,
                 file_path_string="unpaywall",
             )
 

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -13,6 +13,7 @@ import colrev.ops.search_api_feed
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.search_file
+import colrev.utils
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
@@ -97,7 +98,10 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
                 key, value = parameter.split("=")
                 search_parameters[key] = value
 
-            filename = operation.get_unique_filename(file_path_string="unpaywall")
+            filename = colrev.utils.get_unique_filename(
+                review_manager=operation.review_manager,
+                file_path_string="unpaywall",
+            )
 
             search_parameters["query"] = (
                 UnpaywallAPI.decode_html_url_encoding_to_string(

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -13,7 +13,8 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -13,6 +13,7 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -81,9 +82,11 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -92,9 +95,10 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of WebOfScience"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -13,6 +13,7 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
+from colrev.ops.search_db import create_db_source, run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -64,9 +65,11 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
-        search_source = operation.create_db_source(
+        search_source = create_db_source(
+            review_manager=operation.review_manager,
             search_source_cls=cls,
             params=params_dict,
+            add_to_git=True,
         )
         operation.add_source_and_search(search_source)
         return search_source
@@ -75,9 +78,10 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         """Run a search of Wiley"""
 
         if self.search_source.search_type == SearchType.DB:
-            self.source_operation.run_db_search(  # type: ignore
+            run_db_search(
                 search_source_cls=self.__class__,
                 source=self.search_source,
+                add_to_git=True,
             )
             return
 

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -13,7 +13,8 @@ import colrev.record.record
 from colrev.constants import Fields
 from colrev.constants import SearchSourceHeuristicStatus
 from colrev.constants import SearchType
-from colrev.ops.search_db import create_db_source, run_db_search
+from colrev.ops.search_db import create_db_source
+from colrev.ops.search_db import run_db_search
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code

--- a/colrev/utils.py
+++ b/colrev/utils.py
@@ -51,9 +51,7 @@ def get_unique_filename(
     sources = review_manager.settings.sources
 
     file_path_string = (
-        file_path_string.replace("+", "_")
-        .replace(" ", "_")
-        .replace(";", "_")
+        file_path_string.replace("+", "_").replace(" ", "_").replace(";", "_")
     )
 
     if file_path_string.endswith(suffix):

--- a/colrev/utils.py
+++ b/colrev/utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import requests_cache
 
 from colrev.constants import Filepaths
+from colrev.search_file import load_search_file
 
 _p_printer = pprint.PrettyPrinter(indent=4, width=140, compact=False)
 
@@ -43,12 +44,21 @@ def in_ci_environment() -> bool:
 
 
 def get_unique_filename(
-    *, review_manager, file_path_string: str, suffix: str = ".bib"
+    *,
+    base_path: Path,
+    file_path_string: str,
+    suffix: str = ".bib",
+    prefix: str = "data/search/",
 ) -> Path:
     """Get a unique filename for a (new) SearchSource"""
 
-    review_manager.load_settings()
-    sources = review_manager.settings.sources
+    base_path = base_path / Path(prefix)
+    existing_filenames = []
+    for search_file_path in base_path.glob("*_search_history.json"):
+        search_file = load_search_file(search_file_path)
+        existing_filenames.append(search_file.filepath)
+    for existing_file in base_path.glob("*"):
+        existing_filenames.append(existing_file)
 
     file_path_string = (
         file_path_string.replace("+", "_").replace(" ", "_").replace(";", "_")
@@ -56,14 +66,13 @@ def get_unique_filename(
 
     if file_path_string.endswith(suffix):
         file_path_string = file_path_string.rstrip(suffix)
-    filename = Path(f"data/search/{file_path_string}{suffix}")
-    existing_filenames = [x.search_results_path for x in sources]
+    filename = base_path / Path(f"{file_path_string}{suffix}")
     if all(x != filename for x in existing_filenames):
-        return filename
+        return Path(prefix) / filename
 
     i = 1
     while not all(x != filename for x in existing_filenames):
-        filename = Path(f"data/search/{file_path_string}_{i}{suffix}")
+        filename = Path(f"{file_path_string}_{i}{suffix}")
         i += 1
 
-    return filename
+    return Path(prefix) / filename

--- a/colrev/utils.py
+++ b/colrev/utils.py
@@ -56,7 +56,7 @@ def get_unique_filename(
     existing_filenames = []
     for search_file_path in base_path.glob("*_search_history.json"):
         search_file = load_search_file(search_file_path)
-        existing_filenames.append(search_file.filepath)
+        existing_filenames.append(search_file._filepath)
     for existing_file in base_path.glob("*"):
         existing_filenames.append(existing_file)
 
@@ -68,11 +68,11 @@ def get_unique_filename(
         file_path_string = file_path_string.rstrip(suffix)
     filename = base_path / Path(f"{file_path_string}{suffix}")
     if all(x != filename for x in existing_filenames):
-        return Path(prefix) / filename
+        return Path(prefix) / filename.name
 
     i = 1
     while not all(x != filename for x in existing_filenames):
         filename = Path(f"{file_path_string}_{i}{suffix}")
         i += 1
 
-    return Path(prefix) / filename
+    return Path(prefix) / filename.name

--- a/docs/source/dev_docs/_autosummary/colrev.ops.search.Search.rst
+++ b/docs/source/dev_docs/_autosummary/colrev.ops.search.Search.rst
@@ -21,15 +21,11 @@ colrev.ops.search.Search
       ~Search.check_precondition
       ~Search.conclude
       ~Search.create_api_source
-      ~Search.create_db_source
       ~Search.decorate
       ~Search.get_new_search_files
       ~Search.get_new_source_heuristic
-      ~Search.get_query_filename
-      ~Search.get_unique_filename
       ~Search.main
       ~Search.notify
-      ~Search.run_db_search
       ~Search.select_search_type
 
 

--- a/docs/source/dev_docs/colrev.ops.search.Search.rst
+++ b/docs/source/dev_docs/colrev.ops.search.Search.rst
@@ -21,15 +21,11 @@ colrev.ops.search.Search
       ~Search.check_precondition
       ~Search.conclude
       ~Search.create_api_source
-      ~Search.create_db_source
       ~Search.decorate
       ~Search.get_new_search_files
       ~Search.get_new_source_heuristic
-      ~Search.get_query_filename
-      ~Search.get_unique_filename
       ~Search.main
       ~Search.notify
-      ~Search.run_db_search
       ~Search.select_search_type
 
 

--- a/tests/2_ops/search_operation_test.py
+++ b/tests/2_ops/search_operation_test.py
@@ -7,6 +7,7 @@ import pytest
 
 import colrev.exceptions as colrev_exceptions
 import colrev.review_manager
+import colrev.utils
 from colrev.constants import EndpointType
 from colrev.constants import SearchType
 from colrev.package_manager.package_manager import PackageManager
@@ -76,13 +77,12 @@ def test_search_get_unique_filename(
 ) -> None:
     """Test the search.get_unique_filename()"""
 
-    search_operation = base_repo_review_manager.get_search_operation()
     expected = Path("data/search/test_records_1.bib")
-    actual = search_operation.get_unique_filename(file_path_string="test_records.bib")
+    actual = colrev.utils.get_unique_filename(file_path_string="test_records.bib")
     assert expected == actual
 
     expected = Path("data/search/dbs.bib")
-    actual = search_operation.get_unique_filename(file_path_string="dbs.bib")
+    actual = colrev.utils.get_unique_filename(file_path_string="dbs.bib")
     assert expected == actual
 
 

--- a/tests/2_ops/search_operation_test.py
+++ b/tests/2_ops/search_operation_test.py
@@ -78,11 +78,15 @@ def test_search_get_unique_filename(
     """Test the search.get_unique_filename()"""
 
     expected = Path("data/search/test_records_1.bib")
-    actual = colrev.utils.get_unique_filename(file_path_string="test_records.bib")
+    actual = colrev.utils.get_unique_filename(
+        base_path=base_repo_review_manager.path, file_path_string="test_records.bib"
+    )
     assert expected == actual
 
     expected = Path("data/search/dbs.bib")
-    actual = colrev.utils.get_unique_filename(file_path_string="dbs.bib")
+    actual = colrev.utils.get_unique_filename(
+        base_path=base_repo_review_manager.path, file_path_string="dbs.bib"
+    )
     assert expected == actual
 
 


### PR DESCRIPTION
## Summary
- extract DB source utilities into dedicated `search_db` module
- relocate `get_unique_filename` into `colrev.utils`
- adjust search packages to use `create_db_source` and new filename helper

## Testing
- `pre-commit run --files colrev/ops/search.py colrev/ops/search_db.py colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py colrev/packages/acm_digital_library/src/acm_digital_library.py colrev/packages/ais_library/src/aisel.py colrev/packages/arxiv/src/arxiv.py colrev/packages/colrev_project/src/colrev_project.py colrev/packages/crossref/src/crossref_search_source.py colrev/packages/dblp/src/dblp.py colrev/packages/ebsco_host/src/ebsco_host.py colrev/packages/eric/src/eric.py colrev/packages/europe_pmc/src/europe_pmc.py colrev/packages/files_dir/src/files_dir.py colrev/packages/github/src/github_search_source.py colrev/packages/google_scholar/src/google_scholar.py colrev/packages/ieee/src/ieee.py colrev/packages/jstor/src/jstor.py colrev/packages/local_index/src/local_index.py colrev/packages/osf/src/osf.py colrev/packages/plos/src/plos_search_source.py colrev/packages/prospero/src/prospero_search_source.py colrev/packages/psycinfo/src/psycinfo.py colrev/packages/pubmed/src/pubmed.py colrev/packages/scopus/src/scopus.py colrev/packages/semanticscholar/src/semanticscholar_search_source.py colrev/packages/springer_link/src/springer_link.py colrev/packages/synergy_datasets/src/synergy_datasets.py colrev/packages/taylor_and_francis/src/taylor_and_francis.py colrev/packages/trid/src/trid.py colrev/packages/unknown_source/src/unknown_source.py colrev/packages/unpaywall/src/unpaywall_search_source.py colrev/packages/web_of_science/src/web_of_science.py colrev/packages/wiley/src/wiley.py colrev/utils.py docs/source/dev_docs/_autosummary/colrev.ops.search.Search.rst docs/source/dev_docs/colrev.ops.search.Search.rst` (failed: CONNECT tunnel failed, response 403)
- `pip install -e .` (failed: Could not find a version that satisfies the requirement hatchling)
- `PYTHONPATH=$(pwd) pytest tests/3_packages_search -q` (failed: PackageNotFoundError: No package metadata was found for colrev)


------
https://chatgpt.com/codex/tasks/task_e_6898305210a4832a8bd7c7158bdcc2ee