### PR TITLE
refactor(searchsources): make load() an instance method

### DIFF
--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -251,21 +251,20 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
                 unique_id_field="ID",
             )
-            cls._remove_duplicates(records=records, filename=filename, logger=logger)
+            self._remove_duplicates(records=records, filename=self.search_source.search_results_path, logger=self.logger)
             return records
 
-        if filename.suffix == ".ris":
-            return cls._load_ris(filename, logger)
+        if self.search_source.search_results_path.suffix == ".ris":
+            return self._load_ris(self.search_source.search_results_path, self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -260,7 +260,11 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
                 logger=self.logger,
                 unique_id_field="ID",
             )
-            self._remove_duplicates(records=records, filename=self.search_source.search_results_path, logger=self.logger)
+            self._remove_duplicates(
+                records=records,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
+            )
             return records
 
         if self.search_source.search_results_path.suffix == ".ris":

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -115,11 +115,10 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         """Not implemented"""
         return record
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
                 record_dict.pop("url", None)
@@ -128,21 +127,21 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                 record_dict.pop("month", None)
 
                 if "issue_date" in record_dict:
-                    record_dict[f"{cls.endpoint}.issue_date"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.issue_date"] = record_dict.pop(
                         "issue_date"
                     )
                 if "location" in record_dict:
                     record_dict[Fields.ADDRESS] = record_dict.pop("location", None)
                 if "articleno" in record_dict:
-                    record_dict[f"{cls.endpoint}.articleno"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.articleno"] = record_dict.pop(
                         "articleno"
                     )
 
             records = colrev.loader.load_utils.load(
-                filename=filename,
+                filename=self.search_source.search_results_path,
                 unique_id_field="ID",
                 field_mapper=field_mapper,
-                logger=logger,
+                logger=self.logger,
             )
 
             return records

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -380,11 +380,15 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         # pylint: disable=colrev-missed-constant-usage
         if self.search_source.search_results_path.suffix in [".txt", ".enl"]:
