### PR TITLE
Remove unused imports from package modules

### DIFF
--- a/colrev/packages/bibliography_export/src/bibliography_export.py
+++ b/colrev/packages/bibliography_export/src/bibliography_export.py
@@ -12,8 +12,6 @@ import inquirer
 from pydantic import BaseModel
 from pydantic import Field
 
-import colrev.env.docker_manager
-import colrev.env.utils
 import colrev.package_manager.package_base_classes as base_classes
 import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings

--- a/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
@@ -16,7 +16,6 @@ from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Colors

--- a/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
+++ b/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
@@ -9,7 +9,6 @@ from typing import Optional
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Colors

--- a/colrev/packages/colrev_cli_screen/src/screen_cli.py
+++ b/colrev/packages/colrev_cli_screen/src/screen_cli.py
@@ -10,7 +10,6 @@ from inquirer import prompt
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.packages.screen_utils as util_cli_screen
 import colrev.record.record

--- a/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
+++ b/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
@@ -8,7 +8,6 @@ from typing import Optional
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields

--- a/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
+++ b/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
@@ -13,7 +13,6 @@ from rapidfuzz import fuzz
 from tqdm import tqdm
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Colors

--- a/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
+++ b/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
@@ -12,7 +12,6 @@ from pydantic import Field
 
 import colrev.exceptions as colrev_exceptions
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 import colrev.record.record_prep

--- a/colrev/packages/dedupe/src/dedupe.py
+++ b/colrev/packages/dedupe/src/dedupe.py
@@ -17,7 +17,6 @@ from bib_dedupe.bib_dedupe import match
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields

--- a/colrev/packages/download_from_website/src/download_from_website.py
+++ b/colrev/packages/download_from_website/src/download_from_website.py
@@ -12,7 +12,6 @@ from bs4 import BeautifulSoup
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields

--- a/colrev/packages/export_man_prep/src/prep_man_export.py
+++ b/colrev/packages/export_man_prep/src/prep_man_export.py
@@ -13,9 +13,7 @@ import pymupdf
 from pydantic import BaseModel
 from pydantic import Field
 
-import colrev.env.utils
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Colors

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -12,7 +12,6 @@ from pydantic import Field
 
 import colrev.env.utils
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev import utils

--- a/colrev/packages/local_index/src/local_index_pdf_get.py
+++ b/colrev/packages/local_index/src/local_index_pdf_get.py
@@ -12,7 +12,6 @@ from pydantic import Field
 import colrev.env.local_index
 import colrev.exceptions as colrev_exceptions
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields

--- a/colrev/packages/ocrmypdf/src/ocrmypdf.py
+++ b/colrev/packages/ocrmypdf/src/ocrmypdf.py
@@ -12,9 +12,7 @@ import docker
 from pydantic import Field
 
 import colrev.env.docker_manager
-import colrev.env.utils
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev import utils

--- a/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
+++ b/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
@@ -10,7 +10,6 @@ from pydantic import Field
 
 import colrev.env.utils
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 

--- a/colrev/packages/prescreen_table/src/prescreen_table.py
+++ b/colrev/packages/prescreen_table/src/prescreen_table.py
@@ -11,7 +11,6 @@ import pandas as pd
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Colors

--- a/colrev/packages/profile/src/profile.py
+++ b/colrev/packages/profile/src/profile.py
@@ -10,10 +10,7 @@ import pandas as pd
 from pydantic import BaseModel
 from pydantic import Field
 
-import colrev.env.docker_manager
-import colrev.env.utils
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import FieldValues

--- a/colrev/packages/remove_coverpage/src/remove_cover_page.py
+++ b/colrev/packages/remove_coverpage/src/remove_cover_page.py
@@ -12,7 +12,6 @@ import pymupdf
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import Filepaths

--- a/colrev/packages/remove_last_page/src/remove_last_page.py
+++ b/colrev/packages/remove_last_page/src/remove_last_page.py
@@ -12,7 +12,6 @@ import pymupdf
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 from colrev.constants import Fields
 from colrev.constants import Filepaths

--- a/colrev/packages/scope_prescreen/src/scope_prescreen.py
+++ b/colrev/packages/scope_prescreen/src/scope_prescreen.py
@@ -14,7 +14,6 @@ import colrev.env.language_service
 import colrev.env.local_index
 import colrev.exceptions as colrev_exceptions
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.record.record
 from colrev.constants import Fields

