### PR TITLE
Add packaged search tests for AIS Library, arXiv, and DBLP

### DIFF
--- a/tests/packaged_search/test_ais_library.py
+++ b/tests/packaged_search/test_ais_library.py
@@ -1,0 +1,187 @@
+#! /usr/bin/env python
+import typing
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+import colrev.env.environment_manager
+import colrev.exceptions as colrev_exceptions
+import colrev.loader.load_utils
+import colrev.search_file
+from colrev.constants import Fields, SearchType
+
+try:  # pragma: no cover - compatibility with previous module names
+    from colrev.packages.ais_library.src.ais_library import AISLibrarySearchSource
+except ImportError:  # pragma: no cover - fallback for legacy structure
+    from colrev.packages.ais_library.src.aisel import (
+        AISeLibrarySearchSource as AISLibrarySearchSource,
+    )
+
+
+@pytest.fixture()
+def ais_library_search_file_factory() -> typing.Callable:
+    """Return a factory to build AIS Library search files for validation tests."""
+
+    def _build(
+        version_marker: typing.Optional[str], include_version_param: bool = True
+    ) -> colrev.search_file.ExtendedSearchFile:
+        search_file = colrev.search_file.ExtendedSearchFile(
+            platform="colrev.ais_library",
+            search_results_path=Path("data/search/ais_library.bib"),
+            search_type=SearchType.API,
+            search_string="",
+            comment="",
+            version="0.1.0",
+        )
+
+        search_parameters: dict[str, typing.Any] = {
+            "url": "https://aisel.aisnet.org/do/search/?q=validation",
+            "query": [
+                {"operator": "", "term": "validation", "field": "All fields"},
+            ],
+        }
+        if include_version_param and version_marker is not None:
+            search_parameters["version"] = version_marker
+        search_file.search_parameters = search_parameters
+
+        if version_marker is not None:
+            search_file.version = version_marker
+        else:
+            search_file.version = None
+
+        return search_file
+
+    return _build
+
+
+def test_ais_library_validate_accepts_current_version(
+    ais_library_search_file_factory: typing.Callable,
+) -> None:
+    search_file = ais_library_search_file_factory("0.1.0")
+
+    AISLibrarySearchSource(search_file=search_file)
+
+
+def test_ais_library_validate_rejects_missing_version(
+    ais_library_search_file_factory: typing.Callable,
+) -> None:
+    search_file = ais_library_search_file_factory(
+        version_marker=None, include_version_param=False
+    )
+
+    with pytest.raises(colrev_exceptions.InvalidQueryException) as exc_info:
+        AISLibrarySearchSource(search_file=search_file)
+
+    assert str(exc_info.value) == "AISLibrary version should be 0.1.0, found None"
+
+
+def test_ais_library_validate_rejects_mismatched_version(
+    ais_library_search_file_factory: typing.Callable,
+) -> None:
+    search_file = ais_library_search_file_factory("9.9.9")
+
+    with pytest.raises(colrev_exceptions.InvalidQueryException) as exc_info:
+        AISLibrarySearchSource(search_file=search_file)
+
+    assert str(exc_info.value) == "AISLibrary version should be 0.1.0, found 9.9.9"
+
+
+def test_ais_library_search_persists_api_results(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run a full AIS Library API search and persist the retrieved records."""
+
+    monkeypatch.chdir(tmp_path)
+    Path("data/search").mkdir(parents=True)
+
+    search_file = colrev.search_file.ExtendedSearchFile(
+        platform="colrev.ais_library",
+        search_results_path=Path("data/search/ais_library.bib"),
+        search_type=SearchType.API,
+        search_string="",
+        comment="",
+        version="0.1.0",
+    )
+    search_file.search_parameters = {
+        "url": "https://aisel.aisnet.org/do/search/?q=validation",
+        "query": [
+            {"operator": "", "term": "validation", "field": "All fields"},
+        ],
+        "version": "0.1.0",
+    }
+
+    mocker.patch.object(
+        colrev.env.environment_manager.EnvironmentManager,
+        "get_name_mail_from_git",
+        return_value=("Test User", "test@example.com"),
+    )
+
+    fake_enl = """
+%T Validating Digital Platforms in IS Research
+%0 Journal Article
+%A Doe, Alex
+%A Roe, Sam
+%D 2022
+%U https://aisel.aisnet.org/validating_digital_platforms
+%R 10.5555/AIS-VALIDATE-2022
+""".strip()
+
+    class FakeResponse:
+        def __init__(self, *, status_code: int, text: str = "") -> None:
+            self.status_code = status_code
+            self.text = text
+
+        def json(self) -> typing.Any:
+            raise ValueError("JSON data was not provided for this response")
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP status {self.status_code}")
+
+    ais_results_prefix = "https://aisel.aisnet.org/do/search/results/refer?"
+
+    def fake_request(
+        self,
+        method: str,
+        url: str,
+        params: typing.Optional[dict] = None,
+        headers: typing.Optional[dict] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> FakeResponse:
+        del self, method, params, headers, timeout
+        if url.startswith(ais_results_prefix):
+            return FakeResponse(status_code=200, text=fake_enl)
+        raise AssertionError(f"Unexpected URL called: {url}")
+
+    mocker.patch(
+        "requests.sessions.Session.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+    mocker.patch(
+        "requests_cache.session.CachedSession.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+
+    ais_source = AISLibrarySearchSource(search_file=search_file)
+    ais_source.search(rerun=True)
+
+    search_results_path = Path(search_file.search_results_path)
+    assert search_results_path.is_file()
+
+    saved_records = colrev.loader.load_utils.load(
+        filename=search_results_path,
+        unique_id_field=Fields.ID,
+    )
+
+    assert len(saved_records) == 1
+    saved_record = next(iter(saved_records.values()))
+    assert saved_record[Fields.ID] == "000001"
+    assert saved_record[Fields.TITLE] == "Validating Digital Platforms in IS Research"
+    assert saved_record[Fields.AUTHOR] == "Doe, Alex and Roe, Sam"
+    assert saved_record[Fields.YEAR] == "2022"
+    assert saved_record[Fields.DOI] == "10.5555/AIS-VALIDATE-2022"

--- a/tests/packaged_search/test_arxiv.py
+++ b/tests/packaged_search/test_arxiv.py
@@ -1,0 +1,192 @@
+#! /usr/bin/env python
+import typing
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+import colrev.env.environment_manager
+import colrev.exceptions as colrev_exceptions
+import colrev.loader.load_utils
+import colrev.search_file
+from colrev.constants import Fields, SearchType
+
+try:  # pragma: no cover - compatibility with updated interfaces
+    from colrev.packages.arxiv.src.arxiv import ArXivSearchSource
+except ImportError:  # pragma: no cover - fallback for legacy class name
+    from colrev.packages.arxiv.src.arxiv import ArXivSource as ArXivSearchSource
+
+
+@pytest.fixture()
+def arxiv_search_file_factory() -> typing.Callable:
+    """Return a factory to build arXiv search files for validation tests."""
+
+    def _build(
+        version_marker: typing.Optional[str], include_version_param: bool = True
+    ) -> colrev.search_file.ExtendedSearchFile:
+        search_file = colrev.search_file.ExtendedSearchFile(
+            platform="colrev.arxiv",
+            search_results_path=Path("data/search/arxiv.bib"),
+            search_type=SearchType.API,
+            search_string="",
+            comment="",
+            version="0.1.0",
+        )
+
+        search_parameters: dict[str, typing.Any] = {
+            "url": "https://arxiv.org/search/?query=fitbit&searchtype=all",
+            "query": "fitbit",
+        }
+        if include_version_param and version_marker is not None:
+            search_parameters["version"] = version_marker
+        search_file.search_parameters = search_parameters
+
+        if version_marker is not None:
+            search_file.version = version_marker
+        else:
+            search_file.version = None
+
+        return search_file
+
+    return _build
+
+
+def test_arxiv_validate_accepts_current_version(
+    arxiv_search_file_factory: typing.Callable,
+) -> None:
+    search_file = arxiv_search_file_factory("0.1.0")
+
+    ArXivSearchSource(search_file=search_file)
+
+
+def test_arxiv_validate_rejects_missing_version(
+    arxiv_search_file_factory: typing.Callable,
+) -> None:
+    search_file = arxiv_search_file_factory(
+        version_marker=None, include_version_param=False
+    )
+
+    with pytest.raises(colrev_exceptions.InvalidQueryException) as exc_info:
+        ArXivSearchSource(search_file=search_file)
+
+    assert str(exc_info.value) == "arXiv version should be 0.1.0, found None"
+
+
+def test_arxiv_validate_rejects_mismatched_version(
+    arxiv_search_file_factory: typing.Callable,
+) -> None:
+    search_file = arxiv_search_file_factory("9.9.9")
+
+    with pytest.raises(colrev_exceptions.InvalidQueryException) as exc_info:
+        ArXivSearchSource(search_file=search_file)
+
+    assert str(exc_info.value) == "arXiv version should be 0.1.0, found 9.9.9"
+
+
+def test_arxiv_search_persists_api_results(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run a full arXiv API search and persist the retrieved records."""
+
+    monkeypatch.chdir(tmp_path)
+    Path("data/search").mkdir(parents=True)
+
+    search_file = colrev.search_file.ExtendedSearchFile(
+        platform="colrev.arxiv",
+        search_results_path=Path("data/search/arxiv.bib"),
+        search_type=SearchType.API,
+        search_string="",
+        comment="",
+        version="0.1.0",
+    )
+    search_file.search_parameters = {
+        "url": "https://arxiv.org/search/?query=fitbit&searchtype=all",
+        "query": "fitbit",
+        "version": "0.1.0",
+    }
+
+    mocker.patch.object(
+        colrev.env.environment_manager.EnvironmentManager,
+        "get_name_mail_from_git",
+        return_value=("Test User", "test@example.com"),
+    )
+
+    class FakeResponse:
+        def __init__(self, *, status_code: int, json_data: typing.Any = None, text: str = "") -> None:
+            self.status_code = status_code
+            self._json_data = json_data
+            self.text = text
+
+        def json(self) -> typing.Any:
+            if self._json_data is None:
+                raise ValueError("JSON data was not provided for this response")
+            return self._json_data
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP status {self.status_code}")
+
+    def fake_request(
+        self,
+        method: str,
+        url: str,
+        params: typing.Optional[dict] = None,
+        headers: typing.Optional[dict] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> FakeResponse:
+        del self, method, url, params, headers, timeout
+        raise AssertionError("Unexpected HTTP request executed")
+
+    mocker.patch(
+        "requests.sessions.Session.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+    mocker.patch(
+        "requests_cache.session.CachedSession.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+
+    def fake_feedparser_parse(url: str) -> dict:
+        assert url.startswith(
+            "https://export.arxiv.org/api/query?search_query=all:fitbit&start=0&max_results=20"
+        )
+        return {
+            "entries": [
+                {
+                    "id": "http://arxiv.org/abs/000001",
+                    "title": "Tracking Fitbit usage for longitudinal studies",
+                    "summary": "Example abstract content for Fitbit trials.",
+                    "published": "2023-01-01T00:00:00Z",
+                    "authors": [
+                        {"name": "Doe, Alex"},
+                        {"name": "Roe, Sam"},
+                    ],
+                    "arxiv_doi": "10.1000/FITBIT-TRIALS",
+                }
+            ]
+        }
+
+    mocker.patch("feedparser.parse", side_effect=fake_feedparser_parse)
+
+    arxiv_source = ArXivSearchSource(search_file=search_file)
+    arxiv_source.search(rerun=True)
+
+    search_results_path = Path(search_file.search_results_path)
+    assert search_results_path.is_file()
+
+    saved_records = colrev.loader.load_utils.load(
+        filename=search_results_path,
+        unique_id_field=Fields.ID,
+    )
+
+    assert len(saved_records) == 1
+    saved_record = next(iter(saved_records.values()))
+    assert saved_record[Fields.ID] == "000001"
+    assert saved_record[Fields.TITLE] == "Tracking Fitbit usage for longitudinal studies"
+    assert saved_record[Fields.AUTHOR] == "Doe, Alex and Roe, Sam"
+    assert saved_record[Fields.YEAR] == "2023"
+    assert saved_record[Fields.DOI] == "10.1000/FITBIT-TRIALS"

--- a/tests/packaged_search/test_dblp.py
+++ b/tests/packaged_search/test_dblp.py
@@ -1,0 +1,239 @@
+#! /usr/bin/env python
+import json
+import typing
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+import colrev.env.environment_manager
+import colrev.exceptions as colrev_exceptions
+import colrev.loader.load_utils
+import colrev.search_file
+from colrev.constants import Fields, SearchType
+from colrev.packages.dblp.src.dblp import DBLPSearchSource
+
+
+@pytest.fixture()
+def dblp_search_file_factory() -> typing.Callable:
+    """Return a factory to build DBLP search files for validation tests."""
+
+    def _build(
+        version_marker: typing.Optional[str], include_version_param: bool = True
+    ) -> colrev.search_file.ExtendedSearchFile:
+        search_file = colrev.search_file.ExtendedSearchFile(
+            platform="colrev.dblp",
+            search_results_path=Path("data/search/dblp.bib"),
+            search_type=SearchType.API,
+            search_string="",
+            comment="",
+            version="0.1.0",
+        )
+
+        search_parameters: dict[str, typing.Any] = {
+            "url": "https://dblp.org/search/publ/api?q=validation&h=10&format=json",
+            "query": "https://dblp.org/search/publ/api?q=validation",
+        }
+        if include_version_param and version_marker is not None:
+            search_parameters["version"] = version_marker
+        search_file.search_parameters = search_parameters
+
+        if version_marker is not None:
+            search_file.version = version_marker
+        else:
+            search_file.version = None
+
+        return search_file
+
+    return _build
+
+
+def test_dblp_validate_accepts_current_version(
+    dblp_search_file_factory: typing.Callable,
+) -> None:
+    search_file = dblp_search_file_factory("0.1.0")
+
+    DBLPSearchSource(search_file=search_file)
+
+
+def test_dblp_validate_rejects_missing_version(
+    dblp_search_file_factory: typing.Callable,
+) -> None:
+    search_file = dblp_search_file_factory(
+        version_marker=None, include_version_param=False
+    )
+
+    with pytest.raises(colrev_exceptions.InvalidQueryException) as exc_info:
+        DBLPSearchSource(search_file=search_file)
+
+    assert str(exc_info.value) == "DBLP version should be 0.1.0, found None"
+
+
+def test_dblp_validate_rejects_mismatched_version(
+    dblp_search_file_factory: typing.Callable,
+) -> None:
+    search_file = dblp_search_file_factory("9.9.9")
+
+    with pytest.raises(colrev_exceptions.InvalidQueryException) as exc_info:
+        DBLPSearchSource(search_file=search_file)
+
+    assert str(exc_info.value) == "DBLP version should be 0.1.0, found 9.9.9"
+
+
+def test_dblp_search_persists_api_results(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run a full DBLP API search and persist the retrieved records."""
+
+    monkeypatch.chdir(tmp_path)
+    Path("data/search").mkdir(parents=True)
+
+    search_file = colrev.search_file.ExtendedSearchFile(
+        platform="colrev.dblp",
+        search_results_path=Path("data/search/dblp.bib"),
+        search_type=SearchType.API,
+        search_string="",
+        comment="",
+        version="0.1.0",
+    )
+    search_file.search_parameters = {
+        "url": "https://dblp.org/search/publ/api?q=validation&h=10&format=json",
+        "query": "https://dblp.org/search/publ/api?q=validation",
+        "version": "0.1.0",
+    }
+
+    mocker.patch.object(
+        colrev.env.environment_manager.EnvironmentManager,
+        "get_name_mail_from_git",
+        return_value=("Test User", "test@example.com"),
+    )
+
+    class FakeResponse:
+        def __init__(
+            self,
+            *,
+            status_code: int,
+            json_data: typing.Optional[typing.Any] = None,
+            text: str = "",
+        ) -> None:
+            self.status_code = status_code
+            self._json_data = json_data
+            self.text = text
+
+        def json(self) -> typing.Any:
+            if self._json_data is None:
+                raise ValueError("JSON data was not provided for this response")
+            return self._json_data
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP status {self.status_code}")
+
+    total_url = "https://dblp.org/search/publ/api?q=validation&format=json"
+    search_url = (
+        "https://dblp.org/search/publ/api?q=validation&format=json&h=250&f=0"
+    )
+    venue_url = "https://dblp.org/search/venue/api?q=isr&format=json"
+
+    fake_total_payload = {
+        "result": {
+            "hits": {"@total": "1"},
+        }
+    }
+    fake_search_payload = {
+        "result": {
+            "time": {"text": "0.0"},
+            "hits": {
+                "hit": [
+                    {
+                        "info": {
+                            "title": "Validating Digital Platforms in IS Research",
+                            "type": "Journal Articles",
+                            "key": "journals/isr/000001",
+                            "year": "2021",
+                            "doi": "10.4242/DBLP-VALIDATE-2021",
+                            "authors": {
+                                "author": [
+                                    {"text": "Doe, Alex"},
+                                    {"text": "Roe, Sam"},
+                                ]
+                            },
+                        }
+                    }
+                ]
+            },
+        }
+    }
+    fake_venue_payload = {
+        "result": {
+            "hits": {
+                "hit": [
+                    {
+                        "info": {
+                            "type": "Journal",
+                            "venue": "Information Systems Research",
+                            "url": "https://dblp.org/db/journals/isr/index.html",
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+    def fake_request(
+        self,
+        method: str,
+        url: str,
+        params: typing.Optional[dict] = None,
+        headers: typing.Optional[dict] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> FakeResponse:
+        del self, method, params, headers, timeout
+        if url == total_url:
+            return FakeResponse(
+                status_code=200,
+                text=json.dumps(fake_total_payload),
+            )
+        if url == search_url:
+            return FakeResponse(
+                status_code=200,
+                text=json.dumps(fake_search_payload),
+            )
+        if url == venue_url:
+            return FakeResponse(
+                status_code=200,
+                text=json.dumps(fake_venue_payload),
+            )
+        raise AssertionError(f"Unexpected URL called: {url}")
+
+    mocker.patch(
+        "requests.sessions.Session.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+    mocker.patch(
+        "requests_cache.session.CachedSession.request",
+        autospec=True,
+        side_effect=fake_request,
+    )
+
+    dblp_source = DBLPSearchSource(search_file=search_file)
+    dblp_source.search(rerun=True)
+
+    search_results_path = Path(search_file.search_results_path)
+    assert search_results_path.is_file()
+
+    saved_records = colrev.loader.load_utils.load(
+        filename=search_results_path,
+        unique_id_field=Fields.ID,
+    )
+
+    assert len(saved_records) == 1
+    saved_record = next(iter(saved_records.values()))
+    assert saved_record[Fields.ID] == "000001"
+    assert saved_record[Fields.TITLE] == "Validating Digital Platforms in IS Research"
+    assert saved_record[Fields.AUTHOR] == "Doe, Alex and Roe, Sam"
+    assert saved_record[Fields.YEAR] == "2021"
+    assert saved_record[Fields.DOI] == "10.4242/DBLP-VALIDATE-2021"


### PR DESCRIPTION
## Summary
- add AIS Library packaged search tests covering version validation and API persistence
- add arXiv packaged search tests mirroring PubMed-style validation and search persistence
- add DBLP packaged search tests verifying version handling and mocked API search persistence

## Testing
- PYTHONPATH=. pytest tests/packaged_search -k ais_library *(fails: ModuleNotFoundError: No module named 'search_query')*

------
https://chatgpt.com/codex/tasks/task_e_68d521ab2394832a84584a8f64afe25b