### PR TITLE
refactor: use standalone create_api_source in packages

### DIFF
--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -14,6 +14,7 @@ from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
@@ -210,7 +211,9 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 )
             else:
                 # Add API search without params
-                search_source = operation.create_api_source(platform=cls.endpoint)
+                search_source = create_api_source(
+                    platform=cls.endpoint, path=operation.review_manager.path
+                )
 
         # elif search_type == SearchType.TOC:
         else:

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -15,6 +15,7 @@ from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
@@ -88,7 +89,9 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
 
         # Note : always API search
         if len(params_dict) == 0:
-            search_source = operation.create_api_source(platform=cls.endpoint)
+            search_source = create_api_source(
+                platform=cls.endpoint, path=operation.review_manager.path
+            )
 
         # pylint: disable=colrev-missed-constant-usage
         else:

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -159,7 +159,9 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.API:
             if len(params_dict) == 0:
-                search_source = create_api_source(platform=cls.endpoint)
+                search_source = create_api_source(
+                    platform=cls.endpoint, path=operation.review_manager.path
+                )
                 # pylint: disable=colrev-missed-constant-usage
                 search_source.search_string = (
                     cls._api_url

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -15,6 +15,7 @@ from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
@@ -126,7 +127,9 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.API:
             if len(params_dict) == 0:
-                search_source = operation.create_api_source(platform=cls.endpoint)
+                search_source = create_api_source(
+                    platform=cls.endpoint, path=operation.review_manager.path
+                )
 
             # pylint: disable=colrev-missed-constant-usage
             elif "url" in params_dict:

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -19,6 +19,7 @@ from rapidfuzz import fuzz
 
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
@@ -367,7 +368,9 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                     params_dict[key] = value
 
         if len(params_dict) == 0:
-            search_source = operation.create_api_source(platform=cls.endpoint)
+            search_source = create_api_source(
+                platform=cls.endpoint, path=operation.review_manager.path
+            )
 
         # pylint: disable=colrev-missed-constant-usage
         elif "url" in params_dict:

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -16,6 +16,7 @@ from pydantic import Field
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.search
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.search_file
 import colrev.utils
@@ -111,7 +112,9 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
                     print("Invalid search parameter format")
 
         if len(params_dict) == 0:
-            search_source = operation.create_api_source(platform="colrev.github")
+            search_source = create_api_source(
+                platform="colrev.github", path=operation.review_manager.path
+            )
 
             # Checking where to search
             search_source.search_string["scope"] = cls._choice_scope()

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -12,6 +12,7 @@ from pydantic import Field
 import colrev.env.environment_manager
 import colrev.ops.prep
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.packages.ieee.src.ieee_api
 import colrev.record.record
@@ -107,7 +108,9 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         if search_type == SearchType.API:
             if len(params_dict) == 0:
-                search_source = operation.create_api_source(platform=cls.endpoint)
+                search_source = create_api_source(
+                    platform=cls.endpoint, path=operation.review_manager.path
+                )
 
             # pylint: disable=colrev-missed-constant-usage
             elif (

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -18,6 +18,7 @@ import colrev.env.local_index
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.check
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.search_file
@@ -232,7 +233,9 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         # always API search
 
         if len(params) == 0:
-            search_source = operation.create_api_source(platform=cls.endpoint)
+            search_source = create_api_source(
+                platform=cls.endpoint, path=operation.review_manager.path
+            )
         else:
             filename = colrev.utils.get_unique_filename(
                 base_path=operation.review_manager.path,

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -13,6 +13,7 @@ import colrev.loader.load_utils
 import colrev.ops.prep
 import colrev.ops.search
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.process.operation
 import colrev.record.record
@@ -92,7 +93,9 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         if search_type == SearchType.API:
             # Check for params being empty and initialize if needed
             if len(params_dict) == 0:
-                search_source = operation.create_api_source(platform=cls.endpoint)
+                search_source = create_api_source(
+                    platform=cls.endpoint, path=operation.review_manager.path
+                )
                 # Search title per default (other fields may be supported later)
                 search_source.search_string["query"] = {
                     "title": search_source.search_string["query"]

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -12,6 +12,7 @@ import colrev.loader.load_utils
 import colrev.ops.prep
 import colrev.ops.search
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.packages.doi_org.src.doi_org as doi_connector
 import colrev.process.operation
@@ -91,7 +92,9 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_type = cls._select_search_type(operation, params_dict)
         if search_type == SearchType.API:
             if len(params) == 0:
-                search_source = operation.create_api_source(platform=cls.endpoint)
+                search_source = create_api_source(
+                    platform=cls.endpoint, path=operation.review_manager.path
+                )
 
                 search_source.search_string[Fields.URL] = (
                     cls._api_url

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -16,6 +16,7 @@ from pydantic import Field
 import colrev.exceptions as colrev_exceptions
 import colrev.loader.load_utils
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.packages.prospero.src.prospero_api
 import colrev.process
@@ -60,7 +61,9 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Adds Prospero as a search source endpoint based on user-provided parameters."""
         if len(params) == 0:
             # TODO : test prospero search
-            search_source = operation.create_api_source(platform=cls.endpoint)
+            search_source = create_api_source(
+                platform=cls.endpoint, path=operation.review_manager.path
+            )
             search_source.search_string[Fields.URL] = (
                 cls.db_url + "search?" + search_source.search_string + "#searchadvanced"
             )

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -14,6 +14,7 @@ from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.record.record_prep
@@ -120,7 +121,9 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         elif search_type == SearchType.API:
             if len(params_dict) == 0:
-                search_source = operation.create_api_source(platform=cls.endpoint)
+                search_source = create_api_source(
+                    platform=cls.endpoint, path=operation.review_manager.path
+                )
 
             # pylint: disable=colrev-missed-constant-usage
             elif "url" in params_dict:

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -10,6 +10,7 @@ from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
 import colrev.ops.search_api_feed
+from colrev.ops.search_api_feed import create_api_source
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.record.record
 import colrev.search_file
@@ -81,7 +82,9 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
                     params_dict[key] = value
 
         if len(params_dict) == 0:
-            search_source = operation.create_api_source(platform=cls.endpoint)
+            search_source = create_api_source(
+                platform=cls.endpoint, path=operation.review_manager.path
+            )
 
         # pylint: disable=colrev-missed-constant-usage
         elif "https://api.unpaywall.org/v2/search" in params_dict["url"]:


### PR DESCRIPTION
## Summary
- refactor package search sources to import create_api_source from search_api_feed
- ensure create_api_source calls pass review_manager.path

## Testing
- `pre-commit run --files colrev/packages/ais_library/src/aisel.py colrev/packages/arxiv/src/arxiv.py colrev/packages/crossref/src/crossref_search_source.py colrev/packages/dblp/src/dblp.py colrev/packages/europe_pmc/src/europe_pmc.py colrev/packages/github/src/github_search_source.py colrev/packages/ieee/src/ieee.py colrev/packages/local_index/src/local_index.py colrev/packages/osf/src/osf.py colrev/packages/plos/src/plos_search_source.py colrev/packages/prospero/src/prospero_search_source.py colrev/packages/pubmed/src/pubmed.py colrev/packages/unpaywall/src/unpaywall_search_source.py` (failed: CONNECT tunnel failed, response 403)
- `pytest -q` (failed: ModuleNotFoundError: No module named 'colrev')

------
https://chatgpt.com/codex/tasks/task_e_68989adcd600832a8142e939c5b92698