### PR TITLE
Add syntax version to ExtendedSearchFile constructors

### DIFF
--- a/colrev/ops/custom_scripts/custom_search_source_script.py
+++ b/colrev/ops/custom_scripts/custom_search_source_script.py
@@ -14,6 +14,7 @@ from colrev.constants import Fields
 
 class CustomSearch(base_classes.SearchSourcePackageBaseClass):
     """Class for custom search scripts"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     source_identifier = "custom"
 

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -25,6 +25,7 @@ from colrev.writer.write_utils import write_file
 
 class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
     """ABI/INFORM (ProQuest)"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.abi_inform_proquest"
     source_identifier = "{{ID}}"

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -27,6 +27,7 @@ if typing.TYPE_CHECKING:
 
 class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     """ACM digital Library"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.acm_digital_library"
     # Note : the ID contains the doi

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -35,6 +35,7 @@ from colrev.packages.ais_library.src import aisel_api
 
 class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     """AIS electronic Library (AISeL)"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     # pylint: disable=colrev-missed-constant-usage
     source_identifier = "url"
@@ -201,6 +202,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
                     file_path_string="ais",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(
+                    version=cls.CURRENT_SYNTAX_VERSION,
                     platform=cls.endpoint,
                     search_results_path=filename,
                     search_type=SearchType.API,

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -32,6 +32,7 @@ from colrev.packages.arxiv.src import arxiv_api
 
 class ArXivSource(base_classes.SearchSourcePackageBaseClass):
     """arXiv"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.arxiv"
     source_identifier = "arxivid"
@@ -108,6 +109,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
             )
 
             search_source = colrev.search_file.ExtendedSearchFile(
+                version=cls.CURRENT_SYNTAX_VERSION,
                 platform="colrev.arxiv",
                 search_results_path=filename,
                 search_type=SearchType.API,

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -32,6 +32,7 @@ from colrev.constants import SearchType
 
 class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
     """CoLRev projects"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     source_identifier = "colrev_project_identifier"
     search_types = [SearchType.API]
@@ -86,6 +87,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
             file_path_string=params.split("/")[-1],
         )
         search_source = colrev.search_file.ExtendedSearchFile(
+            version=cls.CURRENT_SYNTAX_VERSION,
             platform=cls.endpoint,
             search_results_path=filename,
             search_type=SearchType.OTHER,

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -24,6 +24,7 @@ from colrev.ops.search_db import run_db_search
 
 class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
     """EBSCOHost"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.ebsco_host"
     # https://connect.ebsco.com/s/article/

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -29,6 +29,7 @@ from colrev.packages.eric.src import eric_api
 
 class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
     """ERIC API"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     # pylint: disable=colrev-missed-constant-usage
     source_identifier = "ID"
@@ -55,6 +56,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
             self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
+                version=self.CURRENT_SYNTAX_VERSION,
                 platform=self.endpoint,
                 search_results_path=Path("data/search/eric.bib"),
                 search_type=SearchType.OTHER,
@@ -138,6 +140,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
                 file_path_string=f"eric_{search}",
             )
             search_source = colrev.search_file.ExtendedSearchFile(
+                version=cls.CURRENT_SYNTAX_VERSION,
                 platform=cls.endpoint,
                 search_results_path=filename,
                 search_type=SearchType.API,

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -37,6 +37,7 @@ from colrev.packages.europe_pmc.src import europe_pmc_api
 
 class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Europe PMC"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     #
     source_identifier = Fields.EUROPE_PMC_ID
@@ -353,6 +354,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
                     file_path_string="europepmc",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(
+                    version=cls.CURRENT_SYNTAX_VERSION,
                     platform=cls.endpoint,
                     search_results_path=filename,
                     search_type=SearchType.API,

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -39,6 +39,7 @@ from colrev.writer.write_utils import write_file
 
 class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Files directories (PDFs based on GROBID)"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     # pylint: disable=too-many-instance-attributes
 
@@ -744,6 +745,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
         # pylint: disable=no-value-for-parameter
         search_source = colrev.search_file.ExtendedSearchFile(
+            version=cls.CURRENT_SYNTAX_VERSION,
             platform="colrev.files_dir",
             search_results_path=filename,
             search_type=SearchType.FILES,

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -38,6 +38,7 @@ def is_github_api_key(previous: dict, answer: str) -> bool:
 
 class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
     """GitHub API"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     search_types = [SearchType.API]
     endpoint = "colrev.github"
@@ -138,6 +139,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
                 file_path_string="github",
             )
             search_source = colrev.search_file.ExtendedSearchFile(
+                version=cls.CURRENT_SYNTAX_VERSION,
                 platform="colrev.github",
                 search_results_path=filename,
                 search_type=SearchType.API,

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -23,6 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
     """GoogleScholar"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.google_scholar"
     # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -32,6 +32,7 @@ from colrev.ops.search_db import run_db_search
 
 class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
     """IEEEXplore"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     flag = True
 
@@ -64,6 +65,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
             self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
+                version=self.CURRENT_SYNTAX_VERSION,
                 platform=self.endpoint,
                 search_results_path=Path("data/search/ieee.bib"),
                 search_type=SearchType.OTHER,
@@ -140,6 +142,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
                 )
 
                 search_source = colrev.search_file.ExtendedSearchFile(
+                    version=cls.CURRENT_SYNTAX_VERSION,
                     platform=cls.endpoint,
                     search_results_path=filename,
                     search_type=SearchType.API,

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -23,6 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
     """JSTOR"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.jstor"
     # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -37,6 +37,7 @@ from colrev.ops.search_api_feed import create_api_source
 
 class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
     """LocalIndex"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     # pylint: disable=too-many-instance-attributes
 
@@ -239,6 +240,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
                 ),
             )
             search_source = colrev.search_file.ExtendedSearchFile(
+                version=cls.CURRENT_SYNTAX_VERSION,
                 platform=cls.endpoint,
                 search_results_path=filename,
                 search_type=SearchType.API,

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -25,6 +25,7 @@ from colrev.packages.open_alex.src import open_alex_api
 
 class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
     """OpenAlex API"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.open_alex"
     source_identifier = "openalex_id"

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -31,6 +31,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Forward search based on OpenCitations
     Scope: all included papers with colrev_status in (rev_included, rev_synthesized)
     """
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.open_citations_forward_search"
     source_identifier = "fwsearch_ref"
@@ -61,6 +62,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
     def get_default_source(cls) -> colrev.search_file.ExtendedSearchFile:
         """Get the default SearchSource settings"""
         return colrev.search_file.ExtendedSearchFile(
+            version=cls.CURRENT_SYNTAX_VERSION,
             platform="colrev.open_citations_forward_search",
             search_results_path=Path("data/search/forward_search.bib"),
             search_type=SearchType.FORWARD_SEARCH,

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -32,6 +32,7 @@ from colrev.packages.open_library.src import open_library_api
 
 class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     """OpenLibrary API"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.open_library"
     # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -31,6 +31,7 @@ from colrev.packages.osf.src.osf_api import OSFApiQuery
 
 class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
     """OSF"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     source_identifier = Fields.ID
     search_types = [SearchType.API]
@@ -58,6 +59,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
             self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
+                version=self.CURRENT_SYNTAX_VERSION,
                 platform=self.endpoint,
                 search_results_path=Path("data/search/osf.bib"),
                 search_type=SearchType.API,
@@ -118,6 +120,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
                     file_path_string=f"osf_{last_value}",
                 )
                 search_source = colrev.search_file.ExtendedSearchFile(
+                    version=cls.CURRENT_SYNTAX_VERSION,
                     platform=cls.endpoint,
                     search_results_path=filename,
                     search_type=SearchType.API,

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -43,6 +43,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Backward search extracting references from PDFs using GROBID
     Scope: all included papers with colrev_status in (rev_included, rev_synthesized)
     """
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     _api_url = "https://opencitations.net/index/coci/api/v1/references/"
 
@@ -81,6 +82,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         """Get the default SearchSource settings"""
 
         return colrev.search_file.ExtendedSearchFile(
+            version=cls.CURRENT_SYNTAX_VERSION,
             platform="colrev.pdf_backward_search",
             search_results_path=Path("data/search/pdf_backward_search.bib"),
             search_type=SearchType.BACKWARD_SEARCH,

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -30,6 +30,7 @@ from colrev.packages.plos.src import plos_api
 # pylint: disable=unused-argument
 class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
     """PLOS API"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.plos"
     source_identifier = Fields.DOI
@@ -100,7 +101,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
                     + "journal,publication_date,volume,issue"
                 )
 
-                search_source.search_parameters = {"version": "0.1.0"}
+                search_source.version = cls.CURRENT_SYNTAX_VERSION
 
                 return search_source
 
@@ -115,6 +116,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
             search_source = colrev.search_file.ExtendedSearchFile(
+                version=cls.CURRENT_SYNTAX_VERSION,
                 platform="colrev.plos",
                 search_results_path=filename,
                 search_type=SearchType.API,

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -29,6 +29,7 @@ from colrev.ops.search_api_feed import create_api_source
 
 class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Prospero Search Source for retrieving protocol data"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.prospero"
     source_identifier = Fields.PROSPERO_ID
@@ -65,7 +66,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
             search_source.search_string[Fields.URL] = (
                 cls.db_url + "search?" + search_source.search_string + "#searchadvanced"
             )
-            search_source.version = "0.1.0"
+            search_source.version = cls.CURRENT_SYNTAX_VERSION
             return search_source
 
         filename = colrev.utils.get_unique_filename(
@@ -74,6 +75,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         new_search_source = colrev.search_file.ExtendedSearchFile(
+            version=cls.CURRENT_SYNTAX_VERSION,
             platform=cls.endpoint,
             search_results_path=filename,
             search_type=SearchType.API,

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -24,6 +24,7 @@ from colrev.ops.search_db import run_db_search
 
 class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
     """PsycINFO"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.psycinfo"
     # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -29,6 +29,7 @@ from colrev.packages.scopus.src import scopus_api
 
 class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Scopus"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.scopus"
     source_identifier = "scopus.eid"

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -37,6 +37,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Semantic Scholar API Search Source"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     # Provide objects with classes
     _search_return: PaginatedResults
@@ -78,6 +79,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
+                version=self.CURRENT_SYNTAX_VERSION,
                 platform="colrev.semanticscholar",
                 search_results_path=self._s2_filename,
                 search_type=SearchType.API,
@@ -380,6 +382,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
         search_source = colrev.search_file.ExtendedSearchFile(
+            version=cls.CURRENT_SYNTAX_VERSION,
             platform="colrev.semanticscholar",
             search_results_path=filename,
             search_type=SearchType.API,

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -39,6 +39,7 @@ from colrev.packages.springer_link.src import springer_link_api
 
 class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Springer Link"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.springer_link"
     # pylint: disable=colrev-missed-constant-usage

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -42,6 +42,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
     metadata is added based on dois and pubmedid (openalex is not yet supported)
 
     """
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.synergy_datasets"
     # pylint: disable=colrev-missed-constant-usage
@@ -142,6 +143,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
             file_path_string=f"SYNERGY_{dataset.replace('/', '_').replace('_ids.csv', '')}",
         )
         search_source = colrev.search_file.ExtendedSearchFile(
+            version=cls.CURRENT_SYNTAX_VERSION,
             platform="colrev.synergy_datasets",
             search_results_path=filename,
             search_type=SearchType.API,

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -24,6 +24,7 @@ from colrev.ops.search_db import run_db_search
 
 class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Taylor and Francis"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     db_url = "https://www.tandfonline.com/"
     endpoint = "colrev.taylor_and_francis"

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -28,6 +28,7 @@ class TransportResearchInternationalDocumentation(
     base_classes.SearchSourcePackageBaseClass
 ):
     """Transport Research International Documentation"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.trid"
     source_identifier = "biburl"

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -33,6 +33,7 @@ from colrev.ops.search_db import run_db_search
 
 class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Unknown SearchSource"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.unknown_source"
 

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -26,6 +26,7 @@ from colrev.packages.unpaywall.src.api import UnpaywallAPI
 
 class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Unpaywall Search Source"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     source_identifier = "doi"
     search_types = [SearchType.API]
@@ -53,6 +54,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
             self.search_source = search_file
         else:
             self.search_source = colrev.search_file.ExtendedSearchFile(
+                version=self.CURRENT_SYNTAX_VERSION,
                 platform=self.endpoint,
                 search_results_path=Path("data/search/unpaywall.bib"),
                 search_type=SearchType.API,
@@ -114,6 +116,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
             search_source = colrev.search_file.ExtendedSearchFile(
+                version=cls.CURRENT_SYNTAX_VERSION,
                 platform=cls.endpoint,
                 search_results_path=filename,
                 search_type=SearchType.API,

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -23,6 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Web of Science"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.web_of_science"
     source_identifier = (

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -23,6 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     """Wiley"""
+    CURRENT_SYNTAX_VERSION = "0.1.0"
 
     endpoint = "colrev.wiley"
     source_identifier = "url"


### PR DESCRIPTION
## Summary
- pass CURRENT_SYNTAX_VERSION to ExtendedSearchFile constructors across search source packages
- remove legacy search parameter version usage in PLOS and Prospero setups

## Testing
- `pytest tests/3_packages_search/pubmed_test.py` *(fails: ModuleNotFoundError: No module named 'colrev')*

------
https://chatgpt.com/codex/tasks/task_e_68d403f49030832ab26c3ef1a82f59c8