--- a/colrev/packages/screen_table/src/screen_table.py
+++ b/colrev/packages/screen_table/src/screen_table.py
@@ -12,7 +12,6 @@ import pandas as pd
 from pydantic import Field
 
 import colrev.package_manager.package_base_classes as base_classes
-import colrev.package_manager.package_manager
 import colrev.package_manager.package_settings
 import colrev.packages.screen_utils as util_cli_screen
 import colrev.record.record

--- a/colrev/packages/screen_utils.py
+++ b/colrev/packages/screen_utils.py
@@ -2,7 +2,6 @@
 """Screening utilities"""
 from __future__ import annotations
 
-import colrev.package_manager.package_manager
 import colrev.record.record
 import colrev.settings
 from colrev.constants import Fields

--- a/tests/data/package_init/data.py
+++ b/tests/data/package_init/data.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.data
 from colrev.package_manager.package_base_classes import DataPackageBaseClass
 
 class CustomName(DataPackageBaseClass):

--- a/tests/data/package_init/dedupe.py
+++ b/tests/data/package_init/dedupe.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.dedupe
 from colrev.package_manager.package_base_classes import DedupePackageBaseClass
 
 class CustomName(DedupePackageBaseClass):

--- a/tests/data/package_init/pdf_get.py
+++ b/tests/data/package_init/pdf_get.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.pdf_get
 from colrev.package_manager.package_base_classes import PDFGetPackageBaseClass
 
 class CustomName(PDFGetPackageBaseClass):

--- a/tests/data/package_init/pdf_get_man.py
+++ b/tests/data/package_init/pdf_get_man.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.pdf_get_man
 from colrev.package_manager.package_base_classes import PDFGetManPackageBaseClass
 
 class CustomName(PDFGetManPackageBaseClass):

--- a/tests/data/package_init/pdf_prep.py
+++ b/tests/data/package_init/pdf_prep.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.pdf_prep
 from colrev.package_manager.package_base_classes import PDFPrepPackageBaseClass
 
 class CustomName(PDFPrepPackageBaseClass):

--- a/tests/data/package_init/pdf_prep_man.py
+++ b/tests/data/package_init/pdf_prep_man.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.pdf_prep_man
 from colrev.package_manager.package_base_classes import PDFPrepManPackageBaseClass
 
 class CustomName(PDFPrepManPackageBaseClass):

--- a/tests/data/package_init/prep.py
+++ b/tests/data/package_init/prep.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.prep
 from colrev.package_manager.package_base_classes import PrepPackageBaseClass
 
 class CustomName(PrepPackageBaseClass):

--- a/tests/data/package_init/prep_man.py
+++ b/tests/data/package_init/prep_man.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.prep_man
 from colrev.package_manager.package_base_classes import PrepManPackageBaseClass
 
 class CustomName(PrepManPackageBaseClass):

--- a/tests/data/package_init/prescreen.py
+++ b/tests/data/package_init/prescreen.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.prescreen
 from colrev.package_manager.package_base_classes import PrescreenPackageBaseClass
 
 class CustomName(PrescreenPackageBaseClass):

--- a/tests/data/package_init/review_type.py
+++ b/tests/data/package_init/review_type.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.data
 from colrev.package_manager.package_base_classes import ReviewTypePackageBaseClass
 
 class CustomName(ReviewTypePackageBaseClass):

--- a/tests/data/package_init/screen.py
+++ b/tests/data/package_init/screen.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.ops.screen
 from colrev.package_manager.package_base_classes import ScreenPackageBaseClass
 
 class CustomName(ScreenPackageBaseClass):

--- a/tests/data/package_init/search_source.py
+++ b/tests/data/package_init/search_source.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 """CustomName"""
-import logging
-from typing import Optional
 
-import colrev.search_file
 from colrev.package_manager.package_base_classes import SearchSourcePackageBaseClass
 
 class CustomName(SearchSourcePackageBaseClass):


### PR DESCRIPTION
## Summary
- drop unused package_manager dependencies from package endpoint modules that never instantiate a PackageManager
- remove redundant colrev.env utility imports from profile/bibliography/pdf preparation endpoints to trim runtime dependencies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc63d99e8832a918283e4d527a060