### PR TITLE
test(pubmed): verify API search persists results

### DIFF
--- a/tests/3_packages_search/pubmed_test.py
+++ b/tests/3_packages_search/pubmed_test.py
@@ -4,8 +4,11 @@ from pathlib import Path
 
 import pytest
 
+import colrev.env.environment_manager
 import colrev.exceptions as colrev_exceptions
+import colrev.loader.load_utils
 import colrev.search_file
+from colrev.constants import Fields
 from colrev.constants import SearchType
 from colrev.packages.pubmed.src.pubmed import PubMedSearchSource
 
@@ -21,12 +24,14 @@ def pubmed_search_file_factory() -> typing.Callable:
             platform="colrev.pubmed",
             search_results_path=Path("data/search/test_pubmed.bib"),
             search_type=SearchType.API,
-            search_string="https://pubmed.ncbi.nlm.nih.gov/?term=validation",
+            search_string="",
             comment="",
             version="0.1.0",
         )
 
-        search_parameters = {"url": search_file.search_string}
+        search_parameters = {
+            "url": "https://pubmed.ncbi.nlm.nih.gov/?term=validation",
+        }
         if include_version_param and version_marker is not None:
             search_parameters["version"] = version_marker
         search_file.search_parameters = search_parameters
@@ -72,3 +77,148 @@ def test_pubmed_validate_rejects_mismatched_version(
         PubMedSearchSource(search_file=search_file)
 
     assert str(exc_info.value) == "PubMed version should be 0.1.0, found 9.9.9"
+
+
+def test_pubmed_search_persists_api_results(
+    tmp_path: Path,
+    mocker: pytest.MockFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run a full PubMed API search and persist the retrieved records."""
+
+    monkeypatch.chdir(tmp_path)
+    Path("data/search").mkdir(parents=True)
+
+    search_file = colrev.search_file.ExtendedSearchFile(
+        platform="colrev.pubmed",
+        search_results_path=Path("data/search/pubmed.bib"),
+        search_type=SearchType.API,
+        search_string="",
+        comment="",
+        version="0.1.0",
+    )
+    search_file.search_parameters = {
+        "url": "https://pubmed.ncbi.nlm.nih.gov/?term=fitbit",
+    }
+
+    mocker.patch.object(
+        colrev.env.environment_manager.EnvironmentManager,
+        "get_name_mail_from_git",
+        return_value=("Test User", "test@example.com"),
+    )
+
+    fake_esearch_response = {
+        "esearchresult": {
+            "count": "1",
+            "idlist": ["37000000"],
+        }
+    }
+    fake_esearch_empty_response = {
+        "esearchresult": {
+            "count": "1",
+            "idlist": [],
+        }
+    }
+    fake_efetch_xml = """
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <Article>
+        <ArticleTitle>Tracking Fitbit usage for longitudinal studies</ArticleTitle>
+        <Journal>
+          <JournalIssue>
+            <Volume>42</Volume>
+            <Issue>7</Issue>
+            <PubDate>
+              <Year>2023</Year>
+            </PubDate>
+          </JournalIssue>
+          <ISOAbbreviation>J Fitbit Res</ISOAbbreviation>
+        </Journal>
+        <AuthorList>
+          <Author>
+            <LastName>Doe</LastName>
+            <ForeName>Alex</ForeName>
+          </Author>
+          <Author>
+            <LastName>Roe</LastName>
+            <ForeName>Sam</ForeName>
+          </Author>
+        </AuthorList>
+        <Abstract>
+          <AbstractText>Example abstract content for Fitbit trials.</AbstractText>
+        </Abstract>
+      </Article>
+    </MedlineCitation>
+    <PubmedData>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">37000000</ArticleId>
+        <ArticleId IdType="doi">10.1000/FITBIT-TRIALS</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>
+""".strip()
+
+    class FakeResponse:
+        def __init__(self, *, status_code: int, json_data=None, text: str = "") -> None:
+            self.status_code = status_code
+            self._json_data = json_data
+            self.text = text
+
+        def json(self):
+            if self._json_data is None:
+                raise ValueError("JSON data was not provided for this response")
+            return self._json_data
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP status {self.status_code}")
+
+    esearch_url = "https://pubmed.ncbi.nlm.nih.gov/?term=fitbit"
+
+    def fake_request(self, method, url, params=None, headers=None, timeout=None):
+        del self  # unused
+        if url == esearch_url:
+            retstart = int((params or {}).get("retstart", 0))
+            if retstart == 0:
+                return FakeResponse(status_code=200, json_data=fake_esearch_response)
+            return FakeResponse(status_code=200, json_data=fake_esearch_empty_response)
+
+        if url.startswith("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"):
+            return FakeResponse(status_code=200, text=fake_efetch_xml)
+
+        raise AssertionError(f"Unexpected URL called: {url}")
+
+    mocker.patch(
+        "requests.sessions.Session.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+    mocker.patch(
+        "requests_cache.session.CachedSession.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+
+    pubmed_source = PubMedSearchSource(search_file=search_file)
+    pubmed_source.search(rerun=True)
+
+    search_results_path = Path(search_file.search_results_path)
+    assert search_results_path.is_file()
+
+    saved_records = colrev.loader.load_utils.load(
+        filename=search_results_path,
+        unique_id_field=Fields.ID,
+    )
+
+    assert len(saved_records) == 1
+    saved_record = next(iter(saved_records.values()))
+    assert saved_record[Fields.ID] == "000001"
+    assert (
+        saved_record[Fields.TITLE]
+        == "Tracking Fitbit usage for longitudinal studies"
+    )
+    assert saved_record[Fields.AUTHOR] == "Doe, Alex and Roe, Sam"
+    assert saved_record["pubmedid"] == "37000000"
+    assert saved_record[Fields.DOI] == "10.1000/FITBIT-TRIALS"


### PR DESCRIPTION
## Summary
- add an end-to-end PubMed search test using an ExtendedSearchFile with a blank search string and URL-based search parameters
- mock the PubMed eSearch and eFetch API responses by patching the requests session to provide deterministic record data
- assert that the search operation writes the mocked record (including its DOI) to the expected feed file

## Testing
- `PYTHONPATH=. pytest tests/3_packages_search/pubmed_test.py` *(fails: missing installed package metadata for `colrev` in the offline test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d514605000832a8d9fd856a35087c9