### PR TITLE
Add linter for requests imports in SearchSource packages

### DIFF
--- a/colrev/linter/colrev_search_source_requests_import.py
+++ b/colrev/linter/colrev_search_source_requests_import.py
@@ -56,7 +56,10 @@ class SearchSourceRequestsImportChecker(checkers.BaseChecker):
                 and base.attrname == "SearchSourcePackageBaseClass"
             ):
                 return True
-            if isinstance(base, nodes.Name) and base.name == "SearchSourcePackageBaseClass":
+            if (
+                isinstance(base, nodes.Name)
+                and base.name == "SearchSourcePackageBaseClass"
+            ):
                 return True
         return False
 

--- a/colrev/linter/colrev_search_source_requests_import.py
+++ b/colrev/linter/colrev_search_source_requests_import.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Linter for CoLRev - SearchSource packages importing requests.
+
+Network I/O should be extracted to a dedicated :mod:`api` module.
+"""
+from __future__ import annotations
+
+import typing
+
+from astroid import nodes
+from pylint import checkers
+from pylint.checkers.utils import only_required_for_messages
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from pylint.lint import PyLinter
+
+
+class SearchSourceRequestsImportChecker(checkers.BaseChecker):
+    """SearchSourceRequestsImportChecker"""
+
+    name = "colrev-search-source-requests-import"
+
+    msgs = {
+        "W0933": (
+            "SearchSource package imports requests. Move requests usage to a separate api.py module.",
+            "colrev-search-source-requests-import",
+            "Emitted when a module containing a SearchSourcePackageBaseClass imports requests. "
+            "Network I/O must live in <package>/api.py.",
+        ),
+    }
+
+    @only_required_for_messages("colrev-search-source-requests-import")
+    def visit_module(self, node: nodes.Module) -> None:
+        """Detect requests imports in SearchSource packages."""
+
+        if not any(
+            self._is_search_source_class(classdef)
+            for classdef in node.nodes_of_class(nodes.ClassDef)
+        ):
+            return
+
+        for imp in node.nodes_of_class(nodes.Import):
+            if any(name == "requests" for name, _ in imp.names):
+                self.add_message(self.name, node=imp)
+
+        for impfrom in node.nodes_of_class(nodes.ImportFrom):
+            if impfrom.modname == "requests":
+                self.add_message(self.name, node=impfrom)
+
+    def _is_search_source_class(self, classdef: nodes.ClassDef) -> bool:
+        """Check whether class inherits from SearchSourcePackageBaseClass."""
+
+        for base in classdef.bases:
+            if (
+                isinstance(base, nodes.Attribute)
+                and base.attrname == "SearchSourcePackageBaseClass"
+            ):
+                return True
+            if isinstance(base, nodes.Name) and base.name == "SearchSourcePackageBaseClass":
+                return True
+        return False
+
+
+def register(linter: PyLinter) -> None:  # pragma: no cover
+    """Required method to auto register this checker."""
+
+    linter.register_checker(SearchSourceRequestsImportChecker(linter))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,8 @@ extension-pkg-whitelist = "lxml.etree"
 load-plugins = [
     "colrev.linter.colrev_direct_status_assign",
     "colrev.linter.colrev_missed_constant_usage",
-    "colrev.linter.colrev_records_variable_naming_convention"
+    "colrev.linter.colrev_records_variable_naming_convention",
+    "colrev.linter.colrev_search_source_requests_import"
 ]
 
 [tool.pylint."MESSAGES CONTROL"]


### PR DESCRIPTION
## Summary
- add pylint checker to detect `requests` imports in SearchSource packages
- wire new checker into pylint configuration
- cover checker with dedicated tests
- clarify warning message to direct developers to move HTTP calls into a separate `api.py` module

## Testing
- `pre-commit run --files colrev/linter/colrev_search_source_requests_import.py pyproject.toml tests/0_core/linter_test.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pip install hatchling` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'colrev')*


------
https://chatgpt.com/codex/tasks/task_e_68c693fb6cf8832a8739556d88226d6f