### PR TITLE
docs: document search file formats for additional sources

### DIFF
--- a/colrev/packages/ais_library/README.md
+++ b/colrev/packages/ais_library/README.md
@@ -28,6 +28,40 @@ Note: Complex queries can be entered in the basic search field. Example:
 title:microsourcing AND ( digital OR online)
 ```
 
+Format of the search-history file (DB search):
+
+```json
+{
+    "search_string": "title:microsourcing",
+    "platform": "colrev.ais_library",
+    "search_results_path": "data/search/ais_library.bib",
+    "search_type": "DB",
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.ais_library",
+    "search_results_path": "data/search/ais_library_api.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": [
+            {"operator": "", "term": "microsourcing", "field": "All fields"},
+            {"operator": "AND", "term": "outsourcing", "field": "title"}
+        ],
+        "scope": {
+            "peer_reviewed": true
+        }
+    },
+    "version": "0.1.0"
+}
+```
+
+
 ## Links
 
 [AIS eLibrary](https://aisel.aisnet.org/)

--- a/colrev/packages/arxiv/README.md
+++ b/colrev/packages/arxiv/README.md
@@ -10,6 +10,21 @@
 colrev search --add colrev.arxiv -p "https://arxiv.org/search/?query=fitbit&searchtype=all&abstracts=show&order=-announced_date_first&size=50"
 ```
 
+Format of the search-history file:
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.arxiv",
+    "search_results_path": "data/search/arxiv.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": "microsourcing"
+    },
+    "version": "0.1.0"
+}
+```
+
 ## Links
 
 - [arXiv](https://arxiv.org/)

--- a/colrev/packages/colrev_project/README.md
+++ b/colrev/packages/colrev_project/README.md
@@ -10,4 +10,21 @@
 colrev search --add colrev.colrev_project -p "https://github.com/CoLRev-Environment/example"
 ```
 
+Format of the search-history file:
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.colrev_project",
+    "search_results_path": "data/search/colrev_project.bib",
+    "search_type": "OTHER",
+    "search_parameters": {
+        "scope": {
+            "url": "https://github.com/CoLRev-Environment/example.git"
+        }
+    },
+    "version": "0.1.0"
+}
+```
+
 ## Links

--- a/colrev/packages/eric/README.md
+++ b/colrev/packages/eric/README.md
@@ -40,6 +40,35 @@ colrev search --add colrev.eric -p "https://api.ies.ed.gov/eric/?search=blockcha
 
 This command returns 5 records with starting record number 0.
 
+Format of the search-history file (DB search):
+
+```json
+{
+    "search_string": "descriptor:distance education",
+    "platform": "colrev.eric",
+    "search_results_path": "data/search/eric.bib",
+    "search_type": "DB",
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.eric",
+    "search_results_path": "data/search/eric_api.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": "author%3A%22Creamer%2C%20Don%22",
+        "start": "0",
+        "rows": "2000"
+    },
+    "version": "0.1.0"
+}
+```
+
 ## Links
 
 - [ERIC](https://eric.ed.gov/)

--- a/colrev/packages/europe_pmc/README.md
+++ b/colrev/packages/europe_pmc/README.md
@@ -9,6 +9,45 @@ Europe PMC is a comprehensive database that includes metadata from PubMed Centra
 ```
 colrev search --add colrev.europe_pmc -p "https://europepmc.org/search?query=fitbit%20AND%20gamification%20AND%20RCT%20AND%20diabetes%20mellitus"
 ```
+Format of the search-history file (DB search):
+
+```json
+{
+    "search_string": "TITLE:\"microsourcing\"",
+    "platform": "colrev.europe_pmc",
+    "search_results_path": "data/search/europe_pmc.bib",
+    "search_type": "DB",
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.europe_pmc",
+    "search_results_path": "data/search/europe_pmc_api.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": "TITLE:%22microsourcing%22"
+    },
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (metadata search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.europe_pmc",
+    "search_results_path": "data/search/md_europe_pmc.bib",
+    "search_type": "MD",
+    "version": "0.1.0"
+}
+```
+
 ## prep
 
 EuropePMC linking

--- a/colrev/packages/github/README.md
+++ b/colrev/packages/github/README.md
@@ -16,6 +16,36 @@ Keywords are entered after the search command is executed. The user can chose to
 colrev search --add colrev.github
 ```
 
