### PR TITLE
refactor(scopus): move api interactions to dedicated module

### DIFF
--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -3,14 +3,9 @@
 from __future__ import annotations
 
 import logging
-import os
-import time
-import typing
-import urllib.parse
 from pathlib import Path
 from typing import Optional
 
-import requests
 from pydantic import Field
 
 import colrev.loader.bib
@@ -27,7 +22,7 @@ from colrev.constants import SearchType
 from colrev.ops.search_api_feed import create_api_source
 from colrev.ops.search_db import create_db_source
 from colrev.ops.search_db import run_db_search
-from colrev.packages.scopus.src import transformer
+from colrev.packages.scopus.src import scopus_api
 
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
@@ -44,14 +39,6 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     db_url = "https://www.scopus.com/search/form.uri?display=advanced"
 
-    # --- External API endpoints ---
-    _SCOPUS_SEARCH_URL = "https://api.elsevier.com/content/search/scopus"
-    _SCOPUS_ABSTRACT_BY_EID_URL = "https://api.elsevier.com/content/abstract/eid/"
-    _CROSSREF_WORKS_URL = "https://api.crossref.org/works/"
-
-    # Throttling to be gentle with APIs
-    _THROTTLE_S = 0.34
-
     def __init__(
         self,
         *,
@@ -62,137 +49,14 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
         self.verbose_mode = verbose_mode
-
-    # ------------------------
-    # Author-resolution helpers
-    # ------------------------
-    def _scopus_headers(self) -> dict:
-        api_key = os.getenv("SCOPUS_API_KEY")
-        headers = {"Accept": "application/json"}
-        if api_key:
-            headers["X-ELS-APIKey"] = api_key
-        return headers
-
-    def _crossref_headers(self) -> dict:
-        return {
-            "User-Agent": "colrev-scopus-author-resolution/1.0",
-            "Accept": "application/json",
-        }
-
-    def _scopus_abstract_authors_by_eid(
-        self, *, eid: str
-    ) -> list[dict[str, typing.Optional[str]]]:
-        """Return [{'name': 'Given Family', 'scopus_author_id': '...'}, ...]
-        via Abstract Retrieval."""
-        url = self._SCOPUS_ABSTRACT_BY_EID_URL + urllib.parse.quote(eid)
-        r = requests.get(
-            url,
-            headers=self._scopus_headers(),
-            timeout=30,
-            params={"field": "authors"},
-        )
-        r.raise_for_status()
-        data = r.json()
-        arr = (
-            data.get("abstracts-retrieval-response", {})
-            .get("authors", {})
-            .get("author", [])
-        )
-        if not isinstance(arr, list):
-            arr = [arr] if arr else []
-        out: list[dict[str, typing.Optional[str]]] = []
-        for a in arr:
-            if not isinstance(a, dict):
-                continue
-            auid = a.get("@auid")
-            pref = a.get("preferred-name") or {}
-            if not isinstance(pref, dict):
-                pref = {}
-            given = pref.get("ce:given-name") or a.get("ce:given-name")
-            family = pref.get("ce:surname") or a.get("ce:surname")
-            name = " ".join([p for p in [given, family] if p])
-            out.append({"name": name if name else None, "scopus_author_id": auid})
-        return out
-
-    def _crossref_authors_by_doi(
-        self, *, doi: str
-    ) -> list[dict[str, typing.Optional[str]]]:
-        """Return [{'name': 'Given Family', 'scopus_author_id': None}, ...] via Crossref."""
-        url = self._CROSSREF_WORKS_URL + urllib.parse.quote(doi)
-        r = requests.get(url, headers=self._crossref_headers(), timeout=30)
-        r.raise_for_status()
-        msg = r.json().get("message", {})
-        authors = msg.get("author", []) or []
-        out: list[dict[str, typing.Optional[str]]] = []
-        for a in authors:
-            if not isinstance(a, dict):
-                continue
-            given = a.get("given")
-            family = a.get("family")
-            name = " ".join([p for p in [given, family] if p])
-            out.append({"name": name if name else None, "scopus_author_id": None})
-        return out
-
-    def _resolve_authors(
-        self, *, eid: typing.Optional[str], doi: typing.Optional[str]
-    ) -> tuple[str, list[dict[str, typing.Optional[str]]]]:
-        """
-        Try Scopus Abstract Retrieval first (IDs + names), then Crossref (names only).
-        Returns (source, authors).
-        """
-        # 1) Scopus Abstract Retrieval
-        if eid:
-            try:
-                authors = self._scopus_abstract_authors_by_eid(eid=eid)
-                time.sleep(self._THROTTLE_S)
-                if authors:
-                    return "scopus_abstract_retrieval", authors
-            except requests.HTTPError:
-                pass
-
-        # 2) Crossref fallback (no Scopus IDs)
-        if doi:
-            authors = self._crossref_authors_by_doi(doi=doi)
-            time.sleep(self._THROTTLE_S)
-            if authors:
-                return "crossref", authors
-
-        return "none", []
-
-    @staticmethod
-    def _looks_like_single_author(author_field: str | None) -> bool:
-        """Heuristic: treat empty or single 'and'-less string as single author."""
-        if not author_field:
-            return True
-        return " and " not in author_field.strip()
-
-    @staticmethod
-    def _names_to_bibtex_and(names: list[str]) -> str:
-        """
-        Convert ['Given Family', 'Given2 Family2'] -> 'Family, Given and Family2, Given2'
-        (best-effort; falls back to provided order if splitting is unclear).
-        """
-        converted = []
-        for n in names:
-            n = (n or "").strip()
-            if not n:
-                continue
-            parts = n.split()
-            if len(parts) >= 2:
-                family = parts[-1]
-                given = " ".join(parts[:-1])
-                converted.append(f"{family}, {given}")
-            else:
-                converted.append(n)
-        return " and ".join(converted)
+        self.api = scopus_api.ScopusAPI(logger=self.logger)
 
     # ------------------------
     # API search + integration
     # ------------------------
     def _simple_api_search(self, query: str, rerun: bool) -> None:
 
-        api_key = os.getenv("SCOPUS_API_KEY")
-        if not api_key:
+        if not self.api.has_api_key():
             self.logger.info(
                 'No API key found. Set API key using: export SCOPUS_API_KEY="XXXXX"'
             )
@@ -207,62 +71,13 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         try:
-            params = {
-                "query": query,
-                "count": 10,
-                "start": 0,
-                "view": "STANDARD",  # STANDARD: only first author (with ID) in results
-            }
-
-            response = requests.get(
-                self._SCOPUS_SEARCH_URL,
-                headers=self._scopus_headers(),
-                params=params,
-                timeout=30,
-            )
-
-            if response.status_code != 200:
-                self.logger.info(f"API Error: {response.status_code} — {response.text}")
-
-            data = response.json()
-            entries = data.get("search-results", {}).get("entry", []) or []
-            self.logger.info("Found %d results via API", len(entries))
-
-            for record in self._get_records_from_api(entries):
+            for record in self.api.iter_records(query=query):
                 scopus_feed.add_update_record(retrieved_record=record)
 
-        except ValueError as e:
-            self.logger.info("API search error: %s", str(e))
+        except ValueError as exc:
+            self.logger.info("API search error: %s", str(exc))
 
         scopus_feed.save()
-
-    def _get_records_from_api(
-        self,
-        entries: list,
-    ) -> typing.Generator[colrev.record.record_prep.PrepRecord]:
-        """
-        Transform each Scopus entry to a CoLRev record and enrich with a resolved author list:
-        - colrev.scopus.author_resolution_source
-        - colrev.scopus.authors_json
-        - Update 'author' field (BibTeX) if only single/empty author present
-        """
-        for entry in entries:
-            rec = transformer.transform_record(entry)
-
-            # Grab EID / DOI directly from the search entry
-            eid = entry.get("eid") or rec.get("scopus.eid")  # transformer may set it
-            doi = entry.get("prism:doi") or rec.get("doi")
-
-            _, authors = self._resolve_authors(eid=eid, doi=doi)
-
-            # Optionally update the human-readable BibTeX 'author' if it's empty/single
-            names: list[str] = [
-                n for a in authors if isinstance((n := a.get("name")), str) and n
-            ]
-            if names and self._looks_like_single_author(rec.get(Fields.AUTHOR)):
-                rec[Fields.AUTHOR] = self._names_to_bibtex_and(names)
-
-            yield colrev.record.record_prep.PrepRecord(rec)
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:

--- a/colrev/packages/scopus/src/scopus_api.py
+++ b/colrev/packages/scopus/src/scopus_api.py
@@ -1,0 +1,200 @@
+#! /usr/bin/env python
+"""Scopus API helper module."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+import typing
+import urllib.parse
+
+import requests
+
+import colrev.record.record_prep
+from colrev.constants import Fields
+from colrev.packages.scopus.src import transformer
+
+
+class ScopusAPIError(Exception):
+    """Scopus API error."""
+
+
+class ScopusAPI:
+    """Wrapper around the Scopus and Crossref endpoints used by the package."""
+
+    _SCOPUS_SEARCH_URL = "https://api.elsevier.com/content/search/scopus"
+    _SCOPUS_ABSTRACT_BY_EID_URL = "https://api.elsevier.com/content/abstract/eid/"
+    _CROSSREF_WORKS_URL = "https://api.crossref.org/works/"
+    _THROTTLE_S = 0.34
+
+    def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+
+    @staticmethod
+    def _scopus_headers() -> dict:
+        api_key = os.getenv("SCOPUS_API_KEY")
+        headers = {"Accept": "application/json"}
+        if api_key:
+            headers["X-ELS-APIKey"] = api_key
+        return headers
+
+    @staticmethod
+    def _crossref_headers() -> dict:
+        return {
+            "User-Agent": "colrev-scopus-author-resolution/1.0",
+            "Accept": "application/json",
+        }
+
+    @staticmethod
+    def has_api_key() -> bool:
+        return bool(os.getenv("SCOPUS_API_KEY"))
+
+    def _scopus_abstract_authors_by_eid(
+        self, *, eid: str
+    ) -> list[dict[str, typing.Optional[str]]]:
+        """Retrieve authors (names + ids) from the Scopus abstract endpoint."""
+
+        url = self._SCOPUS_ABSTRACT_BY_EID_URL + urllib.parse.quote(eid)
+        response = requests.get(
+            url,
+            headers=self._scopus_headers(),
+            timeout=30,
+            params={"field": "authors"},
+        )
+        response.raise_for_status()
+        data = response.json()
+        arr = (
+            data.get("abstracts-retrieval-response", {})
+            .get("authors", {})
+            .get("author", [])
+        )
+        if not isinstance(arr, list):
+            arr = [arr] if arr else []
+        out: list[dict[str, typing.Optional[str]]] = []
+        for author in arr:
+            if not isinstance(author, dict):
+                continue
+            auid = author.get("@auid")
+            preferred = author.get("preferred-name") or {}
+            if not isinstance(preferred, dict):
+                preferred = {}
+            given = preferred.get("ce:given-name") or author.get("ce:given-name")
+            family = preferred.get("ce:surname") or author.get("ce:surname")
+            name = " ".join([part for part in [given, family] if part])
+            out.append({"name": name if name else None, "scopus_author_id": auid})
+        return out
+
+    def _crossref_authors_by_doi(
+        self, *, doi: str
+    ) -> list[dict[str, typing.Optional[str]]]:
+        """Retrieve authors (names only) from Crossref as a fallback."""
+
+        url = self._CROSSREF_WORKS_URL + urllib.parse.quote(doi)
+        response = requests.get(
+            url, headers=self._crossref_headers(), timeout=30
+        )
+        response.raise_for_status()
+        message = response.json().get("message", {})
+        authors = message.get("author", []) or []
+        out: list[dict[str, typing.Optional[str]]] = []
+        for author in authors:
+            if not isinstance(author, dict):
+                continue
+            given = author.get("given")
+            family = author.get("family")
+            name = " ".join([part for part in [given, family] if part])
+            out.append({"name": name if name else None, "scopus_author_id": None})
+        return out
+
+    def resolve_authors(
+        self, *, eid: typing.Optional[str], doi: typing.Optional[str]
+    ) -> tuple[str, list[dict[str, typing.Optional[str]]]]:
+        """Resolve authors using Scopus Abstract Retrieval first, then Crossref."""
+
+        if eid:
+            try:
+                authors = self._scopus_abstract_authors_by_eid(eid=eid)
+                time.sleep(self._THROTTLE_S)
+                if authors:
+                    return "scopus_abstract_retrieval", authors
+            except requests.HTTPError:
+                pass
+
+        if doi:
+            authors = self._crossref_authors_by_doi(doi=doi)
+            time.sleep(self._THROTTLE_S)
+            if authors:
+                return "crossref", authors
+
+        return "none", []
+
+    @staticmethod
+    def _looks_like_single_author(author_field: str | None) -> bool:
+        if not author_field:
+            return True
+        return " and " not in author_field.strip()
+
+    @staticmethod
+    def _names_to_bibtex_and(names: list[str]) -> str:
+        converted = []
+        for name in names:
+            name = (name or "").strip()
+            if not name:
+                continue
+            parts = name.split()
+            if len(parts) >= 2:
+                family = parts[-1]
+                given = " ".join(parts[:-1])
+                converted.append(f"{family}, {given}")
+            else:
+                converted.append(name)
+        return " and ".join(converted)
+
+    def _records_from_entries(
+        self, entries: list
+    ) -> typing.Iterator[colrev.record.record_prep.PrepRecord]:
+        for entry in entries:
+            record_dict = transformer.transform_record(entry)
+
+            eid = entry.get("eid") or record_dict.get("scopus.eid")
+            doi = entry.get("prism:doi") or record_dict.get("doi")
+
+            _, authors = self.resolve_authors(eid=eid, doi=doi)
+
+            names: list[str] = [
+                name
+                for author in authors
+                if isinstance((name := author.get("name")), str) and name
+            ]
+            if names and self._looks_like_single_author(record_dict.get(Fields.AUTHOR)):
+                record_dict[Fields.AUTHOR] = self._names_to_bibtex_and(names)
+
+            yield colrev.record.record_prep.PrepRecord(record_dict)
+
+    def iter_records(
+        self, *, query: str
+    ) -> typing.Iterator[colrev.record.record_prep.PrepRecord]:
+        params = {
+            "query": query,
+            "count": 10,
+            "start": 0,
+            "view": "STANDARD",
+        }
+
+        response = requests.get(
+            self._SCOPUS_SEARCH_URL,
+            headers=self._scopus_headers(),
+            params=params,
+            timeout=30,
+        )
+
+        if response.status_code != 200:
+            self.logger.info(
+                "API Error: %s — %s", response.status_code, response.text
+            )
+
+        data = response.json()
+        entries = data.get("search-results", {}).get("entry", []) or []
+        self.logger.info("Found %d results via API", len(entries))
+
+        yield from self._records_from_entries(entries)


### PR DESCRIPTION
## Summary
- add a dedicated scopus_api module that encapsulates all HTTP calls and author resolution logic
- update the Scopus search source to rely on the new API helper for fetching results

## Testing
- PYTHONPATH=. pytest tests/review_manager/3_packages_search/db_search_load_prep_test.py *(fails: importlib.metadata.PackageNotFoundError because colrev is not installed and build deps cannot be fetched without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4e07f140832a829d53019bedbf4e