### PR TITLE
refactor: update db source call sites

### DIFF
--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -74,6 +74,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -75,10 +75,11 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.DB:
             search_source = create_db_source(
-                review_manager=operation.review_manager,
+                path=operation.review_manager.path,
                 search_source_cls=cls,
                 params=params_dict,
                 add_to_git=True,
+                logger=operation.review_manager.logger,
             )
         else:
             raise NotImplementedError

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -183,10 +183,11 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.DB:
             search_source = create_db_source(
-                review_manager=operation.review_manager,
+                path=operation.review_manager.path,
                 search_source_cls=cls,
                 params=params_dict,
                 add_to_git=True,
+                logger=operation.review_manager.logger,
             )
 
         # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -71,10 +71,11 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         params_dict = {params.split("=")[0]: params.split("=")[1]}
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -117,10 +117,11 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if len(params_dict) == 0:
             search_source = create_db_source(
-                review_manager=operation.review_manager,
+                path=operation.review_manager.path,
                 search_source_cls=cls,
                 params=params_dict,
                 add_to_git=True,
+                logger=operation.review_manager.logger,
             )
 
         # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -81,10 +81,11 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -148,10 +148,11 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         elif search_type == SearchType.DB:
             search_source = create_db_source(
-                review_manager=operation.review_manager,
+                path=operation.review_manager.path,
                 search_source_cls=cls,
                 params=params_dict,
                 add_to_git=True,
+                logger=operation.review_manager.logger,
             )
         else:
             raise NotImplementedError

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -70,10 +70,11 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -71,10 +71,11 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -111,10 +111,11 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.DB:
             search_source = create_db_source(
-                review_manager=operation.review_manager,
+                path=operation.review_manager.path,
                 search_source_cls=cls,
                 params=params_dict,
                 add_to_git=True,
+                logger=operation.review_manager.logger,
             )
 
         elif search_type == SearchType.API:

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -74,10 +74,11 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -96,10 +96,11 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.DB:
             search_source = create_db_source(
-                review_manager=operation.review_manager,
+                path=operation.review_manager.path,
                 search_source_cls=cls,
                 params=params_dict,
                 add_to_git=True,
+                logger=operation.review_manager.logger,
             )
 
         elif search_type == SearchType.API:

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -64,10 +64,11 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -47,7 +47,6 @@ class TransportResearchInternationalDocumentation(
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
         self.source_operation = source_operation
-        self.review_manager = source_operation.review_manager
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
@@ -71,10 +70,11 @@ class TransportResearchInternationalDocumentation(
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -87,10 +87,11 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
                 key, value = item.split("=")
                 params_dict[key] = value
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -84,10 +84,11 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -67,10 +67,11 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
-            review_manager=operation.review_manager,
+            path=operation.review_manager.path,
             search_source_cls=cls,
             params=params_dict,
             add_to_git=True,
+            logger=operation.review_manager.logger,
         )
         operation.add_source_and_search(search_source)
         return search_source


### PR DESCRIPTION
## Summary
- update SearchSource packages to pass explicit `path` and `logger` to `create_db_source`
- drop unused `review_manager` attribute from TRID search source

## Testing
- `pre-commit run --files colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py colrev/packages/acm_digital_library/src/acm_digital_library.py colrev/packages/ais_library/src/aisel.py colrev/packages/ebsco_host/src/ebsco_host.py colrev/packages/eric/src/eric.py colrev/packages/google_scholar/src/google_scholar.py colrev/packages/ieee/src/ieee.py colrev/packages/jstor/src/jstor.py colrev/packages/psycinfo/src/psycinfo.py colrev/packages/pubmed/src/pubmed.py colrev/packages/scopus/src/scopus.py colrev/packages/springer_link/src/springer_link.py colrev/packages/taylor_and_francis/src/taylor_and_francis.py colrev/packages/trid/src/trid.py colrev/packages/unknown_source/src/unknown_source.py colrev/packages/web_of_science/src/web_of_science.py colrev/packages/wiley/src/wiley.py` *(fails: fatal unable to access GitHub, 403)*
- `pip install -e .` *(fails: cannot connect to proxy, 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'colrev')*

------
https://chatgpt.com/codex/tasks/task_e_689892fc1574832a876c7052cc873aab