+Format of the search-history file (interactive API search):
+
+```json
+{
+    "search_string": {
+        "query": "microsourcing",
+        "scope": "title,readme"
+    },
+    "platform": "colrev.github",
+    "search_results_path": "data/search/github.bib",
+    "search_type": "API",
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (URL-based API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.github",
+    "search_results_path": "data/search/github_search.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": "topic:microsourcing"
+    },
+    "version": "0.1.0"
+}
+```
+
 ## prep
 
 GitHub can be used to provide meta data for linking and updating existing records.

--- a/colrev/packages/ieee/README.md
+++ b/colrev/packages/ieee/README.md
@@ -40,6 +40,35 @@ If your search query includes Boolean operators, add "queryText=query" to the UR
 colrev search --add colrev.ieee -p "https://ieeexploreapi.ieee.org/api/v1/search/articles?booleanText=(rfid%20AND%20%22internet%20of%20things%22)"
 ```
 
+Format of the search-history file (DB search):
+
+```json
+{
+    "search_string": "microsourcing",
+    "platform": "colrev.ieee",
+    "search_results_path": "data/search/ieee.bib",
+    "search_type": "DB",
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.ieee",
+    "search_results_path": "data/search/ieee_api.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "querytext": "microsourcing",
+        "max_records": "200",
+        "start_record": "1"
+    },
+    "version": "0.1.0"
+}
+```
+
 ## Links
 
 - [IEEEXplore](https://ieeexplore.ieee.org/)

--- a/colrev/packages/local_index/README.md
+++ b/colrev/packages/local_index/README.md
@@ -16,6 +16,22 @@ colrev env -i
 colrev search --add colrev.local_index -p "title LIKE '%dark side%'"
 ```
 
+
+Format of the search-history file:
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.local_index",
+    "search_results_path": "data/search/local_index_dark_side.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": "title LIKE '%dark side%'"
+    },
+    "version": "0.1.0"
+}
+```
+
 ## pdf-get
 
 Retrieves PDF documents from other local CoLRev repositories, given that they are registered, and that the index is updated.

--- a/colrev/packages/open_alex/README.md
+++ b/colrev/packages/open_alex/README.md
@@ -10,6 +10,18 @@
 colrev search --add colrev.open_alex -p "..."
 ```
 
+Format of the search-history file (metadata search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.open_alex",
+    "search_results_path": "data/search/md_open_alex.bib",
+    "search_type": "MD",
+    "version": "0.1.0"
+}
+```
+
 ## prep
 
 Links meta data from OpenAlex to existing records.

--- a/colrev/packages/osf/README.md
+++ b/colrev/packages/osf/README.md
@@ -24,6 +24,39 @@ The search can be filtered by changing the filter parameter to one of the follow
 colrev search --add colrev.osf -p "https://api.osf.io/v2/nodes/?filter[description]=machine%20learning"
 ```
 
+Format of the search-history file (interactive API search):
+
+```json
+{
+    "search_string": {
+        "query": {
+            "title": "reproducibility"
+        }
+    },
+    "platform": "colrev.osf",
+    "search_results_path": "data/search/osf.bib",
+    "search_type": "API",
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (URL-based API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.osf",
+    "search_results_path": "data/search/osf_description.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": {
+            "description": "machine learning"
+        }
+    },
+    "version": "0.1.0"
+}
+```
+
 ## Links
 
 - [OSF](https://osf.io/)

--- a/colrev/packages/plos/README.md
+++ b/colrev/packages/plos/README.md
@@ -35,6 +35,18 @@ Enter the keywords:
 ```
 
 
+Format of the search-history file:
+
+```json
+{
+    "search_string": "http://api.plos.org/search?q=microsourcing&fl=id,abstract,author_display,title_display,journal,publication_date,volume,issue",
+    "platform": "colrev.plos",
+    "search_results_path": "data/search/plos.bib",
+    "search_type": "API",
+    "version": "0.1.0"
+}
+```
+
 ### Load
 
 ```

--- a/colrev/packages/prospero/README.md
+++ b/colrev/packages/prospero/README.md
@@ -16,6 +16,21 @@ colrev search --add colrev.prospero
 ```
 The search is done using keywords that can be entered into the console.
 
+Format of the search-history file:
+
+```json
+{
+    "search_string": {
+        "query": "microsourcing",
+        "url": "https://www.crd.york.ac.uk/prospero/search?microsourcing#searchadvanced"
+    },
+    "platform": "colrev.prospero",
+    "search_results_path": "data/search/prospero_results.bib",
+    "search_type": "API",
+    "version": "0.1.0"
+}
+```
+
 ### load
 It is possible to save the records after search. All records that were found during the search will be saved to a data/records.bib file. Load function will add the records to the file or update existing one.
 

--- a/colrev/packages/semanticscholar/README.md
+++ b/colrev/packages/semanticscholar/README.md
@@ -19,6 +19,25 @@ The API search is launched with the following command:
 colrev search --add colrev.semanticscholar
 ```
 
+Format of the search-history file:
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.semanticscholar",
+    "search_results_path": "data/search/semanticscholar_keyword.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "search_subject": "keyword",
+        "query": "microsourcing",
+        "year": "2020-2023",
+        "fields_of_study": "Computer Science,Medicine"
+    },
+    "version": "0.1.0"
+}
+```
+
+
 Upon entering the command above with no additional parameters, a console interface opens up, in which the user is asked to enter the parameters and query for their search.
 
 #### API search: The user interface

--- a/colrev/packages/springer_link/README.md
+++ b/colrev/packages/springer_link/README.md
@@ -18,7 +18,39 @@ The user can select the search type by navigating through the list with `uparrow
 
 ### DB search
 