-            return self._load_enl(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_enl(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         # for API-based searches
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -375,17 +375,16 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
         # pylint: disable=colrev-missed-constant-usage
-        if filename.suffix in [".txt", ".enl"]:
-            return cls._load_enl(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix in [".txt", ".enl"]:
+            return self._load_enl(filename=self.search_source.search_results_path, logger=self.logger)
 
         # for API-based searches
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -333,15 +333,14 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
                 rerun=rerun,
             )
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
         # for API-based searches
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             for record in records.values():
                 record[Fields.INSTITUTION] = "ArXiv"

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -276,14 +276,13 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return result
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             for record_id in records:
                 records[record_id] = {

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -322,31 +322,30 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         else:
             raise NotImplementedError
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
                 if "timestamp" in record_dict:
-                    record_dict[f"{cls.endpoint}.timestamp"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.timestamp"] = record_dict.pop(
                         "timestamp"
                     )
                 if "biburl" in record_dict:
-                    record_dict[f"{cls.endpoint}.biburl"] = record_dict.pop("biburl")
+                    record_dict[f"{self.endpoint}.biburl"] = record_dict.pop("biburl")
                 if "bibsource" in record_dict:
-                    record_dict[f"{cls.endpoint}.bibsource"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.bibsource"] = record_dict.pop(
                         "bibsource"
                     )
                 if "dblp_key" in record_dict:
                     record_dict[Fields.DBLP_KEY] = record_dict.pop("dblp_key")
 
             records = colrev.loader.load_utils.load(
-                filename=filename,
+                filename=self.search_source.search_results_path,
                 unique_id_field="ID",
                 field_mapper=field_mapper,
-                logger=logger,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -120,7 +120,9 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -116,12 +116,11 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -260,17 +260,16 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".nbib":
-            return cls._load_nbib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".nbib":
+            return self._load_nbib(filename=self.search_source.search_results_path, logger=self.logger)
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -264,7 +264,9 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".nbib":
-            return self._load_nbib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_nbib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -398,12 +398,11 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -402,7 +402,9 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -793,28 +793,27 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         except (colrev_exceptions.RecordNotFoundInPrepSourceException,):
             pass
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
                 if "note" in record_dict:
-                    record_dict[f"{cls.endpoint}.note"] = record_dict.pop("note")
+                    record_dict[f"{self.endpoint}.note"] = record_dict.pop("note")
 
             records = colrev.loader.load_utils.load(
-                filename=filename,
+                filename=self.search_source.search_results_path,
                 unique_id_field="ID",
                 field_mapper=field_mapper,
-                logger=logger,
+                logger=self.logger,
             )
 
             for record_dict in records.values():
                 if Fields.GROBID_VERSION in record_dict:
                     del record_dict[Fields.GROBID_VERSION]
 
-                cls._update_based_on_doi(record_dict=record_dict)
+                self._update_based_on_doi(record_dict=record_dict)
 
             return records
 

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -208,13 +208,12 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
             self._run_api_search(github_feed)
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
                 unique_id_field="url",
             )
 

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -111,59 +111,58 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Not implemented"""
         return record
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
 
             def bib_field_mapper(record_dict: dict) -> None:
                 if "related" in record_dict:
-                    record_dict[f"{cls.endpoint}.related"] = record_dict.pop("related")
+                    record_dict[f"{self.endpoint}.related"] = record_dict.pop("related")
                 if "note" in record_dict:
-                    record_dict[f"{cls.endpoint}.note"] = record_dict.pop("note")
+                    record_dict[f"{self.endpoint}.note"] = record_dict.pop("note")
                 if "type" in record_dict:
-                    record_dict[f"{cls.endpoint}.type"] = record_dict.pop("type")
+                    record_dict[f"{self.endpoint}.type"] = record_dict.pop("type")
 
             records = colrev.loader.load_utils.load(
-                filename=filename,
+                filename=self.search_source.search_results_path,
                 field_mapper=bib_field_mapper,
-                logger=logger,
+                logger=self.logger,
             )
             return records
 
-        if filename.suffix == ".json":
+        if self.search_source.search_results_path.suffix == ".json":
             # pylint: disable=too-many-branches
             def json_field_mapper(record_dict: dict) -> None:
                 if "related" in record_dict:
-                    record_dict[f"{cls.endpoint}.related"] = record_dict.pop("related")
+                    record_dict[f"{self.endpoint}.related"] = record_dict.pop("related")
                 if "note" in record_dict:
-                    record_dict[f"{cls.endpoint}.note"] = record_dict.pop("note")
+                    record_dict[f"{self.endpoint}.note"] = record_dict.pop("note")
                 if "type" in record_dict:
-                    record_dict[f"{cls.endpoint}.type"] = record_dict.pop("type")
+                    record_dict[f"{self.endpoint}.type"] = record_dict.pop("type")
                 if "article_url" in record_dict:
-                    record_dict[f"{cls.endpoint}.article_url"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.article_url"] = record_dict.pop(
                         "article_url"
                     )
                 if "cites_url" in record_dict:
-                    record_dict[f"{cls.endpoint}.cites_url"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.cites_url"] = record_dict.pop(
                         "cites_url"
                     )
                 if "related_url" in record_dict:
-                    record_dict[f"{cls.endpoint}.related_url"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.related_url"] = record_dict.pop(
                         "related_url"
                     )
                 if "fulltext_url" in record_dict:
-                    record_dict[f"{cls.endpoint}.fulltext_url"] = record_dict.pop(
+                    record_dict[f"{self.endpoint}.fulltext_url"] = record_dict.pop(
                         "fulltext_url"
                     )
 
                 if "uid" in record_dict:
-                    record_dict[f"{cls.endpoint}.uid"] = record_dict.pop("uid")
+                    record_dict[f"{self.endpoint}.uid"] = record_dict.pop("uid")
                 if "source" in record_dict:
                     record_dict[Fields.JOURNAL] = record_dict.pop("source")
                 if "cites" in record_dict:
-                    record_dict[f"{cls.endpoint}.cites"] = record_dict.pop("cites")
+                    record_dict[f"{self.endpoint}.cites"] = record_dict.pop("cites")
 
                 record_dict.pop("volume", None)
                 record_dict.pop("issue", None)
@@ -191,12 +190,12 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
                 record_dict[Fields.ENTRYTYPE] = ENTRYTYPES.MISC
 
             records = colrev.loader.load_utils.load(
-                filename=filename,
+                filename=self.search_source.search_results_path,
                 entrytype_setter=json_entrytype_setter,
                 field_mapper=json_field_mapper,
                 # Note: uid not always available.
                 unique_id_field="INCREMENTAL",
-                logger=logger,
+                logger=self.logger,
             )
 
             return records

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -361,10 +361,14 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".ris":
-            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_ris(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         if self.search_source.search_results_path.suffix == ".csv":
-            return self._load_csv(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_csv(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -357,15 +357,14 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".ris":
-            return cls._load_ris(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".ris":
+            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
 
-        if filename.suffix == ".csv":
-            return cls._load_csv(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".csv":
+            return self._load_csv(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -198,12 +198,11 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".ris":
-            return cls._load_ris(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".ris":
+            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -202,7 +202,9 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".ris":
-            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_ris(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -248,11 +248,10 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
         return search_source
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
                 if "link" in record_dict:
@@ -262,13 +261,13 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
                         record_dict[Fields.URL] = record_dict.pop("link")
                 for key in list(record_dict.keys()):
                     if key not in FieldSet.STANDARDIZED_FIELD_KEYS:
-                        logger.debug(f"Field {key} not in standard field set")
+                        self.logger.debug(f"Field {key} not in standard field set")
                         del record_dict[key]
 
             records = colrev.loader.load_utils.load(
-                filename=filename,
+                filename=self.search_source.search_results_path,
                 field_mapper=field_mapper,
-                logger=logger,
+                logger=self.logger,
             )
             for record_id in records:
                 record_dict = {

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -173,14 +173,13 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         raise NotImplementedError
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -217,14 +217,13 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Not implemented"""
         return record
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -287,14 +287,13 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return record
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -189,14 +189,13 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return record
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records."""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
                 unique_id_field="ID",
             )
             return records

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -572,14 +572,13 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
         return search_source
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             for record_dict in records.values():
                 record_dict.pop("bw_search_origins")

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -278,14 +278,13 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         else:
             raise NotImplementedError
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load records from the SearchSource (and convert to .bib)"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
                 unique_id_field="ID",
             )
             return records

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -187,15 +187,14 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
     # pylint: disable=unused-argument
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """
         The interface requires a load method.
         We only handle .bib files here,
         so we raise NotImplementedError for other formats.
         """
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
         raise NotImplementedError(
             "Only .bib loading is implemented for ProsperoSearchSource."
         )

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -194,7 +194,9 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         so we raise NotImplementedError for other formats.
         """
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
         raise NotImplementedError(
             "Only .bib loading is implemented for ProsperoSearchSource."
         )

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -185,7 +185,9 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".ris":
-            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_ris(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -181,12 +181,11 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".ris":
-            return cls._load_ris(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".ris":
+            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -487,7 +487,9 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".csv":
-            return self._load_csv(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_csv(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -483,17 +483,16 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".csv":
-            return cls._load_csv(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".csv":
+            return self._load_csv(filename=self.search_source.search_results_path, logger=self.logger)
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -177,7 +177,9 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -173,12 +173,11 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -389,15 +389,14 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
 
         return result
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
         # Not yet implemented
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -545,15 +545,14 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".csv":
-            return cls._load_csv(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".csv":
+            return self._load_csv(filename=self.search_source.search_results_path, logger=self.logger)
 
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -549,10 +549,14 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".csv":
-            return self._load_csv(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_csv(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -352,14 +352,13 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Not implemented"""
         return record
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             for record in records.values():
                 if "pmid" in record:

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -121,7 +121,9 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -117,12 +117,11 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -204,12 +204,11 @@ class TransportResearchInternationalDocumentation(
 
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".ris":
-            return cls._load_ris(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".ris":
+            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -208,7 +208,9 @@ class TransportResearchInternationalDocumentation(
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".ris":
-            return self._load_ris(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_ris(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -487,27 +487,26 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Ensure that the SearchSource file is append-only"""
         return filename.suffix in [".ris", ".csv", ".xlsx", ".xls", ".md"]
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if not filename.is_file():
+        if not self.search_source.search_results_path.is_file():
             return {}
 
         __load_methods = {
-            ".ris": cls._load_ris,
-            ".bib": cls._load_bib,
-            ".csv": cls._load_table,
-            ".xls": cls._load_table,
-            ".xlsx": cls._load_table,
-            ".md": cls._load_md,
-            ".enl": cls._load_enl,
+            ".ris": self._load_ris,
+            ".bib": self._load_bib,
+            ".csv": self._load_table,
+            ".xls": self._load_table,
+            ".xlsx": self._load_table,
+            ".md": self._load_md,
+            ".enl": self._load_enl,
         }
 
-        if filename.suffix not in __load_methods:
+        if self.search_source.search_results_path.suffix not in __load_methods:
             raise NotImplementedError
 
-        records = __load_methods[filename.suffix](filename=filename, logger=logger)
+        records = __load_methods[self.search_source.search_results_path.suffix](filename=self.search_source.search_results_path, logger=self.logger)
         for record_id in records:
             records[record_id] = {
                 k: v

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -506,7 +506,9 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         if self.search_source.search_results_path.suffix not in __load_methods:
             raise NotImplementedError
 
-        records = __load_methods[self.search_source.search_results_path.suffix](filename=self.search_source.search_results_path, logger=self.logger)
+        records = __load_methods[self.search_source.search_results_path.suffix](
+            filename=self.search_source.search_results_path, logger=self.logger
+        )
         for record_id in records:
             records[record_id] = {
                 k: v

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -153,14 +153,13 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         else:
             raise NotImplementedError
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
             )
             return records
 

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -162,7 +162,9 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Load the records from the SearchSource file"""
 
         if self.search_source.search_results_path.suffix == ".bib":
-            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
+            return self._load_bib(
+                filename=self.search_source.search_results_path, logger=self.logger
+            )
 
         raise NotImplementedError
 

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -158,12 +158,11 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         return records
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
-            return cls._load_bib(filename=filename, logger=logger)
+        if self.search_source.search_results_path.suffix == ".bib":
+            return self._load_bib(filename=self.search_source.search_results_path, logger=self.logger)
 
         raise NotImplementedError
 

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -98,14 +98,13 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         """Not implemented"""
         return record
 
-    @classmethod
-    def load(cls, *, filename: Path, logger: logging.Logger) -> dict:
+    def load(self) -> dict:
         """Load the records from the SearchSource file"""
 
-        if filename.suffix == ".bib":
+        if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
-                filename=filename,
-                logger=logger,
+                filename=self.search_source.search_results_path,
+                logger=self.logger,
                 unique_id_field="ID",
             )
             for record_dict in records.values():


### PR DESCRIPTION
## Summary
- refactor SearchSource load implementations to instance methods
- use self.search_source.search_results_path and self.logger in load()

## Testing
- `ruff check colrev/packages`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'search_query')*

------
https://chatgpt.com/codex/tasks/task_e_68a0dc8c2950832aad6cdad19f7f34fb