+Format of the search-history file (DB search):
+
+```json
+{
+    "search_string": "keyword:\"microsourcing\"",
+    "platform": "colrev.springer_link",
+    "search_results_path": "data/search/springer_link.bib",
+    "search_type": "DB",
+    "version": "0.1.0"
+}
+```
+
 ### API search
+
+Format of the search-history file (API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.springer_link",
+    "search_results_path": "data/search/springer_link_api.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": "keyword:microsourcing",
+        "subject": "Business and Management",
+        "language": "en",
+        "year": "2020",
+        "type": "Journal",
+        "page_size": "50"
+    },
+    "version": "0.1.0"
+}
+```
 
 ℹ️ Restriction: Springer Link only allows a daily quota of 500 requests. This might lead to the site being unavailable with a response code of 403.
 

--- a/colrev/packages/synergy_datasets/README.md
+++ b/colrev/packages/synergy_datasets/README.md
@@ -17,6 +17,18 @@ Note: some datasets are "broken". For example, the [Nagtegaal_2019](https://gith
 
 The percentage of records with missing meatadata (no ids) is shown upon `colrev search`.
 
+Format of the search-history file:
+
+```json
+{
+    "search_string": "dataset=Howard_2016/Wassenaar_2017_ids.csv",
+    "platform": "colrev.synergy_datasets",
+    "search_results_path": "data/search/SYNERGY_Howard_2016_Wassenaar_2017.bib",
+    "search_type": "API",
+    "version": "0.1.0"
+}
+```
+
 ## Links
 
 - [SYNERGY Datasets](https://github.com/asreview/synergy-dataset)

--- a/colrev/packages/unpaywall/README.md
+++ b/colrev/packages/unpaywall/README.md
@@ -70,6 +70,35 @@ The user can enter a single term or use the Boolean `AND`, `OR`, `NOT` for a spe
 - `email:` Your email address to access the API. If the email address is manually specified in the URL, this email will be saved and used for later requests.
 
 
+Format of the search-history file (interactive API search):
+
+```json
+{
+    "search_string": "thermometry",
+    "platform": "colrev.unpaywall",
+    "search_results_path": "data/search/unpaywall_keywords.bib",
+    "search_type": "API",
+    "version": "0.1.0"
+}
+```
+
+Format of the search-history file (URL-based API search):
+
+```json
+{
+    "search_string": "",
+    "platform": "colrev.unpaywall",
+    "search_results_path": "data/search/unpaywall_api.bib",
+    "search_type": "API",
+    "search_parameters": {
+        "query": "thermometry",
+        "is_oa": "true",
+        "email": "unpaywall_01@example.com"
+    },
+    "version": "0.1.0"
+}
+```
+
 ## pdf-get
 
 <!--


### PR DESCRIPTION
## Summary
- Documented the expected JSON structure of search-history files for multiple search-source packages, covering DB/API/metadata variants where available.

## Testing
- Not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d4e59f9aec832a9ef16d623735ce6d