### PR TITLE
Apply broad PEP 257 docstring lint autofixes across colrev codebase

### DIFF
--- a/colrev/constants.py
+++ b/colrev/constants.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 
 class Filepaths:
-    """Filepaths for CoLRev"""
+    """Filepaths for CoLRev."""
 
     # Environment-specific paths
     LOCAL_ENVIRONMENT_DIR = Path.home().joinpath(".colrev")
@@ -41,7 +41,7 @@ class Filepaths:
 
 
 class FileSets:
-    """File sets for CoLRev"""
+    """File sets for CoLRev."""
 
     DEFAULT_GIT_IGNORE_ITEMS = [
         ".history",
@@ -73,7 +73,7 @@ class FileSets:
 
 
 class ENTRYTYPES:
-    """Constants for record ENTRYTYPEs"""
+    """Constants for record ENTRYTYPEs."""
 
     ARTICLE = "article"
     INPROCEEDINGS = "inproceedings"
@@ -95,7 +95,7 @@ class ENTRYTYPES:
 
     @classmethod
     def get_all(cls) -> list:
-        """Get all ENTRYTYPES"""
+        """Get all ENTRYTYPES."""
         return [
             cls.ARTICLE,
             cls.INPROCEEDINGS,
@@ -116,7 +116,7 @@ class ENTRYTYPES:
 
 
 class Fields:
-    """Constant field names"""
+    """Constant field names."""
 
     ID = "ID"
     ENTRYTYPE = "ENTRYTYPE"
@@ -222,13 +222,13 @@ class Fields:
 
 
 class FieldsRegex:
-    """Regex patterns for specific fields"""
+    """Regex patterns for specific fields."""
 
     DOI = re.compile(r"10\.\d{4,9}/[-._;/:A-Za-z0-9]*")
 
 
 class LocalIndexFields:
-    """Fields used in the local index"""
+    """Fields used in the local index."""
 
     ID = "id"
     CITATION_KEY = "citation_key"
@@ -239,7 +239,7 @@ class LocalIndexFields:
 
 
 class FieldValues:
-    """Constant field values"""
+    """Constant field values."""
 
     UNKNOWN = "UNKNOWN"
     FORTHCOMING = "forthcoming"
@@ -249,7 +249,7 @@ class FieldValues:
 
 
 class FieldSet:
-    """Constant field sets"""
+    """Constant field sets."""
 
     # """Keys of identifying fields considered for masterdata provenance"""
     PROVENANCE_KEYS = [
@@ -384,7 +384,8 @@ ENTRYTYPE_FIELD_REQUIREMENTS = {
 
 class RecordState(Enum):
     """The possible RecordStates stored in the colrev_status field
-    (corresponding to the ProcessModel)"""
+    (corresponding to the ProcessModel).
+    """
 
     # pylint: disable=invalid-name
 
@@ -433,7 +434,7 @@ class RecordState(Enum):
 
     @classmethod
     def get_states_requiring_file(cls) -> list:
-        """Get the states that require a file"""
+        """Get the states that require a file."""
         return [
             RecordState.pdf_imported,
             RecordState.pdf_needs_manual_preparation,
@@ -445,7 +446,7 @@ class RecordState(Enum):
 
     @classmethod
     def get_non_processed_states(cls) -> list:
-        """Get the states that correspond to not-yet-processed"""
+        """Get the states that correspond to not-yet-processed."""
         return [
             RecordState.md_retrieved,
             RecordState.md_imported,
@@ -455,7 +456,7 @@ class RecordState(Enum):
 
     @classmethod
     def get_post_x_states(cls, *, state: "RecordState") -> typing.Set["RecordState"]:
-        """Get the states after state x (passed as a parameter)"""
+        """Get the states after state x (passed as a parameter)."""
         # pylint: disable=too-many-return-statements
         if state == RecordState.md_prepared:
             return {
@@ -528,7 +529,7 @@ class RecordState(Enum):
 
 
 class DefectCodes:
-    """Constant defect codes"""
+    """Constant defect codes."""
 
     MISSING = "missing"
     RECORD_NOT_IN_TOC = "record-not-in-toc"
@@ -560,7 +561,7 @@ class DefectCodes:
 
 
 class PDFDefectCodes:
-    """Constant PDF defect codes"""
+    """Constant PDF defect codes."""
 
     NO_TEXT_IN_PDF = "no-text-in-pdf"
     PDF_INCOMPLETE = "pdf-incomplete"
@@ -571,7 +572,7 @@ class PDFDefectCodes:
 
 
 class OperationsType(Enum):
-    """Operation types correspond to the main state transitions (see ProcessModel)"""
+    """Operation types correspond to the main state transitions (see ProcessModel)."""
 
     # pylint: disable=invalid-name
 
@@ -596,7 +597,7 @@ class OperationsType(Enum):
 
     @classmethod
     def get_manual_extra_operations(cls) -> list:
-        """Get the manual operations that require extra manual steps"""
+        """Get the manual operations that require extra manual steps."""
         return [
             OperationsType.pdf_prep_man,
             OperationsType.pdf_get_man,
@@ -605,7 +606,7 @@ class OperationsType(Enum):
 
 
 class IDPattern(Enum):
-    """The pattern for generating record IDs"""
+    """The pattern for generating record IDs."""
 
     # pylint: disable=invalid-name
     first_author_year = "first_author_year"
@@ -613,13 +614,13 @@ class IDPattern(Enum):
 
     @classmethod
     def get_options(cls) -> typing.List[str]:
-        """Get the options"""
+        """Get the options."""
         # pylint: disable=no-member
         return cls._member_names_
 
 
 class SortedEnumMeta(EnumMeta):
-    """SortedEnumMeta"""
+    """SortedEnumMeta."""
 
     def __init__(
         cls, name: str, bases: typing.Tuple[type, ...], classdict: dict
@@ -633,7 +634,7 @@ class SortedEnumMeta(EnumMeta):
 
 
 class SearchType(Enum, metaclass=SortedEnumMeta):
-    """Type of search source"""
+    """Type of search source."""
 
     API = "API"  # Keyword-searches
     DB = "DB"  # search-results-file with search query
@@ -646,7 +647,7 @@ class SearchType(Enum, metaclass=SortedEnumMeta):
 
     @classmethod
     def get_options(cls) -> typing.List[str]:
-        """Get the options"""
+        """Get the options."""
         # pylint: disable=no-member
         return cls._member_names_
 
@@ -660,7 +661,7 @@ class SearchType(Enum, metaclass=SortedEnumMeta):
 
 
 class SearchSourceHeuristicStatus(Enum):
-    """Status of the SearchSource heuristic"""
+    """Status of the SearchSource heuristic."""
 
     # pylint: disable=invalid-name
     na = "not_applicable"
@@ -673,7 +674,7 @@ class SearchSourceHeuristicStatus(Enum):
 
 
 class PDFPathType(Enum):
-    """Policy for handling PDFs (create symlinks or copy files)"""
+    """Policy for handling PDFs (create symlinks or copy files)."""
 
     # pylint: disable=invalid-name
     symlink = "symlink"
@@ -681,13 +682,13 @@ class PDFPathType(Enum):
 
     @classmethod
     def get_options(cls) -> typing.List[str]:
-        """Get the options"""
+        """Get the options."""
         # pylint: disable=no-member
         return cls._member_names_
 
 
 class ScreenCriterionType(Enum):
-    """Type of screening criterion"""
+    """Type of screening criterion."""
 
     # pylint: disable=invalid-name
     inclusion_criterion = "inclusion_criterion"
@@ -695,7 +696,7 @@ class ScreenCriterionType(Enum):
 
     @classmethod
     def get_options(cls) -> typing.List[str]:
-        """Get the options"""
+        """Get the options."""
         # pylint: disable=no-member
         return cls._member_names_
 
@@ -704,7 +705,7 @@ class ScreenCriterionType(Enum):
 
 
 class ShareStatReq(Enum):
-    """Record status requirements for sharing"""
+    """Record status requirements for sharing."""
 
     # pylint: disable=invalid-name
     none = "none"
@@ -714,14 +715,14 @@ class ShareStatReq(Enum):
 
     @classmethod
     def get_options(cls) -> typing.List[str]:
-        """Get the options"""
+        """Get the options."""
         # pylint: disable=no-member
         return cls._member_names_
 
 
 # pylint: disable=colrev-missed-constant-usage
 class EndpointType(Enum):
-    """An enum for the types of PackageEndpoints"""
+    """An enum for the types of PackageEndpoints."""
 
     # pylint: disable=C0103
     review_type = "review_type"
@@ -753,14 +754,14 @@ class EndpointType(Enum):
 
 
 class ExitCodes:
-    """Exit codes"""
+    """Exit codes."""
 
     SUCCESS = 0
     FAIL = 1
 
 
 class Colors:
-    """Colors for CLI printing"""
+    """Colors for CLI printing."""
 
     RED = "\033[91m"
     GREEN = "\033[92m"

--- a/colrev/dataset.py
+++ b/colrev/dataset.py
@@ -25,22 +25,21 @@ from colrev.writer.write_utils import to_string
 
 
 class Dataset:
-    """The CoLRev dataset (records and their history in git)"""
+    """The CoLRev dataset (records and their history in git)."""
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
         self.review_manager = review_manager
 
     @cached_property
     def git_repo(self) -> GitRepo:
-        """Get the GitRepo object for the review_manager path"""
+        """Get the GitRepo object for the review_manager path."""
         return GitRepo(path=self.review_manager.path)
 
     def get_origin_state_dict(self, records_string: str = "") -> dict:
-        """Get the origin_state_dict (to determine state transitions efficiently)
+        """Get the origin_state_dict (to determine state transitions efficiently).
 
         {'30_example_records.bib/Staehr2010': <RecordState.pdf_not_available: 10>,}
         """
-
         current_origin_states_dict = {}
         if records_string != "":
             with tempfile.NamedTemporaryFile(
@@ -65,7 +64,7 @@ class Dataset:
         return current_origin_states_dict
 
     def get_committed_origin_state_dict(self) -> dict:
-        """Get the committed origin_state_dict"""
+        """Get the committed origin_state_dict."""
         revlist = (
             (
                 commit.hexsha,
@@ -85,21 +84,22 @@ class Dataset:
         return committed_origin_state_dict
 
     def load_records_from_history(self, commit_sha: str = "") -> typing.Iterator[dict]:
-        """
-        Iterates through Git history, yielding records file contents as dictionaries.
+        """Iterates through Git history, yielding records file contents as dictionaries.
 
         Starts iteration from a provided commit SHA.
         Skips commits where the records file is unchanged.
         Useful for tracking dataset changes over time.
 
-        Parameters:
+        Parameters
+        ----------
             commit_sha (str, optional): Start iteration from this commit SHA.
             Defaults to beginning of Git history if not provided.
 
-        Yields:
+        Yields
+        ------
             dict: Records file contents at a specific Git history point, as a dictionary.
-        """
 
+        """
         reached_target_commit = False  # if no commit_sha provided
         for current_commit in self.git_repo.repo.iter_commits(
             paths=self.review_manager.paths.RECORDS_FILE_GIT
@@ -130,7 +130,7 @@ class Dataset:
         *,
         header_only: bool = False,
     ) -> dict[str, dict[str, typing.Any]]:
-        """Load the records
+        """Load the records.
 
         header_only:
 
@@ -142,7 +142,6 @@ class Dataset:
         'colrev_data_provenance': {Fields.AUTHOR:{"source":"...", "note":"..."}}},
         }
         """
-
         if self.review_manager.notified_next_operation is None:
             raise colrev_exceptions.ReviewManagerNotNotifiedError()
 
@@ -170,7 +169,7 @@ class Dataset:
         return records_dict
 
     def save_records_dict_to_file(self, records: dict) -> None:
-        """Save the records dict"""
+        """Save the records dict."""
         # Note : this classmethod function can be called by CoLRev scripts
         # operating outside a CoLRev repo (e.g., sync)
 
@@ -240,7 +239,7 @@ class Dataset:
         self.git_repo.add_changes(self.review_manager.paths.RECORDS_FILE)
 
     def save_records_dict(self, records: dict, *, partial: bool = False) -> None:
-        """Save the records dict in RECORDS_FILE"""
+        """Save the records dict in RECORDS_FILE."""
         if not records:
             return
         if partial:
@@ -249,8 +248,7 @@ class Dataset:
         self.save_records_dict_to_file(records)
 
     def read_next_record(self, *, conditions: list) -> typing.Iterator[dict]:
-        """Read records (Iterator) based on condition"""
-
+        """Read records (Iterator) based on condition."""
         # Note : matches conditions connected with 'OR'
         records = self.load_records_dict()
 
@@ -263,8 +261,7 @@ class Dataset:
         yield from records_list
 
     def format_records_file(self) -> dict:
-        """Format the records file (Entrypoint for pre-commit hooks)"""
-
+        """Format the records file (Entrypoint for pre-commit hooks)."""
         if (
             not self.review_manager.paths.records.is_file()
             or not self.git_repo.records_changed()
@@ -304,15 +301,14 @@ class Dataset:
         return {"status": ExitCodes.SUCCESS, "msg": "Everything ok."}
 
     def reset_log_if_no_changes(self) -> None:
-        """Reset the report log file if there are not changes"""
+        """Reset the report log file if there are not changes."""
         if not self.git_repo.repo.is_dirty():
             self.review_manager.reset_report_logger()
 
     # ID creation, update and lookup ---------------------------------------
 
     def propagated_id(self, *, record_id: str) -> bool:
-        """Check whether an ID is propagated (i.e., its record's status is beyond md_processed)"""
-
+        """Check whether an ID is propagated (i.e., its record's status is beyond md_processed)."""
         for record in self.load_records_dict(header_only=True).values():
             if record[Fields.ID] == record_id:
                 if record[Fields.STATUS] in RecordState.get_post_x_states(
@@ -324,7 +320,8 @@ class Dataset:
 
     def set_ids(self, selected_ids: typing.Optional[list] = None) -> dict:
         """Set the IDs of records according to predefined formats or
-        according to the LocalIndex"""
+        according to the LocalIndex.
+        """
         id_setter = colrev.record.record_id_setter.IDSetter(
             id_pattern=self.review_manager.settings.project.id_pattern,
             skip_local_index=self.review_manager.settings.is_curated_masterdata_repo(),

--- a/colrev/env/__init__.py
+++ b/colrev/env/__init__.py
@@ -1,4 +1,4 @@
-"""Environment"""
+"""Environment."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/env/docker_manager.py
+++ b/colrev/env/docker_manager.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Manages Docker"""
+"""Manages Docker."""
 
 from __future__ import annotations
 
@@ -15,14 +15,14 @@ from colrev.constants import Colors
 
 class DockerManager:
     """The DockerManager manages everything related to Docker
-    (e.g. building images, running containers)"""
+    (e.g. building images, running containers).
+    """
 
     @classmethod
     def build_docker_image(
         cls, *, imagename: str, dockerfile: typing.Optional[Path] = None
     ) -> None:
-        """Build a docker image"""
-
+        """Build a docker image."""
         try:
             client = docker.from_env()
             repo_tags = [t for image in client.images.list() for t in image.tags]
@@ -52,8 +52,7 @@ class DockerManager:
 
     @classmethod
     def check_docker_installed(cls) -> None:  # pragma: no cover
-        """Check whether Docker is installed"""
-
+        """Check whether Docker is installed."""
         try:
             client = docker.from_env()
             _ = client.version()

--- a/colrev/env/environment_manager.py
+++ b/colrev/env/environment_manager.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Manages environment registry, services, and stauts"""
+"""Manages environment registry, services, and stauts."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from colrev.env.utils import get_by_path
 
 
 class EnvironmentManager:
-    """The EnvironmentManager manages environment resources and services"""
+    """The EnvironmentManager manages environment resources and services."""
 
     load_yaml = False
 
@@ -30,7 +30,7 @@ class EnvironmentManager:
         self._registered_ports: typing.List[str] = []
 
     def register_ports(self, ports: typing.List[str]) -> None:
-        """Register a localhost port to avoid conflicts"""
+        """Register a localhost port to avoid conflicts."""
         for port_to_register in ports:
             if port_to_register in self._registered_ports:
                 raise colrev_exceptions.PortAlreadyRegisteredException(
@@ -84,7 +84,7 @@ class EnvironmentManager:
         path_to_register: Path,
         logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
-        """Register a repository"""
+        """Register a repository."""
         path_to_register = path_to_register.resolve().absolute()
         self.environment_registry = self.load_environment_registry()
 
@@ -121,7 +121,7 @@ class EnvironmentManager:
 
     @classmethod
     def get_name_mail_from_git(cls) -> typing.Tuple[str, str]:  # pragma: no cover
-        """Get the committer name and email from git (globals)"""
+        """Get the committer name and email from git (globals)."""
         global_conf_details = ("NA", "NA")
         try:
             username = git.config.GitConfigParser().get_value("user", "name")
@@ -134,8 +134,7 @@ class EnvironmentManager:
         return global_conf_details
 
     def check_git_installed(self) -> None:  # pragma: no cover
-        """Check whether git is installed"""
-
+        """Check whether git is installed."""
         try:
             git_instance = git.Git()
             _ = git_instance.version()
@@ -153,8 +152,7 @@ class EnvironmentManager:
         return status_dict
 
     def get_environment_details(self) -> dict:
-        """Get the environment details"""
-
+        """Get the environment details."""
         environment_details = {}
         size = 0
         last_modified = "NOT_INITIATED"
@@ -177,8 +175,7 @@ class EnvironmentManager:
         return environment_details
 
     def _get_environment_stats(self) -> dict:
-        """Get the environment stats"""
-
+        """Get the environment stats."""
         local_repos = self.local_repos()
         repos = []
         broken_links = []
@@ -212,7 +209,7 @@ class EnvironmentManager:
         return {"repos": repos, "broken_links": broken_links}
 
     def get_curated_outlets(self) -> list:
-        """Get the curated outlets"""
+        """Get the curated outlets."""
         curated_outlets: typing.List[str] = []
         for repo_source_path in [
             x["repo_source_path"]
@@ -272,9 +269,10 @@ class EnvironmentManager:
         return True
 
     def get_settings_by_key(self, key: str) -> str | None:
-        """Loads setting by the given key
+        """Loads setting by the given key.
 
-        The registry is stored in /home/username/colrev/registry.json"""
+        The registry is stored in /home/username/colrev/registry.json
+        """
         environment_registry = self.load_environment_registry()
         keys = key.split(".")
         if self._dict_keys_exists(environment_registry, *keys):
@@ -282,10 +280,10 @@ class EnvironmentManager:
         return None
 
     def update_registry(self, key: str, value: str) -> None:
-        """Updates a given key in the registry with new value
+        """Updates a given key in the registry with new value.
 
-        The registry is stored in /home/username/colrev/registry.json"""
-
+        The registry is stored in /home/username/colrev/registry.json
+        """
         keys = key.split(".")
         # We don't want to allow user to replace any core settings, so check for packages key
         if keys[0] != "packages" or len(keys) < 2:

--- a/colrev/env/grobid_service.py
+++ b/colrev/env/grobid_service.py
@@ -13,7 +13,7 @@ import colrev.env.docker_manager
 
 
 class GrobidService:
-    """An environment service for machine readability/annotation (PDF to TEI conversion)"""
+    """An environment service for machine readability/annotation (PDF to TEI conversion)."""
 
     GROBID_URL = "http://localhost:8070"
     # Important: do not use :latest versions or :SNAPSHOT versions
@@ -39,7 +39,7 @@ class GrobidService:
             raise Exception  # pylint: disable=broad-exception-raised
 
     def check_grobid_availability(self, *, wait: bool = True) -> bool:
-        """Check whether the GROBID service is available"""
+        """Check whether the GROBID service is available."""
         i = 0
         while True:
             i += 1
@@ -62,7 +62,7 @@ class GrobidService:
         return True
 
     def start(self) -> None:
-        """Start the GROBID service"""
+        """Start the GROBID service."""
         # pylint: disable=consider-using-with
 
         try:

--- a/colrev/env/language_service.py
+++ b/colrev/env/language_service.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Service to detect languages and handle language codes"""
+"""Service to detect languages and handle language codes."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from colrev.constants import Fields
 
 
 class LanguageService:
-    """Service to detect languages and handle language codes"""
+    """Service to detect languages and handle language codes."""
 
     _eng_false_negatives = ["editorial", "introduction"]
 
@@ -84,7 +84,7 @@ class LanguageService:
         return ""  # pragma: no cover
 
     def compute_language(self, *, text: str) -> str:
-        """Compute the most likely language code"""
+        """Compute the most likely language code."""
         if text.lower() in self._eng_false_negatives:
             return "eng"
 
@@ -115,7 +115,7 @@ class LanguageService:
         return predictions_unified
 
     def validate_iso_639_3_language_codes(self, *, lang_code_list: list) -> None:
-        """Validates whether a list of language codes complies with the ISO 639-3 standard"""
+        """Validates whether a list of language codes complies with the ISO 639-3 standard."""
         assert isinstance(lang_code_list, list)
 
         invalid_language_codes = [x for x in lang_code_list if 3 != len(x)]

--- a/colrev/env/local_index.py
+++ b/colrev/env/local_index.py
@@ -23,7 +23,7 @@ from colrev.env.local_index_prep import prepare_record_for_return
 
 
 class LocalIndex:
-    """The LocalIndex implements indexing and retrieval of records across projects"""
+    """The LocalIndex implements indexing and retrieval of records across projects."""
 
     def __init__(
         self,
@@ -37,7 +37,7 @@ class LocalIndex:
         self.thread_lock = Lock()
 
     def get_journal_rankings(self, journal: str) -> list:
-        """Get the journal rankings from the sqlite database"""
+        """Get the journal rankings from the sqlite database."""
         sqlite_index_ranking = colrev.env.local_index_sqlite.SQLiteIndexRankings()
         return sqlite_index_ranking.select(journal=journal)
 
@@ -104,8 +104,7 @@ class LocalIndex:
         return retrieved_record
 
     def search(self, query: str) -> list[colrev.record.record.Record]:
-        """Run a search for records"""
-
+        """Run a search for records."""
         try:
             self.thread_lock.acquire(timeout=60)
             sqlite_index_record = colrev.env.local_index_sqlite.SQLiteIndexRecord()
@@ -123,8 +122,7 @@ class LocalIndex:
         return records_to_return
 
     def get_year_from_toc(self, record_dict: dict) -> str:
-        """Determine the year of a paper based on its table-of-content (journal-volume-number)"""
-
+        """Determine the year of a paper based on its table-of-content (journal-volume-number)."""
         try:
             sqlite_index_toc = colrev.env.local_index_sqlite.SQLiteIndexTOC()
             toc_key = colrev.record.record.Record(record_dict).get_toc_key()
@@ -207,8 +205,7 @@ class LocalIndex:
         include_file: bool = False,
         search_across_tocs: bool = False,
     ) -> colrev.record.record.Record:
-        """Retrieve a record from the toc (table-of-contents)"""
-
+        """Retrieve a record from the toc (table-of-contents)."""
         # Note: in NotTOCIdentifiableException cases, we still need a toc_key.
         # to accomplish this, the get_toc_key() may acced an "accept_incomplete" flag
         try:
@@ -255,9 +252,8 @@ class LocalIndex:
     def retrieve_based_on_colrev_pdf_id(
         self, *, colrev_pdf_id: str
     ) -> colrev.record.record.Record:
-        """
-        Convenience function to retrieve the indexed record_dict metadata
-        based on a colrev_pdf_id
+        """Convenience function to retrieve the indexed record_dict metadata
+        based on a colrev_pdf_id.
         """
         try:
             sqlite_index_record = colrev.env.local_index_sqlite.SQLiteIndexRecord()
@@ -277,11 +273,9 @@ class LocalIndex:
         include_file: bool = False,
         include_colrev_ids: bool = False,
     ) -> colrev.record.record.Record:
+        """Convenience function to retrieve the indexed record_dict metadata
+        based on another record_dict.
         """
-        Convenience function to retrieve the indexed record_dict metadata
-        based on another record_dict
-        """
-
         # To avoid modifications to the original record
         record_dict = deepcopy(record_dict)
 
@@ -342,7 +336,8 @@ class LocalIndex:
 
     def get_fields_to_remove(self, record_dict: dict) -> list:
         """Compares the record to available toc items and
-        returns fields to remove (if any), such as the volume or number."""
+        returns fields to remove (if any), such as the volume or number.
+        """
         # pylint: disable=too-many-return-statements
 
         fields_to_remove: typing.List[str] = []
@@ -396,7 +391,7 @@ class LocalIndex:
         return fields_to_remove
 
     def get_curations(self) -> list[Path]:
-        """Get the directories of curations"""
+        """Get the directories of curations."""
         return [
             Path(x["repo_source_path"])
             for x in self.environment_manager.local_repos()

--- a/colrev/env/local_index_builder.py
+++ b/colrev/env/local_index_builder.py
@@ -36,7 +36,7 @@ from colrev.writer.write_utils import to_string
 
 
 class LocalIndexBuilder:
-    """The LocalIndexBuilder implements indexing functionality"""
+    """The LocalIndexBuilder implements indexing functionality."""
 
     def __init__(
         self,
@@ -50,8 +50,7 @@ class LocalIndexBuilder:
         self.thread_lock = Lock()
 
     def reinitialize_sqlite_db(self) -> None:
-        """Reinitialize the SQLITE database ()"""
-
+        """Reinitialize the SQLITE database ()."""
         Filepaths.LOCAL_INDEX_SQLITE_FILE.unlink(missing_ok=True)
         colrev.env.local_index_sqlite.SQLiteIndexRecord(reinitialize=True)
         colrev.env.local_index_sqlite.SQLiteIndexTOC(reinitialize=True)
@@ -134,8 +133,7 @@ class LocalIndexBuilder:
         item_to_add: dict,
         curated_fields: list,
     ) -> None:
-        """Adds layered fields to amend existing records"""
-
+        """Adds layered fields to amend existing records."""
         item_record_dict = colrev.loader.load_utils.loads(
             load_string=item_to_add[LocalIndexFields.BIBTEX],
             implementation="bib",
@@ -176,8 +174,7 @@ class LocalIndexBuilder:
         curated_masterdata: bool,
         curated_fields: list,
     ) -> None:
-        """Index a CoLRev project"""
-
+        """Index a CoLRev project."""
         recs_to_index = []
         toc_to_index: typing.Dict[str, str] = {}
         for record_dict in tqdm(records.values()):
@@ -263,7 +260,7 @@ class LocalIndexBuilder:
         return masterdata_curations
 
     def index_colrev_project(self, repo_source_path: Path) -> None:  # pragma: no cover
-        """Index a CoLRev project"""
+        """Index a CoLRev project."""
         try:
             if not Path(repo_source_path).is_dir():
                 print(f"Warning {repo_source_path} not a directory")
@@ -322,8 +319,7 @@ class LocalIndexBuilder:
             print(exc)
 
     def index(self) -> None:  # pragma: no cover
-        """Index all registered CoLRev projects"""
-
+        """Index all registered CoLRev projects."""
         # Note : this task takes long and does not need to run often
         session = requests_cache.CachedSession(
             str(Filepaths.PREP_REQUESTS_CACHE_FILE),
@@ -396,8 +392,7 @@ class LocalIndexBuilder:
         )
 
     def index_journal_rankings(self) -> None:
-        """Indexes journal rankings in sqlite database"""
-
+        """Indexes journal rankings in sqlite database."""
         filedata = colrev.env.utils.get_package_file_content(
             module="colrev.env", filename=Path("journal_rankings.csv")
         )

--- a/colrev/env/local_index_prep.py
+++ b/colrev/env/local_index_prep.py
@@ -155,7 +155,6 @@ def prepare_record_for_return(
     include_colrev_ids: bool = False,
 ) -> colrev.record.record.Record:
     """Prepare record for return from LocalIndex."""
-
     # Note: record['file'] should be an absolute path by definition
     # when stored in the LocalIndex
     if Fields.FILE in record_dict and not Path(record_dict[Fields.FILE]).is_file():

--- a/colrev/env/local_index_sqlite.py
+++ b/colrev/env/local_index_sqlite.py
@@ -46,7 +46,7 @@ from colrev.constants import LocalIndexFields
 
 # pylint: disable=too-few-public-methods
 class SQLiteIndex:
-    """The SQLiteIndex class implements indexing and retrieval of records locally"""
+    """The SQLiteIndex class implements indexing and retrieval of records locally."""
 
     connection: sqlite3.Connection
     CREATE_TABLE_QUERY: str
@@ -73,13 +73,12 @@ class SQLiteIndex:
         return self.connection.cursor()
 
     def commit(self) -> None:
-        """Commit changes to the SQLITE database"""
+        """Commit changes to the SQLITE database."""
         if self.connection:
             self.connection.commit()
 
     def _reinitialize_db(self) -> None:
-        """Reinitialize the SQLITE database"""
-
+        """Reinitialize the SQLITE database."""
         cur = self._get_cursor()
         cur.execute(f"drop table if exists {self.index_name}")
         cur.execute(self.CREATE_TABLE_QUERY)
@@ -103,7 +102,7 @@ class SQLiteIndex:
 
 
 class SQLiteIndexRecord(SQLiteIndex):
-    """The SQLiteIndexRecord class implements indexing and retrieval of records locally"""
+    """The SQLiteIndexRecord class implements indexing and retrieval of records locally."""
 
     INDEX_NAME = "record_index"
     KEYS = [
@@ -164,7 +163,7 @@ class SQLiteIndexRecord(SQLiteIndex):
         *,
         local_index_id: str,
     ) -> bool:
-        """Check if a record exists in the index"""
+        """Check if a record exists in the index."""
         cur = self._get_cursor()
         cur.execute(
             self.SELECT_KEY_QUERIES[LocalIndexFields.ID],
@@ -176,7 +175,7 @@ class SQLiteIndexRecord(SQLiteIndex):
         return True
 
     def insert(self, item: dict) -> None:
-        """Insert a record into the index"""
+        """Insert a record into the index."""
         # May raise sqlite3.IntegrityError
         cur = self._get_cursor()
         cur.execute(self.INSERT_QUERY, item)
@@ -188,7 +187,7 @@ class SQLiteIndexRecord(SQLiteIndex):
         key: str,
         value: str,
     ) -> dict:
-        """Get a record from the index"""
+        """Get a record from the index."""
         try:
             cur = self._get_cursor()
             cur.execute(self.SELECT_KEY_QUERIES[key], (value,))
@@ -237,12 +236,12 @@ class SQLiteIndexRecord(SQLiteIndex):
         return retrieved_record
 
     def update(self, local_index_id: str, bibtex: str) -> None:
-        """Update a record in the index"""
+        """Update a record in the index."""
         cur = self._get_cursor()
         cur.execute(self.UPDATE_RECORD_QUERY, (bibtex, local_index_id))
 
     def search(self, query: str) -> list:
-        """Search for records in the index"""
+        """Search for records in the index."""
         cur = self._get_cursor()
         records_to_return = []
 
@@ -257,7 +256,8 @@ class SQLiteIndexRecord(SQLiteIndex):
 
 class SQLiteIndexRankings(SQLiteIndex):
     """The SQLiteIndexRankings class implements indexing and retrieval
-    of journal rankings locally"""
+    of journal rankings locally.
+    """
 
     INDEX_NAME = "rankings"
     KEYS: typing.List[str] = []
@@ -273,15 +273,14 @@ class SQLiteIndexRankings(SQLiteIndex):
         )
 
     def insert_df(self, data_frame: pd.DataFrame) -> None:
-        """Insert a dataframe of journal rankings into the index"""
+        """Insert a dataframe of journal rankings into the index."""
         conn = sqlite3.connect(str(Filepaths.LOCAL_INDEX_SQLITE_FILE))
         data_frame.to_sql(self.INDEX_NAME, conn, if_exists="replace", index=False)
         conn.commit()
         conn.close()
 
     def select(self, journal: str) -> list:
-        """Select journal rankings from the index"""
-
+        """Select journal rankings from the index."""
         cur = self._get_cursor()
         cur.execute(self.SELECT_QUERY, (journal,))
         rankings = cur.fetchall()
@@ -289,7 +288,7 @@ class SQLiteIndexRankings(SQLiteIndex):
 
 
 class SQLiteIndexTOC(SQLiteIndex):
-    """The SQLiteIndexTOC class implements indexing and retrieval of TOC items locally"""
+    """The SQLiteIndexTOC class implements indexing and retrieval of TOC items locally."""
 
     INDEX_NAME = "toc_index"
     KEYS: typing.List[str] = []
@@ -314,7 +313,7 @@ class SQLiteIndexTOC(SQLiteIndex):
         )
 
     def exists(self, toc_item: str) -> bool:
-        """Check if TOC item exists in the index"""
+        """Check if TOC item exists in the index."""
         cur = self._get_cursor()
         cur.execute(
             self.SELECT_KEY_QUERY[LocalIndexFields.TOC_KEY],
@@ -326,7 +325,7 @@ class SQLiteIndexTOC(SQLiteIndex):
         return True
 
     def get_toc_items(self, toc_key: str = "", partial_toc_key: str = "") -> list:
-        """Get TOC items from the index"""
+        """Get TOC items from the index."""
         if partial_toc_key != "":
             query = f"{self.SELECT_ALL_QUERY} {LocalIndexFields.TOC_KEY} LIKE ?"
             argument = partial_toc_key + "%"
@@ -356,7 +355,7 @@ class SQLiteIndexTOC(SQLiteIndex):
         return toc_items
 
     def add(self, toc_to_index: dict) -> None:
-        """Add TOC items to the index"""
+        """Add TOC items to the index."""
         list_to_add = list((k, v) for k, v in toc_to_index.items() if v != "DROPPED")
         cur = self._get_cursor()
         try:

--- a/colrev/env/resources.py
+++ b/colrev/env/resources.py
@@ -12,13 +12,12 @@ from colrev.constants import Filepaths
 
 
 class Resources:
-    """Class for curated CoLRev resourcs (metadata repositories, annotators)"""
+    """Class for curated CoLRev resourcs (metadata repositories, annotators)."""
 
     # pylint: disable=too-few-public-methods
 
     def install_curated_resource(self, *, curated_resource: str) -> bool:
-        """Install a curated resource"""
-
+        """Install a curated resource."""
         if "http" not in curated_resource:
             curated_resource = "https://github.com/" + curated_resource
         Filepaths.CURATIONS_PATH.mkdir(exist_ok=True, parents=True)

--- a/colrev/env/tei_parser.py
+++ b/colrev/env/tei_parser.py
@@ -35,7 +35,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class TEIParser:
-    """Environment service for TEI parsing"""
+    """Environment service for TEI parsing."""
 
     ns = {
         "tei": "{http://www.tei-c.org/ns/1.0}",
@@ -56,7 +56,7 @@ class TEIParser:
         modes of operation:
         - pdf_path: create TEI and temporarily store in self.data
         - pfd_path and tei_path: create TEI and save in tei_path
-        - tei_path: read TEI from file
+        - tei_path: read TEI from file.
         """
         # pylint: disable=consider-using-with
         assert pdf_path is not None or tei_path is not None
@@ -89,7 +89,7 @@ class TEIParser:
             self.root = self._read_from_tei()  # type: ignore
 
     def _read_from_tei(self):  # type: ignore
-        """Read a TEI from file"""
+        """Read a TEI from file."""
         with open(self.tei_path, "rb") as data:
             xslt_content = data.read()
 
@@ -99,7 +99,7 @@ class TEIParser:
         return DefusedET.fromstring(xslt_content)
 
     def _create_tei(self) -> None:
-        """Create the TEI (based on GROBID)"""
+        """Create the TEI (based on GROBID)."""
         grobid_service = colrev.env.grobid_service.GrobidService()
         grobid_service.start()
         # Note: we have more control and transparency over the consolidation
@@ -154,7 +154,7 @@ class TEIParser:
             raise colrev_exceptions.TEITimeoutException() from exc
 
     def get_tei_str(self) -> str:
-        """Get the TEI string"""
+        """Get the TEI string."""
         try:
             register_namespace("tei", "http://www.tei-c.org/ns/1.0")
             return tostring(self.root, encoding="unicode")
@@ -162,7 +162,7 @@ class TEIParser:
             raise colrev_exceptions.TEIException from exc
 
     def get_grobid_version(self) -> str:
-        """Get the GROBID version used for TEI creation"""
+        """Get the GROBID version used for TEI creation."""
         grobid_version = ""
         encoding_description = self.root.find(".//" + self.ns["tei"] + "encodingDesc")
         if encoding_description is not None:
@@ -251,7 +251,7 @@ class TEIParser:
         return doi
 
     def get_abstract(self) -> str:
-        """Get the abstract"""
+        """Get the abstract."""
         html_tag_regex = re.compile("<.*?>")
 
         def cleanhtml(raw_html: str) -> str:
@@ -271,7 +271,7 @@ class TEIParser:
         return abstract_text
 
     def get_metadata(self) -> dict:
-        """Get the metadata of the PDF (title, author, ...) as a dict"""
+        """Get the metadata of the PDF (title, author, ...) as a dict."""
         reference = self.root.find(".//" + self.ns["tei"] + "sourceDesc").find(
             ".//" + self.ns["tei"] + "biblStruct"
         )
@@ -302,7 +302,7 @@ class TEIParser:
         return keywords
 
     def get_author_details(self) -> list:
-        """Get the author details"""
+        """Get the author details."""
         author_details = []
 
         file_description = self.root.find(".//" + self.ns["tei"] + "sourceDesc")
@@ -651,7 +651,7 @@ class TEIParser:
             yield paragraph_text
 
     def get_references(self, *, add_intext_citation_count: bool = False) -> list:
-        """Get the bibliography (references section) as a list of record dicts"""
+        """Get the bibliography (references section) as a list of record dicts."""
         # Note : could also allow top-10 % of most frequent in-text citations
 
         #  https://epidoc.stoa.org/gl/latest/ref-title.html
@@ -671,7 +671,7 @@ class TEIParser:
         return tei_bib_db
 
     def get_citations_per_section(self) -> dict:
-        """Get a dict of section-names and list-of-citations"""
+        """Get a dict of section-names and list-of-citations."""
         section_citations = {}
         parent_map = {c: p for p in self.root.iter() for c in p}
         sections = self.root.iter(f'{self.ns["tei"]}head')
@@ -691,7 +691,7 @@ class TEIParser:
         return section_citations
 
     def mark_references(self, *, records: dict):  # type: ignore
-        """Mark references with the additional record ID"""
+        """Mark references with the additional record ID."""
         tei_records = self.get_references()
         for record_dict in tei_records:
             if Fields.TITLE not in record_dict:
@@ -756,7 +756,7 @@ def _add_doi_from_pdf_if_not_available(record_dict: dict) -> None:
 # curl -v --form input=@./thefile.pdf -H "Accept: application/x-bibtex"
 # -d "consolidateHeader=0" localhost:8070/api/processHeaderDocument
 def get_record_from_pdf(file_path: Path, *, add_doi_from_pdf: bool = False) -> dict:
-    """Get a record dict form a pdf file_path"""
+    """Get a record dict form a pdf file_path."""
     if file_path.suffix != ".pdf":
         raise ValueError
 

--- a/colrev/env/utils.py
+++ b/colrev/env/utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Collection of utility functions"""
+"""Collection of utility functions."""
 
 import operator
 import pkgutil
@@ -19,7 +19,7 @@ import colrev.exceptions as colrev_exceptions
 
 
 def retrieve_package_file(*, template_file: Path, target: Path) -> None:
-    """Retrieve a file from the CoLRev package"""
+    """Retrieve a file from the CoLRev package."""
     try:
         filedata = pkgutil.get_data("colrev", str(template_file))
         if filedata:
@@ -35,12 +35,12 @@ def retrieve_package_file(*, template_file: Path, target: Path) -> None:
 def get_package_file_content(
     *, module: str, filename: Path
 ) -> typing.Union[bytes, None]:
-    """Get the content of a file in the CoLRev package"""
+    """Get the content of a file in the CoLRev package."""
     return pkgutil.get_data(module, str(filename))
 
 
 def inplace_change(*, filename: Path, old_string: str, new_string: str) -> None:
-    """Replace a string in a file"""
+    """Replace a string in a file."""
     with open(filename, encoding="utf8") as file:
         content = file.read()
         if old_string not in content:
@@ -51,7 +51,7 @@ def inplace_change(*, filename: Path, old_string: str, new_string: str) -> None:
 
 
 def get_template(template_path: str) -> Template:
-    """Load a jinja template"""
+    """Load a jinja template."""
     environment = Environment(
         loader=FunctionLoader(_load_jinja_template), autoescape=True
     )
@@ -74,16 +74,14 @@ def _load_jinja_template(template_path: str) -> str:
 
 
 def remove_accents(input_str: str) -> str:
-    """Replace the accents in a string"""
-
+    """Replace the accents in a string."""
     nfkd_form = unicodedata.normalize("NFKD", input_str)
     wo_ac_list = [c for c in nfkd_form if not unicodedata.combining(c)]
     return "".join(wo_ac_list)
 
 
 def percent_upper_chars(input_string: str) -> float:
-    """Get the percentage of upper-case characters in a string"""
-
+    """Get the percentage of upper-case characters in a string."""
     input_string = re.sub(r"[^a-zA-Z]", "", input_string)
     if len(input_string) == 0:
         return 0.0
@@ -91,7 +89,7 @@ def percent_upper_chars(input_string: str) -> float:
 
 
 def custom_asdict_factory(data) -> dict:  # type: ignore
-    """Custom asdict factory for (dataclass)object-to-dict conversion"""
+    """Custom asdict factory for (dataclass)object-to-dict conversion."""
 
     def convert_value(obj: object) -> object:
         if isinstance(obj, list):
@@ -113,7 +111,7 @@ def custom_asdict_factory(data) -> dict:  # type: ignore
 
 
 def load_complementary_material_keywords() -> list:
-    """Load the list of keywords identifying complementary materials"""
+    """Load the list of keywords identifying complementary materials."""
     complementary_material_keywords = []
     filedata = get_package_file_content(
         module="colrev.env", filename=Path("complementary_material_keywords.txt")
@@ -125,8 +123,7 @@ def load_complementary_material_keywords() -> list:
 
 
 def load_complementary_material_strings() -> list:
-    """Load the list of exact strings identifying complementary materials"""
-
+    """Load the list of exact strings identifying complementary materials."""
     complementary_material_keywords = []
     filedata = get_package_file_content(
         module="colrev.env", filename=Path("complementary_material_strings.txt")
@@ -138,8 +135,7 @@ def load_complementary_material_strings() -> list:
 
 
 def load_complementary_material_prefixes() -> list:
-    """Load the list of prefixes identifying complementary materials"""
-
+    """Load the list of prefixes identifying complementary materials."""
     complementary_material_keywords = []
     filedata = get_package_file_content(
         module="colrev.env", filename=Path("complementary_material_prefixes.txt")
@@ -152,12 +148,11 @@ def load_complementary_material_prefixes() -> list:
 
 def get_by_path(root: dict, items: typing.List[str]) -> typing.Any:
     """Access a nested object in root by item sequence."""
-
     return reduce(operator.getitem, items, root)
 
 
 def dict_set_nested(root: dict, keys: typing.List[str], value: typing.Any) -> None:
-    """Set dict value by nested key, this works on empty dict"""
+    """Set dict value by nested key, this works on empty dict."""
     for key in keys[:-1]:
         root = root.setdefault(key, {})
     root[keys[-1]] = value

--- a/colrev/exceptions.py
+++ b/colrev/exceptions.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Exceptions"""
+"""Exceptions."""
 
 from __future__ import annotations
 
@@ -10,15 +10,11 @@ from colrev.constants import Colors
 
 
 class CoLRevException(Exception):
-    """
-    Base class for all exceptions raised by this package
-    """
+    """Base class for all exceptions raised by this package."""
 
 
 class RepoSetupError(CoLRevException):
-    """
-    The project files are not properly set up as a CoLRev project.
-    """
+    """The project files are not properly set up as a CoLRev project."""
 
     lr_docs = (
         "https://colrev-environment.github.io/colrev/manual/problem_formulation.html"
@@ -70,8 +66,7 @@ class RepoSetupError(CoLRevException):
 
 
 class CoLRevUpgradeError(CoLRevException):
-    """
-    The version of the local CoLRev package does not match with the CoLRev version
+    """The version of the local CoLRev package does not match with the CoLRev version
     used to create the latest commit in the project.
     An explicit upgrade of the data structures is needed.
     """
@@ -85,8 +80,7 @@ class CoLRevUpgradeError(CoLRevException):
 
 
 class ReviewManagerNotNotifiedError(CoLRevException):
-    """
-    The ReviewManager was not notified about the operation.
+    """The ReviewManager was not notified about the operation.
 
     ``Dataset.load_records_dict()`` refuses to return data until the review
     manager knows which operation is about to run. It expects the
@@ -133,9 +127,7 @@ class ReviewManagerNotNotifiedError(CoLRevException):
 
 
 class ParameterError(CoLRevException):
-    """
-    An invalid parameter was passed to CoLRev.
-    """
+    """An invalid parameter was passed to CoLRev."""
 
     def __init__(self, *, parameter: str, value: str, options: list) -> None:
         options_string = "\n  - ".join(sorted(options))
@@ -146,9 +138,7 @@ class ParameterError(CoLRevException):
 
 
 class InvalidSettingsError(CoLRevException):
-    """
-    Invalid value in SETTINGS_FILE.
-    """
+    """Invalid value in SETTINGS_FILE."""
 
     def __init__(self, *, msg: str, fix_per_upgrade: bool = True) -> None:
         msg = f"Error in SETTINGS_FILE: {msg}"
@@ -164,9 +154,7 @@ class InvalidSettingsError(CoLRevException):
 
 
 class UnstagedGitChangesError(CoLRevException):
-    """
-    Unstaged git changes were found although a clean repository is required.
-    """
+    """Unstaged git changes were found although a clean repository is required."""
 
     def __init__(self, changedFiles: list) -> None:
         self.message = (
@@ -176,9 +164,7 @@ class UnstagedGitChangesError(CoLRevException):
 
 
 class CleanRepoRequiredError(CoLRevException):
-    """
-    A clean git repository would be required.
-    """
+    """A clean git repository would be required."""
 
     def __init__(self, changedFiles: list, ignore_pattern: str) -> None:
         self.message = (
@@ -189,9 +175,7 @@ class CleanRepoRequiredError(CoLRevException):
 
 
 class GitConflictError(CoLRevException):
-    """
-    There are git conflicts to be resolved before resuming operations.
-    """
+    """There are git conflicts to be resolved before resuming operations."""
 
     def __init__(self, path: Path) -> None:
         self.message = f"please resolve git conflict in {path}"
@@ -199,9 +183,7 @@ class GitConflictError(CoLRevException):
 
 
 class DirtyRepoAfterProcessingError(CoLRevException):
-    """
-    The git repository was not clean after completing the operation.
-    """
+    """The git repository was not clean after completing the operation."""
 
     def __init__(self, msg: str) -> None:
         self.message = msg
@@ -209,9 +191,7 @@ class DirtyRepoAfterProcessingError(CoLRevException):
 
 
 class GitNotAvailableError(CoLRevException):
-    """
-    Git is currently not available.
-    """
+    """Git is currently not available."""
 
     def __init__(self) -> None:
         self.message = "Git is currently not available (remove .git/index.lock exists)."
@@ -227,7 +207,7 @@ class AppendOnlyViolation(Exception):
 
 
 class ProcessOrderViolation(CoLRevException):
-    """The process triggered dooes not have priority"""
+    """The process triggered dooes not have priority."""
 
     def __init__(
         self,
@@ -243,7 +223,7 @@ class ProcessOrderViolation(CoLRevException):
 
 
 class StatusTransitionError(CoLRevException):
-    """An invalid status transition was observed"""
+    """An invalid status transition was observed."""
 
     def __init__(self, msg: str) -> None:
         self.message = f" {msg}"
@@ -315,7 +295,8 @@ class NotEnoughDataToIdentifyException(CoLRevException):
 class NotTOCIdentifiableException(CoLRevException):
     """The record cannot be identified through table-of-contents.
     Either the table-of-contents key is not implemented or
-    the ENTRYTPE is not organized in tables-of-contents (e.g., online)."""
+    the ENTRYTPE is not organized in tables-of-contents (e.g., online).
+    """
 
     def __init__(self, msg: typing.Optional[str] = None) -> None:
         self.message = msg
@@ -474,7 +455,7 @@ class RecordNotFoundInPrepSourceException(CoLRevException):
 
 
 class DedupeError(CoLRevException):
-    """An exception in the dedupe operation"""
+    """An exception in the dedupe operation."""
 
     def __init__(self, message: str) -> None:
         self.message = message
@@ -485,7 +466,7 @@ class DedupeError(CoLRevException):
 
 
 class DataException(CoLRevException):
-    """Exception in the data operation"""
+    """Exception in the data operation."""
 
     def __init__(self, *, msg: str) -> None:
         self.message = msg
@@ -578,11 +559,11 @@ class PortAlreadyRegisteredException(CoLRevException):
 
 
 class TEITimeoutException(CoLRevException):
-    """A timeout occurred during TEI generation"""
+    """A timeout occurred during TEI generation."""
 
 
 class TEIException(CoLRevException):
-    """An exception related to the TEI format"""
+    """An exception related to the TEI format."""
 
 
 class RecordNotInIndexException(CoLRevException):

--- a/colrev/git_repo.py
+++ b/colrev/git_repo.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Git repository wrapper for CoLRev"""
+"""Git repository wrapper for CoLRev."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
 
 
 class GitRepo:
-    """Wrapper for Git repository interactions"""
+    """Wrapper for Git repository interactions."""
 
     def __init__(self, path: typing.Optional[Path]) -> None:
         self.path = path if path else Path.cwd()
@@ -42,7 +42,7 @@ class GitRepo:
         )
 
     def repo_initialized(self) -> bool:
-        """Check whether the repository is initialized"""
+        """Check whether the repository is initialized."""
         try:
             self.repo.head.commit
         except ValueError:
@@ -50,13 +50,13 @@ class GitRepo:
         return True
 
     def has_record_changes(self, *, change_type: str = "all") -> bool:
-        """Check whether the records have changes"""
+        """Check whether the records have changes."""
         return self.has_changes(
             Path(self.path / "data" / "records.bib"), change_type=change_type
         )
 
     def has_changes(self, relative_path: Path, *, change_type: str = "all") -> bool:
-        """Check whether the relative path (or the git repository) has changes"""
+        """Check whether the relative path (or the git repository) has changes."""
         assert change_type in [
             "all",
             "staged",
@@ -86,7 +86,7 @@ class GitRepo:
     def update_gitignore(
         self, *, add: typing.Optional[list] = None, remove: typing.Optional[list] = None
     ) -> None:
-        """Update the gitignore file by adding or removing particular paths"""
+        """Update the gitignore file by adding or removing particular paths."""
         git_ignore_file = self.path / Path(".gitignore")
         if git_ignore_file.is_file():
             gitignore_content = git_ignore_file.read_text(encoding="utf-8")
@@ -114,7 +114,7 @@ class GitRepo:
     def add_changes(
         self, path: Path, *, remove: bool = False, ignore_missing: bool = False
     ) -> None:
-        """Add changed file to git"""
+        """Add changed file to git."""
         if path.is_absolute():
             path = path.relative_to(self.path)
         path_str = str(path).replace("\\", "/")
@@ -130,11 +130,11 @@ class GitRepo:
                 raise exc
 
     def get_untracked_files(self) -> list[Path]:
-        """Get the files that are untracked by git"""
+        """Get the files that are untracked by git."""
         return [Path(x) for x in self.repo.untracked_files]
 
     def records_changed(self) -> bool:
-        """Check whether the records were changed"""
+        """Check whether the records were changed."""
         main_recs_changed = "data/records.bib" in [
             item.a_path for item in self.repo.index.diff(None)
         ] + [x.a_path for x in self.repo.head.commit.diff()]
@@ -152,7 +152,7 @@ class GitRepo:
         skip_status_yaml: bool = False,
         skip_hooks: bool = True,
     ) -> bool:
-        """Create a commit (including a commit report)"""
+        """Create a commit (including a commit report)."""
         # pylint: disable=import-outside-toplevel
         # pylint: disable=redefined-outer-name
         import colrev.ops.commit
@@ -172,11 +172,11 @@ class GitRepo:
         return ret
 
     def file_in_history(self, filepath: Path) -> bool:
-        """Check whether a file is in the git history"""
+        """Check whether a file is in the git history."""
         return str(filepath) in [o.path for o in self.repo.head.commit.tree.traverse()]
 
     def get_commit_message(self, *, commit_nr: int) -> str:
-        """Get the commit message for commit #"""
+        """Get the commit message for commit #."""
         master = self.repo.head.reference
         assert commit_nr == 0  # extension : implement other cases
         if commit_nr == 0:
@@ -185,12 +185,12 @@ class GitRepo:
         return ""
 
     def add_setting_changes(self) -> None:
-        """Add changes in settings to git"""
+        """Add changes in settings to git."""
         self._sleep_util_git_unlocked()
         self.repo.index.add([str(self.path / "settings.json")])
 
     def has_untracked_search_records(self) -> bool:
-        """Check whether there are untracked search records"""
+        """Check whether there are untracked search records."""
         return any(
             str(Path("data/search")) in str(untracked_file)
             for untracked_file in self.get_untracked_files()
@@ -202,16 +202,16 @@ class GitRepo:
         return "No local changes to save" != ret
 
     def get_last_commit_sha(self) -> str:  # pragma: no cover
-        """Get the last commit sha"""
+        """Get the last commit sha."""
         return str(self.repo.head.commit.hexsha)
 
     def get_tree_hash(self) -> str:  # pragma: no cover
-        """Get the current tree hash"""
+        """Get the current tree hash."""
         tree_hash = self.repo.git.execute(["git", "write-tree"])
         return str(tree_hash)
 
     def get_last_updated(self, feed_file: Path) -> str:
-        """Returns the date of the last update (if available) in YYYY-MM-DD format"""
+        """Returns the date of the last update (if available) in YYYY-MM-DD format."""
         if not feed_file.is_file():
             return ""
         return self.get_last_commit_date(feed_file)
@@ -240,7 +240,7 @@ class GitRepo:
         return [nr_commits_behind, nr_commits_ahead]
 
     def behind_remote(self) -> bool:  # pragma: no cover
-        """Check whether the repository is behind the remote"""
+        """Check whether the repository is behind the remote."""
         nr_commits_behind = 0
         connected_remote = 0 != len(self.repo.remotes)
         if connected_remote:
@@ -255,7 +255,7 @@ class GitRepo:
         return False
 
     def remote_ahead(self) -> bool:  # pragma: no cover
-        """Check whether the remote is ahead"""
+        """Check whether the remote is ahead."""
         connected_remote = 0 != len(self.repo.remotes)
         if connected_remote:
             origin = self.repo.remotes.origin
@@ -269,13 +269,13 @@ class GitRepo:
         return False
 
     def pull_if_repo_clean(self) -> None:  # pragma: no cover
-        """Pull project if repository is clean"""
+        """Pull project if repository is clean."""
         if not self.repo.is_dirty():
             origin = self.repo.remotes.origin
             origin.pull()
 
     def get_remote_url(self) -> str:  # pragma: no cover
-        """Get the remote url"""
+        """Get the remote url."""
         remote_url = "NA"
         for remote in self.repo.remotes:
             if remote.name == "origin":
@@ -283,6 +283,6 @@ class GitRepo:
         return remote_url
 
     def get_last_commit_date(self, filename: Path) -> str:
-        """Get the last commit date for a file"""
+        """Get the last commit date for a file."""
         last_commit = next(self.repo.iter_commits(paths=filename))
         return last_commit.committed_datetime.isoformat()

--- a/colrev/hooks/__init__.py
+++ b/colrev/hooks/__init__.py
@@ -34,7 +34,8 @@
             entry: colrev-hooks-share
             language: python
             stages: [push]
-            pass_filenames: false"""
+            pass_filenames: false
+"""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/hooks/check.py
+++ b/colrev/hooks/check.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""Hook to check CoLRev repositories"""
+"""Hook to check CoLRev repositories."""
 
 import colrev.review_manager
 
 
 def main() -> int:
-    """Main entrypoint for the checks"""
-
+    """Main entrypoint for the checks."""
     review_manager = colrev.review_manager.ReviewManager()
     ret = review_manager.check_repo()
     print(ret)

--- a/colrev/hooks/format.py
+++ b/colrev/hooks/format.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""Hook to format CoLRev repositories"""
+"""Hook to format CoLRev repositories."""
 
 import colrev.review_manager
 
 
 def main() -> int:
-    """Main entrypoint for the formating"""
-
+    """Main entrypoint for the formating."""
     review_manager = colrev.review_manager.ReviewManager()
     ret = review_manager.dataset.format_records_file()
 

--- a/colrev/hooks/report.py
+++ b/colrev/hooks/report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Hook for reporting in CoLRev projects"""
+"""Hook for reporting in CoLRev projects."""
 
 import sys
 from pathlib import Path
@@ -11,8 +11,7 @@ from colrev.constants import ExitCodes
 
 
 def main() -> int:
-    """Main entrypoint for the reporting"""
-
+    """Main entrypoint for the reporting."""
     print(sys.argv)
     msgfile = Path(sys.argv[1])
     review_manager = colrev.review_manager.ReviewManager()

--- a/colrev/hooks/share.py
+++ b/colrev/hooks/share.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""Hook for sharing in CoLRev repositories"""
+"""Hook for sharing in CoLRev repositories."""
 
 import colrev.review_manager
 from colrev.constants import OperationsType
 
 
 def main() -> int:
-    """Main entrypoint for the hook"""
-
+    """Main entrypoint for the hook."""
     review_manager = colrev.review_manager.ReviewManager()
     review_manager.notified_next_operation = OperationsType.check
     advisor = review_manager.get_advisor()

--- a/colrev/linter/colrev_direct_status_assign.py
+++ b/colrev/linter/colrev_direct_status_assign.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Linter for CoLRev - direct status assignment"""
+"""Linter for CoLRev - direct status assignment."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class DirectStatusAssignmentChecker(checkers.BaseChecker):
-    """DirectStatusAssignmentChecker"""
+    """DirectStatusAssignmentChecker."""
 
     name = "colrev-direct-status-assign"
 
@@ -31,10 +31,7 @@ class DirectStatusAssignmentChecker(checkers.BaseChecker):
 
     @only_required_for_messages("colrev-direct-status-assign")
     def visit_assign(self, node: nodes.Assign) -> None:
-        """
-        Detect direct assignment of colrev_status.
-        """
-
+        """Detect direct assignment of colrev_status."""
         if len(node.targets) != 1 or not hasattr(
             node.targets[0], "slice"
         ):  # pragma: no cover
@@ -47,9 +44,7 @@ class DirectStatusAssignmentChecker(checkers.BaseChecker):
 
     @only_required_for_messages("colrev-direct-status-assign")
     def visit_call(self, node: nodes.Assign) -> None:
-        """
-        Detect direct assignment of colrev_status.
-        """
+        """Detect direct assignment of colrev_status."""
         if isinstance(node.func, nodes.Attribute) and node.func.attrname == "update":
             for keyword in node.keywords:
                 if keyword.arg == "colrev_status":
@@ -58,5 +53,4 @@ class DirectStatusAssignmentChecker(checkers.BaseChecker):
 
 def register(linter: PyLinter) -> None:  # pragma: no cover
     """Required method to auto register this checker."""
-
     linter.register_checker(DirectStatusAssignmentChecker(linter))

--- a/colrev/linter/colrev_missed_constant_usage.py
+++ b/colrev/linter/colrev_missed_constant_usage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Linter for CoLRev - missed constant usage"""
+"""Linter for CoLRev - missed constant usage."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class MissedConstantUsageChecker(checkers.BaseChecker):
-    """MissedConstantUsageChecker"""
+    """MissedConstantUsageChecker."""
 
     name = "colrev-missed-constant-usage"
 
@@ -50,10 +50,7 @@ class MissedConstantUsageChecker(checkers.BaseChecker):
 
     @only_required_for_messages("colrev-missed-constant-usage")
     def visit_assign(self, node: nodes.Assign) -> None:
-        """
-        Detect missed constant usage.
-        """
-
+        """Detect missed constant usage."""
         if len(node.targets) != 1:
             return
 
@@ -74,5 +71,4 @@ class MissedConstantUsageChecker(checkers.BaseChecker):
 
 def register(linter: PyLinter) -> None:  # pragma: no cover
     """Required method to auto register this checker."""
-
     linter.register_checker(MissedConstantUsageChecker(linter))

--- a/colrev/linter/colrev_records_variable_naming_convention.py
+++ b/colrev/linter/colrev_records_variable_naming_convention.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Linter for CoLRev – records/record naming and (light) type conventions"""
+"""Linter for CoLRev – records/record naming and (light) type conventions."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class RecordsVariableNamingConventionChecker(checkers.BaseChecker):
-    """RecordsVariableNamingConvention + simple type rules"""
+    """RecordsVariableNamingConvention + simple type rules."""
 
     name = "colrev-records-variable-naming-convention"
 
@@ -48,7 +48,6 @@ class RecordsVariableNamingConventionChecker(checkers.BaseChecker):
     )
     def visit_assign(self, node: nodes.Assign) -> None:
         """Check variable naming and simple type rules for 'record' and 'records'."""
-
         if len(node.targets) != 1:  # pragma: no cover
             return
 

--- a/colrev/linter/colrev_search_source_requests_import.py
+++ b/colrev/linter/colrev_search_source_requests_import.py
@@ -17,7 +17,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class SearchSourceRequestsImportChecker(checkers.BaseChecker):
-    """SearchSourceRequestsImportChecker"""
+    """SearchSourceRequestsImportChecker."""
 
     name = "colrev-search-source-requests-import"
 
@@ -34,7 +34,6 @@ class SearchSourceRequestsImportChecker(checkers.BaseChecker):
     @only_required_for_messages("colrev-search-source-requests-import")
     def visit_module(self, node: nodes.Module) -> None:
         """Detect requests imports in SearchSource packages."""
-
         if not any(
             self._is_search_source_class(classdef)
             for classdef in node.nodes_of_class(nodes.ClassDef)
@@ -51,7 +50,6 @@ class SearchSourceRequestsImportChecker(checkers.BaseChecker):
 
     def _is_search_source_class(self, classdef: nodes.ClassDef) -> bool:
         """Check whether class inherits from SearchSourcePackageBaseClass."""
-
         for base in classdef.bases:
             if (
                 isinstance(base, nodes.Attribute)
@@ -68,5 +66,4 @@ class SearchSourceRequestsImportChecker(checkers.BaseChecker):
 
 def register(linter: PyLinter) -> None:  # pragma: no cover
     """Required method to auto register this checker."""
-
     linter.register_checker(SearchSourceRequestsImportChecker(linter))

--- a/colrev/loader/__init__.py
+++ b/colrev/loader/__init__.py
@@ -1,4 +1,4 @@
-"""Loaders for different data formats, including BibTex, RIS, CSV/Excel files"""
+"""Loaders for different data formats, including BibTex, RIS, CSV/Excel files."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/loader/bib.py
+++ b/colrev/loader/bib.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load bib files"""
+"""Function to load bib files."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.constants import RecordState
 
 
 def run_fix_bib_file(filename: Path, *, logger: logging.Logger) -> None:
-    """Fix a BibTeX file"""
+    """Fix a BibTeX file."""
     # pylint: disable=too-many-statements
 
     def fix_key(
@@ -49,8 +49,7 @@ def run_fix_bib_file(filename: Path, *, logger: logging.Logger) -> None:
         temp_id: str,
         existing_ids: list,
     ) -> str:
-        """Get the next unique ID"""
-
+        """Get the next unique ID."""
         order = 0
         letters = list(string.ascii_lowercase)
         next_unique_id = temp_id
@@ -147,7 +146,6 @@ def run_fix_bib_file(filename: Path, *, logger: logging.Logger) -> None:
 
 def check_valid_bib(filename: Path, logger: logging.Logger) -> None:
     """Check if the file is a valid bib file."""
-
     with open(filename, encoding="utf8") as file:
         contents = "".join(line for _, line in zip(range(20), file))
 
@@ -248,8 +246,8 @@ def process_lines(
 
     Returns:
         List[Dict[str, Any]]: Parsed records.
-    """
 
+    """
     records: typing.List[typing.Dict[str, typing.Any]] = []
     current_record: typing.Dict[str, typing.Any] = {}
     current_key = ""
@@ -307,7 +305,7 @@ def process_lines(
 
 
 def run_resolve_crossref(records: dict, *, logger: logging.Logger) -> None:
-    """Resolve cross-references between records"""
+    """Resolve cross-references between records."""
     # Handle cross-references between records
     crossref_ids = []
     for record_dict in records.values():
@@ -330,7 +328,7 @@ def run_resolve_crossref(records: dict, *, logger: logging.Logger) -> None:
 
 
 class BIBLoader(colrev.loader.loader.Loader):
-    """Loads BibTeX files"""
+    """Loads BibTeX files."""
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -359,7 +357,7 @@ class BIBLoader(colrev.loader.loader.Loader):
 
     @classmethod
     def get_nr_records(cls, filename: Path) -> int:
-        """Get the number of records in the file"""
+        """Get the number of records in the file."""
         count = 0
         with open(filename, encoding="utf8") as file:
             for line in file:

--- a/colrev/loader/enl.py
+++ b/colrev/loader/enl.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load ENL files"""
+"""Function to load ENL files."""
 
 from __future__ import annotations
 
@@ -16,15 +16,15 @@ import colrev.loader.loader
 
 
 class NextLine(Exception):
-    """NextLineException"""
+    """NextLineException."""
 
 
 class ParseError(Exception):
-    """Parsing error"""
+    """Parsing error."""
 
 
 class ENLLoader(colrev.loader.loader.Loader):
-    """Loads enl files"""
+    """Loads enl files."""
 
     PATTERN = r"^%[A-Z]{1,3} "
 
@@ -56,7 +56,7 @@ class ENLLoader(colrev.loader.loader.Loader):
 
     @classmethod
     def get_nr_records(cls, filename: Path) -> int:
-        """Get the number of records in the file"""
+        """Get the number of records in the file."""
         count = 0
         with open(filename, encoding="utf-8") as file:
             for line in file:
@@ -69,7 +69,7 @@ class ENLLoader(colrev.loader.loader.Loader):
         return line[1:3].rstrip()
 
     def _get_content(self, line: str) -> str:
-        """Get the content from a line"""
+        """Get the content from a line."""
         return line[2:].strip()
 
     def _add_tag(self, tag: str, line: str) -> None:
@@ -100,8 +100,7 @@ class ENLLoader(colrev.loader.loader.Loader):
                 continue
 
     def load_records_list(self) -> list:
-        """Loads enl entries"""
-
+        """Loads enl entries."""
         # based on
         # https://github.com/MrTango/rispy/blob/main/rispy/parser.py
         # Note: skip-tags and unknown-tags can be handled

--- a/colrev/loader/json.py
+++ b/colrev/loader/json.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load JSON files"""
+"""Function to load JSON files."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ import colrev.loader.loader
 
 
 class JSONLoader(colrev.loader.loader.Loader):
-    """Loads json files"""
+    """Loads json files."""
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -42,15 +42,14 @@ class JSONLoader(colrev.loader.loader.Loader):
 
     @classmethod
     def get_nr_records(cls, filename: Path) -> int:
-        """Get the number of records in the file"""
+        """Get the number of records in the file."""
         with open(filename, encoding="utf-8-sig") as file:
             records_list = json.load(file)
 
         return len(records_list)
 
     def load_records_list(self) -> list:
-        """Load json entries"""
-
+        """Load json entries."""
         with open(self.filename, encoding="utf-8-sig") as file:
             records_list = json.load(file)
 

--- a/colrev/loader/load_utils.py
+++ b/colrev/loader/load_utils.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load files (BiBTeX, RIS, CSV, etc.)
+"""Function to load files (BiBTeX, RIS, CSV, etc.).
 
 Usage::
 
@@ -152,7 +152,7 @@ from colrev.constants import Fields
 
 
 def bib_entrytype_setter(entrytype: dict) -> None:
-    """Set the entrytype for BibTeX records"""
+    """Set the entrytype for BibTeX records."""
     if Fields.ENTRYTYPE not in entrytype:
         entrytype[Fields.ENTRYTYPE] = ENTRYTYPES.MISC
         return
@@ -177,8 +177,7 @@ def load(  # type: ignore
     empty_if_file_not_exists: bool = True,
     format_names: bool = False,
 ) -> dict:
-    """Load a file and return records as a dictionary"""
-
+    """Load a file and return records as a dictionary."""
     if isinstance(filename, str):
         filename = Path(filename)
 
@@ -231,8 +230,7 @@ def loads(  # type: ignore
     unique_id_field: str = "",
     logger: logging.Logger = logging.getLogger(__name__),
 ) -> dict:
-    """Load a string and return records as a dictionary"""
-
+    """Load a string and return records as a dictionary."""
     if implementation not in [
         "bib",
         "csv",
@@ -265,7 +263,7 @@ def loads(  # type: ignore
 def load_df(
     filename: Path,
 ) -> pd.DataFrame:
-    """Load a file and return records as a DataFrame"""
+    """Load a file and return records as a DataFrame."""
     assert isinstance(
         filename, Path
     ), f"filename must be a Path object, not {type(filename)}"
@@ -276,8 +274,7 @@ def load_df(
 def get_nr_records(  # type: ignore
     filename: Path,
 ) -> int:
-    """Get the number of records in a file"""
-
+    """Get the number of records in a file."""
     if not filename.exists():
         return 0
 

--- a/colrev/loader/load_utils_formatter.py
+++ b/colrev/loader/load_utils_formatter.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function for load formatting"""
+"""Function for load formatting."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from colrev.constants import RecordState
 
 
 class LoadFormatter:
-    """Load formatter class"""
+    """Load formatter class."""
 
     # Based on
     # https://en.wikibooks.org/wiki/LaTeX/Special_Characters
@@ -175,8 +175,7 @@ class LoadFormatter:
             ]
 
     def run(self, record: colrev.record.record.Record) -> None:
-        """Run the load formatter"""
-
+        """Run the load formatter."""
         self._apply_strict_requirements(record=record)
 
         if (

--- a/colrev/loader/load_utils_name_formatter.py
+++ b/colrev/loader/load_utils_name_formatter.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function for name formatting"""
+"""Function for name formatting."""
 
 from __future__ import annotations
 
@@ -12,8 +12,7 @@ from colrev.constants import Fields
 def split_tex_string(
     string: str, sep: str = "", strip: bool = True, filter_empty: bool = False
 ) -> list:
-    """Split a string by a separator"""
-
+    """Split a string by a separator."""
     if sep == "":
         sep = r"[\s~]+"
         filter_empty = True
@@ -45,7 +44,7 @@ def split_tex_string(
 
 
 class NameParser:
-    """Parse a name string"""
+    """Parse a name string."""
 
     def __init__(self, name: str) -> None:
         self._first: list[str] = []
@@ -56,7 +55,7 @@ class NameParser:
         self.parse_string(name)
 
     def parse_string(self, name: str) -> None:
-        """Parse the name string"""
+        """Parse the name string."""
         name = name.strip()
         parts = split_tex_string(name, ",")
 
@@ -103,7 +102,7 @@ class NameParser:
         return " ".join(getattr(self, f"_{part_type}", []))
 
     def format_name(self) -> str:
-        """Format the name"""
+        """Format the name."""
 
         def join(name_list: list) -> str:
             return " ".join([name for name in name_list if name])
@@ -124,7 +123,7 @@ class NameParser:
 
 
 def parse_names(names: str) -> str:
-    """Parse names"""
+    """Parse names."""
     if "," in names:
         return names
     name_list = re.split(r"\s+and\s+|;", names)
@@ -133,12 +132,11 @@ def parse_names(names: str) -> str:
 
 
 def parse_names_in_records(records_dict: dict) -> None:
-    """Parse names in records
+    """Parse names in records.
 
     Note: requires fields to be Fields.AUTHOR/Fields.EDITOR
 
     """
-
     for record in records_dict.values():
         if Fields.AUTHOR in record:
             record[Fields.AUTHOR] = parse_names(record[Fields.AUTHOR])

--- a/colrev/loader/loader.py
+++ b/colrev/loader/loader.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load files (BiBTeX, RIS, CSV, etc.)"""
+"""Function to load files (BiBTeX, RIS, CSV, etc.)."""
 
 import logging
 import typing
@@ -13,7 +13,7 @@ from colrev.loader.load_utils_name_formatter import parse_names_in_records
 
 
 class Loader:
-    """Loader class"""
+    """Loader class."""
 
     def __init__(
         self,
@@ -103,12 +103,12 @@ class Loader:
 
     def load_records_list(self) -> list:
         """The load_records_list must be implemented by the inheriting class
-        (e.g., for ris/bib/...)"""
+        (e.g., for ris/bib/...).
+        """
         raise NotImplementedError  # pragma: no cover
 
     def load(self) -> dict:
-        """Load table entries from the source"""
-
+        """Load table entries from the source."""
         records_list = self.load_records_list()
         self._set_ids(records_list)
         records_dict = {str(r[Fields.ID]): r for r in records_list}

--- a/colrev/loader/md.py
+++ b/colrev/loader/md.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Load conversion of reference sections (bibliographies) in md-documents based on GROBID"""
+"""Load conversion of reference sections (bibliographies) in md-documents based on GROBID."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ from colrev.constants import Fields
 
 
 class MarkdownLoader(colrev.loader.loader.Loader):
-    """Loads reference strings from text (md) files (based on GROBID)"""
+    """Loads reference strings from text (md) files (based on GROBID)."""
 
     def __init__(
         self,
@@ -46,8 +46,7 @@ class MarkdownLoader(colrev.loader.loader.Loader):
 
     @classmethod
     def get_nr_records(cls, filename: Path) -> int:
-        """Get the number of records in the file"""
-
+        """Get the number of records in the file."""
         count = 0
         with open(filename, encoding="utf8") as file:
             for line in file:
@@ -57,8 +56,7 @@ class MarkdownLoader(colrev.loader.loader.Loader):
         return count
 
     def load_records_list(self) -> list:
-        """Load records from the source"""
-
+        """Load records from the source."""
         self.logger.info("Running GROBID to parse structured reference data")
 
         grobid_service = colrev.env.grobid_service.GrobidService()

--- a/colrev/loader/nbib.py
+++ b/colrev/loader/nbib.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load nbib files"""
+"""Function to load nbib files."""
 
 from __future__ import annotations
 
@@ -16,15 +16,15 @@ import colrev.loader.loader
 
 
 class NextLine(Exception):
-    """NextLineException"""
+    """NextLineException."""
 
 
 class ParseError(Exception):
-    """Parsing error"""
+    """Parsing error."""
 
 
 class NBIBLoader(colrev.loader.loader.Loader):
-    """Loads nbib files"""
+    """Loads nbib files."""
 
     PATTERN = r"^[A-Z]{2,4}( ){1,2}- "
 
@@ -56,7 +56,7 @@ class NBIBLoader(colrev.loader.loader.Loader):
 
     @classmethod
     def get_nr_records(cls, filename: Path) -> int:
-        """Get the number of records in the file"""
+        """Get the number of records in the file."""
         count = 0
         with open(filename, encoding="utf-8") as file:
             for line in file:
@@ -69,7 +69,7 @@ class NBIBLoader(colrev.loader.loader.Loader):
         return line[: line.find(" - ")].rstrip()
 
     def _get_content(self, line: str) -> str:
-        """Get the content from a line"""
+        """Get the content from a line."""
         return line[line.find(" - ") + 2 :].strip()
 
     def _add_tag(self, tag: str, line: str) -> None:

--- a/colrev/loader/ris.py
+++ b/colrev/loader/ris.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load RIS files"""
+"""Function to load RIS files."""
 
 from __future__ import annotations
 
@@ -16,15 +16,15 @@ import colrev.loader.loader
 
 
 class NextLine(Exception):
-    """NextLineException"""
+    """NextLineException."""
 
 
 class ParseError(Exception):
-    """Parsing error"""
+    """Parsing error."""
 
 
 class RISLoader(colrev.loader.loader.Loader):
-    """Loads ris files"""
+    """Loads ris files."""
 
     PATTERN = r"^[A-Z0-9]{2,4} "
 
@@ -55,7 +55,7 @@ class RISLoader(colrev.loader.loader.Loader):
 
     @classmethod
     def get_nr_records(cls, filename: Path) -> int:
-        """Get the number of records in the file"""
+        """Get the number of records in the file."""
         count = 0
         with open(filename, encoding="utf-8") as file:
             for line in file:
@@ -68,7 +68,7 @@ class RISLoader(colrev.loader.loader.Loader):
         return line[0 : line.find(" ")].rstrip()
 
     def _get_content(self, line: str) -> str:
-        """Get the content from a line"""
+        """Get the content from a line."""
         return line[line.find(" - ") + 3 :].strip()
 
     def _add_tag(self, tag: str, line: str) -> None:
@@ -114,11 +114,11 @@ class RISLoader(colrev.loader.loader.Loader):
         return "\n".join(lines)
 
     def load_records_list(self, *, content: str = "") -> list:
-        """Load ris entries
+        """Load ris entries.
 
         The resulting keys should coincide with those in the KEY_MAP
-        but they can be adapted before calling the convert_to_records()"""
-
+        but they can be adapted before calling the convert_to_records()
+        """
         # Note : depending on the source, a specific ris_parser implementation may be selected.
         # its DEFAULT_LIST_TAGS can be extended with list fields that should be joined automatically
 

--- a/colrev/loader/table.py
+++ b/colrev/loader/table.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to load tabular files (csv, xlsx)"""
+"""Function to load tabular files (csv, xlsx)."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ import colrev.loader.loader
 
 
 class TableLoader(colrev.loader.loader.Loader):
-    """Loads csv and Excel files (based on pandas)"""
+    """Loads csv and Excel files (based on pandas)."""
 
     def __init__(
         self,
@@ -43,7 +43,7 @@ class TableLoader(colrev.loader.loader.Loader):
 
     @classmethod
     def get_nr_records(cls, filename: Path) -> int:
-        """Get the number of records in the file"""
+        """Get the number of records in the file."""
         if filename.name.endswith(".csv"):
             data = pd.read_csv(filename, dtype=str, keep_default_na=False)
         elif filename.name.endswith((".xls", ".xlsx")):

--- a/colrev/logger.py
+++ b/colrev/logger.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Logger"""
+"""Logger."""
 
 from __future__ import annotations
 
@@ -10,8 +10,7 @@ import colrev.exceptions as colrev_exceptions
 
 
 def setup_logger(*, logger_path: Path, level: int = logging.INFO) -> logging.Logger:
-    """Setup the CoLRev logger"""
-
+    """Setup the CoLRev logger."""
     # for logger debugging:
     # from logging_tree import printout
     # printout()
@@ -39,8 +38,7 @@ def setup_logger(*, logger_path: Path, level: int = logging.INFO) -> logging.Log
 def setup_report_logger(
     *, report_path: Path, level: int = logging.INFO
 ) -> logging.Logger:
-    """Setup the report logger (used for git commit report)"""
-
+    """Setup the report logger (used for git commit report)."""
     try:
         report_logger = logging.getLogger(
             f"colrev_report{str(report_path.parent).replace('/', '_')}"
@@ -72,8 +70,7 @@ def setup_report_logger(
 
 
 def reset_report_logger(*, report_path: Path) -> logging.FileHandler:
-    """Reset the report log file (used for the git commit report)"""
-
+    """Reset the report log file (used for the git commit report)."""
     file_handler = logging.FileHandler(report_path, mode="a")
     file_handler.setLevel(logging.INFO)
     formatter = logging.Formatter(

--- a/colrev/ops/__init__.py
+++ b/colrev/ops/__init__.py
@@ -1,4 +1,4 @@
-"""Operations"""
+"""Operations."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/ops/advisor.py
+++ b/colrev/ops/advisor.py
@@ -195,7 +195,7 @@ class Advisor:
 
     # pylint: disable=colrev-missed-constant-usage
     def _get_collaboration_instructions(self) -> dict:
-        """Get instructions related to collaboration"""
+        """Get instructions related to collaboration."""
         collaboration_instructions: dict = {"items": []}
         git_repo = self.review_manager.dataset.git_repo.repo
 
@@ -565,7 +565,7 @@ class Advisor:
         self,
         environment_instructions: list,
     ) -> None:
-        """Get instructions related to downloading outlets (resources)"""
+        """Get instructions related to downloading outlets (resources)."""
         outlets, outlet_counter = self._extract_outlet_count()
 
         selected = []
@@ -601,7 +601,7 @@ class Advisor:
                 environment_instructions.append(instruction)
 
     def _get_environment_instructions(self) -> list:
-        """Get instructions related to the CoLRev environment"""
+        """Get instructions related to the CoLRev environment."""
         environment_instructions: list[dict] = []
         if self.status_stats.currently.md_imported > 10:
             self._append_download_outlets_instruction(environment_instructions)
@@ -629,7 +629,7 @@ class Advisor:
         return environment_instructions
 
     def get_review_instructions(self) -> list:
-        """Get instructions related to the review (operations)"""
+        """Get instructions related to the review (operations)."""
         review_instructions: typing.List[typing.Dict] = []
         self._append_initial_load_instruction(review_instructions)
         self._append_operation_in_progress_instructions(review_instructions)
@@ -639,7 +639,7 @@ class Advisor:
         return review_instructions
 
     def get_sharing_instructions(self) -> dict:
-        """Get instructions related to sharing the project"""
+        """Get instructions related to sharing the project."""
         collaboration_instructions = self._get_collaboration_instructions()
         return {
             "msg": "\n ".join(
@@ -655,7 +655,7 @@ class Advisor:
         }
 
     def get_instructions(self) -> dict:
-        """Get all instructions on the project"""
+        """Get all instructions on the project."""
         instructions = {
             "review_instructions": self.get_review_instructions(),
             "environment_instructions": self._get_environment_instructions(),

--- a/colrev/ops/check.py
+++ b/colrev/ops/check.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class CheckOperation(colrev.process.operation.Operation):
-    """A dummy operation that is not expected to introduce changes"""
+    """A dummy operation that is not expected to introduce changes."""
 
     # pylint: disable=too-few-public-methods
 

--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Checkers for CoLRev repositories"""
+"""Checkers for CoLRev repositories."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class Checker:
-    """The CoLRev checker makes sure the project setup is ok"""
+    """The CoLRev checker makes sure the project setup is ok."""
 
     records: typing.Dict[str, typing.Any] = {}
 
@@ -40,7 +40,7 @@ class Checker:
         self.review_manager.notified_next_operation = OperationsType.check
 
     def get_colrev_versions(self) -> list[str]:
-        """Get the colrev version as a list: (last_version, current_version)"""
+        """Get the colrev version as a list: (last_version, current_version)."""
         current_colrev_version = version("colrev")
         last_colrev_version = current_colrev_version
         last_colrev_version = self.review_manager.settings.project.colrev_version
@@ -61,7 +61,7 @@ class Checker:
             )
 
     def check_repository_setup(self) -> None:
-        """Check the repository setup"""
+        """Check the repository setup."""
         # 1. git repository?
         if not self._is_git_repo():
             raise colrev_exceptions.RepoSetupError()
@@ -80,7 +80,7 @@ class Checker:
 
     @classmethod
     def in_virtualenv(cls) -> bool:
-        """Check whether CoLRev operates in a virtual environment"""
+        """Check whether CoLRev operates in a virtual environment."""
 
         def get_base_prefix_compat() -> str:
             return (
@@ -219,7 +219,7 @@ class Checker:
         return record_ids
 
     def _check_colrev_origins(self, *, status_data: dict) -> None:
-        """Check colrev_origins"""
+        """Check colrev_origins."""
         # Check whether each record has an origin
         if not len(status_data["entries_without_origin"]) == 0:
             raise colrev_exceptions.OriginError(
@@ -253,7 +253,7 @@ class Checker:
             )
 
     def check_fields(self, *, status_data: dict) -> None:
-        """Check field values"""
+        """Check field values."""
         # Check status fields
         status_schema = RecordState
         stat_diff = set(status_data["status_fields"]).difference(status_schema)
@@ -263,7 +263,7 @@ class Checker:
             )
 
     def check_status_transitions(self, *, status_data: dict) -> None:
-        """Check for invalid state transitions"""
+        """Check for invalid state transitions."""
         # Note : currently, we do not prevent particular transitions.
         # We may decide to provide settings parameters to apply
         # more restrictive rules related to valid transitions.
@@ -343,7 +343,7 @@ class Checker:
                 )
 
     def _check_records_screen(self, *, status_data: dict) -> None:
-        """Check consistency of screening criteria and status"""
+        """Check consistency of screening criteria and status."""
         if not status_data["screening_criteria_list"]:
             return
 
@@ -424,7 +424,7 @@ class Checker:
     def check_change_in_propagated_id(
         self, *, prior_id: str, new_id: str = "TBD", project_context: Path
     ) -> list:
-        """Check whether propagated IDs were changed
+        """Check whether propagated IDs were changed.
 
         A propagated ID is a record ID that is stored outside the records.bib.
         Propagated IDs should not be changed in the records.bib
@@ -468,7 +468,7 @@ class Checker:
     def _check_change_in_propagated_ids(
         self, *, prior: dict, status_data: dict
     ) -> None:
-        """Check for changes in propagated IDs"""
+        """Check for changes in propagated IDs."""
         if "persisted_IDs" not in prior:
             return
         for prior_origin, prior_id in prior["persisted_IDs"]:
@@ -619,7 +619,7 @@ class Checker:
         return status_data
 
     def check_repo_basics(self) -> list:
-        """Calls data.main() to update the stats"""
+        """Calls data.main() to update the stats."""
         data_operation = self.review_manager.get_data_operation(
             notify_state_transition_operation=False
         )
@@ -759,7 +759,7 @@ class Checker:
 
     def check_repo(self) -> dict:
         """Check whether the repository is in a consistent state
-        Entrypoint for pre-commit hooks
+        Entrypoint for pre-commit hooks.
         """
         failure_items = []
         failure_items.extend(self.check_repo_extended())

--- a/colrev/ops/clone.py
+++ b/colrev/ops/clone.py
@@ -13,7 +13,7 @@ from colrev.env.environment_manager import EnvironmentManager
 
 
 class Clone:
-    """Clone CoLRev project from git remote repository"""
+    """Clone CoLRev project from git remote repository."""
 
     # pylint: disable=too-few-public-methods
 

--- a/colrev/ops/colrev_pandas.py
+++ b/colrev/ops/colrev_pandas.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Connector for pandas"""
+"""Connector for pandas."""
 
 from __future__ import annotations
 
@@ -27,8 +27,7 @@ def load_df(
     include_provenance: bool = True,
     notify: str = "",
 ) -> pd.DataFrame:
-    """Get a pandas dataframe from a CoLRev project"""
-
+    """Get a pandas dataframe from a CoLRev project."""
     if project_path == "":
         project_path = str(Path.cwd())
 
@@ -57,7 +56,6 @@ def load_resolved_papers(other_project_path: str) -> pd.DataFrame:
     This is useful when integrating datasets and reusing screening decisions or coding.
 
     Example:
-
     Current project record(s):
 
     @Webster2002{
@@ -77,7 +75,6 @@ def load_resolved_papers(other_project_path: str) -> pd.DataFrame:
     }
 
     Returns:
-
     @Webster2002{
         title = "ANALYZING THE PAST TO PREPARE FOR THE FUTURE",
         author = "WEBSTER; WATSON",
@@ -91,7 +88,6 @@ def load_resolved_papers(other_project_path: str) -> pd.DataFrame:
     by accessing other records based on corresponding current IDs.
 
     """
-
     other_review_manager = colrev.review_manager.ReviewManager(
         path_str=other_project_path, force_mode=True
     )
@@ -157,10 +153,10 @@ def add_from_tei(
     project_path: str = "",
     fields: typing.Optional[typing.List[str]] = None,
 ) -> None:
-    """
-    This function adds data from TEI files to the given DataFrame.
+    """This function adds data from TEI files to the given DataFrame.
 
-    Parameters:
+    Parameters
+    ----------
     records_df (pd.DataFrame): The DataFrame to which the data will be added.
     project_path (str, optional): The path to the project. Defaults to the
                                   current working directory.
@@ -168,8 +164,10 @@ def add_from_tei(
                                             files. Defaults to [Fields.ABSTRACT,
                                             Fields.KEYWORDS].
 
-    Returns:
+    Returns
+    -------
     None
+
     """
     if project_path == "":
         project_path = str(Path.cwd())
@@ -206,18 +204,20 @@ def add_from_tei(
 def extract_pdfs_for_data_extraction(
     records_df: pd.DataFrame, directory: str, copy_files: bool = False
 ) -> None:
-    """
-    This function creates symlinks or copies the PDFs to the given directory
+    """This function creates symlinks or copies the PDFs to the given directory
     based on the copy_files parameter.
 
-    Parameters:
+    Parameters
+    ----------
     records_df (pd.DataFrame): The DataFrame containing the records.
     directory (str): The directory where the symlinks or copies will be created.
     copy_files (bool, optional): If True, copies the PDFs instead of creating
                                  symlinks. Defaults to False.
 
-    Returns:
+    Returns
+    -------
     None
+
     """
     project_path = str(Path.cwd())
     review_manager = colrev.review_manager.ReviewManager(
@@ -244,14 +244,16 @@ def extract_pdfs_for_data_extraction(
 
 
 def save(records_df: pd.DataFrame) -> None:
-    """
-    This function saves the records from a DataFrame to a dataset.
+    """This function saves the records from a DataFrame to a dataset.
 
-    Parameters:
+    Parameters
+    ----------
     records_df (pd.DataFrame): The DataFrame containing the records to be saved.
 
-    Returns:
+    Returns
+    -------
     None
+
     """
     project_path = str(Path.cwd())
     review_manager = colrev.review_manager.ReviewManager(

--- a/colrev/ops/commit.py
+++ b/colrev/ops/commit.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class Commit:
-    """Create commits"""
+    """Create commits."""
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
@@ -145,7 +145,7 @@ class Commit:
         return processing_report
 
     def create(self, *, skip_status_yaml: bool = False) -> bool:
-        """Create a commit (including the commit message and details)"""
+        """Create a commit (including the commit message and details)."""
         status_operation = self.review_manager.get_status_operation()
         git_repo = self.review_manager.dataset.git_repo.repo
         try:
@@ -213,7 +213,7 @@ class Commit:
         return True
 
     def update_report(self, *, msg_file: Path) -> None:
-        """Update the report"""
+        """Update the report."""
         status_operation = self.review_manager.get_status_operation()
         report = self._get_commit_report(status_operation)
         with open(msg_file, "a", encoding="utf8") as file:

--- a/colrev/ops/correct.py
+++ b/colrev/ops/correct.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class Corrections:
-    """Handling corrections of metadata"""
+    """Handling corrections of metadata."""
 
     # pylint: disable=duplicate-code
     essential_md_keys = [
@@ -175,8 +175,7 @@ class Corrections:
             json.dump(dict_to_save, corrections_file, indent=4)
 
     def check_corrections_of_records(self) -> None:
-        """Check for corrections of records"""
-
+        """Check for corrections of records."""
         # to test run
         # colrev-hooks-report .report.log
 

--- a/colrev/ops/custom_scripts/custom_pdf_get_script.py
+++ b/colrev/ops/custom_scripts/custom_pdf_get_script.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Template for a custom PDFGet PackageEndpoint"""
+"""Template for a custom PDFGet PackageEndpoint."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from colrev.constants import Fields
 
 
 class CustomPDFGet(base_classes.PDFGetPackageBaseClass):
-    """Class for custom pdf-get scripts"""
+    """Class for custom pdf-get scripts."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -29,8 +29,7 @@ class CustomPDFGet(base_classes.PDFGetPackageBaseClass):
         self,
         record: colrev.record.record.Record,
     ) -> colrev.record.record.Record:
-        """Get the PDF"""
-
+        """Get the PDF."""
         record.data[Fields.FILE] = "filepath"
         self.pdf_get_operation.import_pdf(record)
 

--- a/colrev/ops/custom_scripts/custom_pdf_prep_script.py
+++ b/colrev/ops/custom_scripts/custom_pdf_prep_script.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Template for a custom PDFPrep PackageEndpoint"""
+"""Template for a custom PDFPrep PackageEndpoint."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from colrev.constants import RecordState
 
 
 class CustomPDFPrep(base_classes.PDFPrepPackageBaseClass):
-    """Class for custom pdf-prep scripts"""
+    """Class for custom pdf-prep scripts."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -34,8 +34,7 @@ class CustomPDFPrep(base_classes.PDFPrepPackageBaseClass):
         record: colrev.record.record.Record,
         pad: int,  # pylint: disable=unused-argument
     ) -> colrev.record.record.Record:
-        """Prepare the PDF"""
-
+        """Prepare the PDF."""
         if random.random() < 0.8:  # nosec
             record.add_field_provenance_note(
                 key=Fields.FILE, note="custom_issue_detected"

--- a/colrev/ops/custom_scripts/custom_prep_script.py
+++ b/colrev/ops/custom_scripts/custom_prep_script.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Template for a custom Prep PackageEndpoint"""
+"""Template for a custom Prep PackageEndpoint."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from colrev.constants import Fields
 
 
 class CustomPrep(base_classes.PrepPackageBaseClass):
-    """Class for custom prep scripts"""
+    """Class for custom prep scripts."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     source_correction_hint = "check with the developer"
@@ -35,8 +35,7 @@ class CustomPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Update record (metadata)"""
-
+        """Update record (metadata)."""
         if Fields.JOURNAL in record.data:
             if record.data[Fields.JOURNAL] == "MISQ":
                 record.update_field(

--- a/colrev/ops/custom_scripts/custom_prescreen_script.py
+++ b/colrev/ops/custom_scripts/custom_prescreen_script.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Template for a custom Prescreen PackageEndpoint"""
+"""Template for a custom Prescreen PackageEndpoint."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ import colrev.record.record
 
 
 class CustomPrescreen(base_classes.PrescreenPackageBaseClass):
-    """Class for custom prescreen scripts"""
+    """Class for custom prescreen scripts."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -32,8 +32,7 @@ class CustomPrescreen(base_classes.PrescreenPackageBaseClass):
         records: dict,
         split: list,  # pylint: disable=unused-argument
     ) -> dict:
-        """Prescreen the record"""
-
+        """Prescreen the record."""
         for record in records.values():
             if random.random() < 0.5:  # nosec
                 self.prescreen_operation.prescreen(

--- a/colrev/ops/custom_scripts/custom_screen_script.py
+++ b/colrev/ops/custom_scripts/custom_screen_script.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Template for a custom Screen PackageEndpoint"""
+"""Template for a custom Screen PackageEndpoint."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class CustomScreen(base_classes.ScreenPackageBaseClass):
-    """Class for custom screen scripts"""
+    """Class for custom screen scripts."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -33,8 +33,7 @@ class CustomScreen(base_classes.ScreenPackageBaseClass):
         self.screen_operation = screen_operation
 
     def run_screen(self, records: dict, split: list) -> dict:
-        """Screen a record"""
-
+        """Screen a record."""
         screen_data = self.screen_operation.get_data()
         screening_criteria = (
             self.screen_operation.review_manager.settings.screen.criteria

--- a/colrev/ops/custom_scripts/custom_search_source_script.py
+++ b/colrev/ops/custom_scripts/custom_search_source_script.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Template for a custom SearchSource PackageEndpoint"""
+"""Template for a custom SearchSource PackageEndpoint."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from colrev.constants import Fields
 
 
 class CustomSearch(base_classes.SearchSourcePackageBaseClass):
-    """Class for custom search scripts"""
+    """Class for custom search scripts."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -28,8 +28,7 @@ class CustomSearch(base_classes.SearchSourcePackageBaseClass):
         self.search_source: colrev.search_file.ExtendedSearchFile = settings
 
     def search(self, rerun: bool) -> None:
-        """Run the search"""
-
+        """Run the search."""
         feed = colrev.ops.search_api_feed.SearchAPIFeed(
             source_identifier=self.source_identifier,
             search_source=self.search_source,
@@ -51,8 +50,7 @@ class CustomSearch(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def validate_search_params(cls, query: str) -> None:
-        """Validate the search parameters"""
-
+        """Validate the search parameters."""
         if " SCOPE " not in query:
             raise colrev_exceptions.InvalidQueryException(
                 "CROSSREF queries require a SCOPE section"
@@ -68,14 +66,13 @@ class CustomSearch(base_classes.SearchSourcePackageBaseClass):
     def heuristic(
         cls, filename: Path, data: str  # pylint: disable=unused-argument
     ) -> dict:
-        """Heuristic to identify the custom source"""
-
+        """Heuristic to identify the custom source."""
         result = {"confidence": 0}
 
         return result
 
     def load(self) -> dict:
-        """Load fixes for the custom source"""
+        """Load fixes for the custom source."""
         records = {"ID1": {"ID": "ID1", "title": "..."}}
 
         return records
@@ -84,6 +81,5 @@ class CustomSearch(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record.Record,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for the custom source"""
-
+        """Source-specific preparation for the custom source."""
         return record

--- a/colrev/ops/data.py
+++ b/colrev/ops/data.py
@@ -20,7 +20,8 @@ from colrev.package_manager.package_manager import PackageManager
 
 class Data(colrev.process.operation.Operation):
     """Class supporting structured and unstructured
-    data extraction, analysis and synthesis"""
+    data extraction, analysis and synthesis.
+    """
 
     _pad = 0
     type = OperationsType.data
@@ -40,7 +41,7 @@ class Data(colrev.process.operation.Operation):
         self.package_manager = PackageManager()
 
     def get_record_ids_for_synthesis(self, records: dict) -> list:
-        """Get the IDs of records for the synthesis"""
+        """Get the IDs of records for the synthesis."""
         return [
             ID
             for ID, record in records.items()
@@ -52,8 +53,7 @@ class Data(colrev.process.operation.Operation):
         ]
 
     def reading_heuristics(self) -> list:
-        """Determine heuristics for the reading process"""
-
+        """Determine heuristics for the reading process."""
         enlit_list = []
         records = self.review_manager.dataset.load_records_dict()
         for relevant_record_id in self.get_record_ids_for_synthesis(records):
@@ -98,8 +98,7 @@ class Data(colrev.process.operation.Operation):
         return enlit_list
 
     def setup_custom_script(self) -> None:
-        """Setup a custom data script"""
-
+        """Setup a custom data script."""
         filedata = colrev.env.utils.get_package_file_content(
             module="colrev.ops", filename=Path("custom_scripts/custom_data_script.py")
         )
@@ -202,11 +201,10 @@ class Data(colrev.process.operation.Operation):
         records: typing.Optional[dict] = None,
         silent_mode: bool = False,
     ) -> dict:
-        """Data operation (main entrypoint)
+        """Data operation (main entrypoint).
 
         silent_mode: for review_manager checks
         """
-
         if not records:
             records = self.review_manager.dataset.load_records_dict()
 

--- a/colrev/ops/dedupe.py
+++ b/colrev/ops/dedupe.py
@@ -29,7 +29,7 @@ def same_source_merge(
     main_record: colrev.record.record.Record,
     dupe_record: colrev.record.record.Record,
 ) -> bool:
-    """Same source merge check"""
+    """Same source merge check."""
     main_rec_sources = [x.split("/")[0] for x in main_record.data[Fields.ORIGIN]]
     dupe_rec_sources = [x.split("/")[0] for x in dupe_record.data[Fields.ORIGIN]]
     same_sources = set(main_rec_sources).intersection(set(dupe_rec_sources))
@@ -49,7 +49,7 @@ def same_source_merge(
 
 
 class Dedupe(colrev.process.operation.Operation):
-    """Deduplicate records (entity resolution)"""
+    """Deduplicate records (entity resolution)."""
 
     NON_DUPLICATE_FILE_XLSX = Path("non_duplicates_to_validate.xlsx")
     NON_DUPLICATE_FILE_TXT = Path("non_duplicates_to_validate.txt")
@@ -92,14 +92,14 @@ class Dedupe(colrev.process.operation.Operation):
 
     @classmethod
     def connected_components(cls, id_sets: list) -> list:
-        """
-        Find the connected components in a graph.
+        """Find the connected components in a graph.
 
         Args:
             id_sets (list): A list of id sets.
 
         Returns:
             list: A list of connected components.
+
         """
         graph = defaultdict(list)
 
@@ -124,7 +124,7 @@ class Dedupe(colrev.process.operation.Operation):
     def get_records_for_dedupe(
         cls, *, records_df: pd.DataFrame, verbosity_level: int = 0
     ) -> pd.DataFrame:
-        """Get (pre-processed) records for dedupe"""
+        """Get (pre-processed) records for dedupe."""
         return prep(records_df=records_df, verbosity_level=verbosity_level)
 
     def _select_primary_merge_record(self, rec_1: dict, rec_2: dict) -> list:
@@ -358,14 +358,13 @@ class Dedupe(colrev.process.operation.Operation):
         complete_dedupe: bool = False,
         preferred_masterdata_sources: typing.Optional[list] = None,
     ) -> None:
-        """Apply deduplication decisions
+        """Apply deduplication decisions.
 
         id_sets : [[ID_1, ID_2, ID_3], ...]
 
         - complete_dedupe: when not all potential duplicates were considered,
         we cannot set records to md_procssed for non-duplicate decisions
         """
-
         preferred_masterdata_source_prefixes = []
         if preferred_masterdata_sources:
             preferred_masterdata_source_prefixes = [
@@ -441,8 +440,8 @@ class Dedupe(colrev.process.operation.Operation):
         Note:
             The id_sets are expected to be *already resolved* (no chained duplicates).
             Therefore, we do not follow temporary merge markers to resolve chains.
-        """
 
+        """
         removed_in_run: set[str] = set()
 
         for id_set in id_sets:
@@ -484,10 +483,7 @@ class Dedupe(colrev.process.operation.Operation):
                 removed_in_run.add(dupe_record.data[Fields.ID])
 
     def _get_origins_for_current_ids(self, current_record_ids: list) -> dict:
-        """
-        For each record ID, get the origins from the most recent history entry.
-        """
-
+        """For each record ID, get the origins from the most recent history entry."""
         ids_origins: typing.Dict[str, typing.List[str]] = {
             rid: [] for rid in current_record_ids
         }
@@ -507,8 +503,7 @@ class Dedupe(colrev.process.operation.Operation):
         return ids_origins
 
     def _remove_merged_records(self, records: dict, ids_origins: dict) -> None:
-        """
-        Remove records that have been merged from the records dictionary.
+        """Remove records that have been merged from the records dictionary.
         These records are identified by their current IDs.
         """
         for rid in ids_origins:
@@ -517,10 +512,7 @@ class Dedupe(colrev.process.operation.Operation):
     def _revert_merge_for_records(
         self, unmerged_records: dict, ids_origins: dict
     ) -> dict:
-        """
-        Attempt to revert the merge operation for each record based on its origins.
-        """
-
+        """Attempt to revert the merge operation for each record based on its origins."""
         for hist_recs in self.review_manager.dataset.load_records_from_history():
             for rid in list(ids_origins.keys()):
                 origins = ids_origins[rid]
@@ -584,8 +576,7 @@ class Dedupe(colrev.process.operation.Operation):
         self.review_manager.dataset.save_records_dict(records)
 
     def fix_errors(self, *, false_positives: list, false_negatives: list) -> None:
-        """Fix lists of errors"""
-
+        """Fix lists of errors."""
         self.unmerge_records(current_record_ids=false_positives)
         self.apply_merges(id_sets=false_negatives, complete_dedupe=False)
 
@@ -596,8 +587,7 @@ class Dedupe(colrev.process.operation.Operation):
             )
 
     def get_info(self) -> dict:
-        """Get info on cuts (overlap of search sources) and same source merges"""
-
+        """Get info on cuts (overlap of search sources) and same source merges."""
         # same_source_merges: typing.Any = []
         # source_overlaps: typing.Any = []
         # info = {
@@ -608,13 +598,11 @@ class Dedupe(colrev.process.operation.Operation):
         raise NotImplementedError
 
     def merge_records(self, *, merge: list) -> None:
-        """Merge records by ID sets"""
-
+        """Merge records by ID sets."""
         self.apply_merges(id_sets=merge)
 
     def merge_based_on_global_ids(self, *, apply: bool = False) -> None:
-        """Merge records based on global IDs (e.g., doi)"""
-
+        """Merge records based on global IDs (e.g., doi)."""
         # pylint: disable=too-many-branches
 
         self.review_manager.logger.info(
@@ -674,8 +662,7 @@ class Dedupe(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, debug: bool = False) -> None:
-        """Dedupe records (main entrypoint)"""
-
+        """Dedupe records (main entrypoint)."""
         self.review_manager.logger.info("Dedupe")
         self.review_manager.logger.info(
             "Identifies duplicate records and merges them (keeping traces to their origins)."

--- a/colrev/ops/distribute.py
+++ b/colrev/ops/distribute.py
@@ -19,7 +19,7 @@ from colrev.writer.write_utils import write_file
 
 
 class Distribute(colrev.process.operation.Operation):
-    """Distribute records to other local CoLRev projects"""
+    """Distribute records to other local CoLRev projects."""
 
     type = OperationsType.check
 
@@ -33,7 +33,7 @@ class Distribute(colrev.process.operation.Operation):
         self.review_manager = review_manager
 
     def get_environment_registry(self) -> list:
-        """Get the environment registry (excluding curated_metadata)"""
+        """Get the environment registry (excluding curated_metadata)."""
         environment_manager = EnvironmentManager()
         return [
             x
@@ -42,7 +42,7 @@ class Distribute(colrev.process.operation.Operation):
         ]
 
     def get_next_id(self, *, bib_file: Path) -> int:
-        """Get the next ID (incrementing counter)"""
+        """Get the next ID (incrementing counter)."""
         ids = []
         if bib_file.is_file():
             with open(bib_file, encoding="utf8") as file:
@@ -57,8 +57,7 @@ class Distribute(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, path: Path, target: Path) -> None:
-        """Distribute records to other CoLRev repositories (main entrypoint)"""
-
+        """Distribute records to other CoLRev repositories (main entrypoint)."""
         # if no options are given, take the current path/repo
         # optional: target-repo-path
         # path_str: could also be a url

--- a/colrev/ops/init.py
+++ b/colrev/ops/init.py
@@ -36,7 +36,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class Initializer:
-    """Initialize a CoLRev project"""
+    """Initialize a CoLRev project."""
 
     review_manager: colrev.review_manager.ReviewManager
 
@@ -457,8 +457,8 @@ class Initializer:
     def _create_example_repo(self) -> None:
         """The example repository is intended to provide an initial illustration
         of CoLRev. It focuses on a quick overview of the process and does
-        not cover advanced features or special cases."""
-
+        not cover advanced features or special cases.
+        """
         self.review_manager.logger.info("Include 30_example_records.bib")
         colrev.env.utils.retrieve_package_file(
             template_file=Path("ops/init/30_example_records.bib"),

--- a/colrev/ops/load.py
+++ b/colrev/ops/load.py
@@ -25,7 +25,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class Load(colrev.process.operation.Operation):
-    """Load the records"""
+    """Load the records."""
 
     type = OperationsType.load
 
@@ -111,7 +111,7 @@ class Load(colrev.process.operation.Operation):
         self,
         record: colrev.record.record.Record,
     ) -> None:
-        """Set the provenance for an imported record"""
+        """Set the provenance for an imported record."""
 
         def set_initial_import_provenance(record: colrev.record.record.Record) -> None:
             # Initialize Fields.MD_PROV
@@ -549,7 +549,7 @@ class Load(colrev.process.operation.Operation):
         *,
         keep_ids: bool = False,
     ) -> None:
-        """Load records (main entrypoint)"""
+        """Load records (main entrypoint)."""
         if not self.review_manager.high_level_operation:
             print()
 

--- a/colrev/ops/merge.py
+++ b/colrev/ops/merge.py
@@ -18,7 +18,7 @@ from colrev.constants import OperationsType
 
 
 class Merge(colrev.process.operation.Operation):
-    """Merge branches of CoLRev project"""
+    """Merge branches of CoLRev project."""
 
     type = OperationsType.check
 
@@ -86,8 +86,7 @@ class Merge(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, branch: str) -> None:
-        """Merge branches of a CoLRev project (main entrypoint)"""
-
+        """Merge branches of a CoLRev project (main entrypoint)."""
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-statements
 

--- a/colrev/ops/pdf_get.py
+++ b/colrev/ops/pdf_get.py
@@ -32,8 +32,7 @@ def relink_pdfs_in_source(
     pdf_dir: Path,
     logger: logging.Logger,
 ) -> None:
-    """Relink PDFs in the given source based on CPIDs"""
-
+    """Relink PDFs in the given source based on CPIDs."""
     # pylint: disable=too-many-locals
 
     def get_pdf_candidates() -> dict:
@@ -170,7 +169,7 @@ def relink_pdfs_in_source(
 
 
 class PDFGet(colrev.process.operation.Operation):
-    """Get the PDFs"""
+    """Get the PDFs."""
 
     to_retrieve: int
     retrieved: int
@@ -209,7 +208,7 @@ class PDFGet(colrev.process.operation.Operation):
             )
 
     def copy_pdfs_to_repo(self) -> None:
-        """Copy the PDFs to the repository"""
+        """Copy the PDFs to the repository."""
         self.review_manager.logger.info("Copy PDFs to dir")
         records = self.review_manager.dataset.load_records_dict()
 
@@ -235,8 +234,7 @@ class PDFGet(colrev.process.operation.Operation):
     def link_pdf(
         self, record: colrev.record.record.Record
     ) -> colrev.record.record.Record:
-        """Link the PDF in its record (should be {ID}.pdf)"""
-
+        """Link the PDF in its record (should be {ID}.pdf)."""
         pdf_filepath = self.review_manager.paths.PDF_DIR / Path(
             f"{record.data['ID']}.pdf"
         )
@@ -253,8 +251,7 @@ class PDFGet(colrev.process.operation.Operation):
         return record
 
     def get_target_filepath(self, record: colrev.record.record.Record) -> Path:
-        """Get the target filepath for a PDF"""
-
+        """Get the target filepath for a PDF."""
         target_filepath = self.review_manager.paths.PDF_DIR / Path(
             f"{record.data['ID']}.pdf"
         )
@@ -277,7 +274,7 @@ class PDFGet(colrev.process.operation.Operation):
         return target_filepath
 
     def import_pdf(self, record: colrev.record.record.Record) -> None:
-        """Import a file (PDF) and copy/symlink it"""
+        """Import a file (PDF) and copy/symlink it."""
         # self.review_manager.pdf_dir.mkdir(exist_ok=True)
         # new_fp = self.review_manager.PDF_DIR_RELATIVE / Path(record.data[Fields.ID] + ".pdf").name
         new_fp = self.get_target_filepath(record)
@@ -321,8 +318,7 @@ class PDFGet(colrev.process.operation.Operation):
 
     # Note : no named arguments (multiprocessing)
     def get_pdf(self, item: dict) -> dict:
-        """Get PDFs (based on the package endpoints in the settings)"""
-
+        """Get PDFs (based on the package endpoints in the settings)."""
         record_dict = item["record"]
 
         if record_dict[Fields.STATUS] not in [
@@ -394,8 +390,7 @@ class PDFGet(colrev.process.operation.Operation):
                 broken_symlink.symlink_to(new_file)
 
     def relink_pdfs(self) -> None:
-        """Relink record files to the corresponding PDFs (if available)"""
-
+        """Relink record files to the corresponding PDFs (if available)."""
         self._fix_broken_symlinks()
 
         sources = [
@@ -422,8 +417,7 @@ class PDFGet(colrev.process.operation.Operation):
         self,
         records: dict,
     ) -> dict[str, dict[str, typing.Any]]:
-        """Check for PDFs that are in the pdfs directory but not linked in the record file"""
-
+        """Check for PDFs that are in the pdfs directory but not linked in the record file."""
         linked_pdfs = [
             str(Path(x[Fields.FILE]).resolve())
             for x in records.values()
@@ -544,8 +538,7 @@ class PDFGet(colrev.process.operation.Operation):
             record.set_status(RecordState.pdf_imported)
 
     def rename_pdfs(self) -> None:
-        """Rename the PDFs"""
-
+        """Rename the PDFs."""
         self.review_manager.logger.info("Rename PDFs")
 
         records = self.review_manager.dataset.load_records_dict()
@@ -685,8 +678,7 @@ class PDFGet(colrev.process.operation.Operation):
         return records
 
     def setup_custom_script(self) -> None:
-        """Setup a custom pfd-get script"""
-
+        """Setup a custom pfd-get script."""
         filedata = colrev.env.utils.get_package_file_content(
             module="colrev.ops",
             filename=Path("custom_scripts/custom_pdf_get_script.py"),
@@ -707,8 +699,7 @@ class PDFGet(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self) -> None:
-        """Get PDFs (main entrypoint)"""
-
+        """Get PDFs (main entrypoint)."""
         if utils.in_ci_environment() and not self.review_manager.in_test_environment():
             raise colrev_exceptions.ServiceNotAvailableException(
                 dep="colrev pdf-prep",

--- a/colrev/ops/pdf_get_man.py
+++ b/colrev/ops/pdf_get_man.py
@@ -21,7 +21,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class PDFGetMan(colrev.process.operation.Operation):
-    """Get PDFs manually"""
+    """Get PDFs manually."""
 
     pdf_get_man_package_endpoints: dict[str, typing.Any]
     MISSING_PDF_FILES_RELATIVE = Path("data/pdf_get_man/missing_pdf_files.csv")
@@ -46,7 +46,7 @@ class PDFGetMan(colrev.process.operation.Operation):
         self.verbose = True
 
     def get_pdf_get_man(self, records: dict) -> list:
-        """Get the records that are missing a PDF"""
+        """Get the records that are missing a PDF."""
         missing_records = []
         for record in records.values():
             if record[Fields.STATUS] == RecordState.pdf_needs_manual_retrieval:
@@ -54,8 +54,7 @@ class PDFGetMan(colrev.process.operation.Operation):
         return missing_records
 
     def export_retrieval_table(self, records: dict) -> None:
-        """Export a table for manual PDF retrieval"""
-
+        """Export a table for manual PDF retrieval."""
         missing_records = self.get_pdf_get_man(records)
 
         if len(missing_records) > 0:
@@ -84,8 +83,7 @@ class PDFGetMan(colrev.process.operation.Operation):
             )
 
     def discard(self) -> None:
-        """Discard missing PDFs (set to pdf_not_available)"""
-
+        """Discard missing PDFs (set to pdf_not_available)."""
         records = self.review_manager.dataset.load_records_dict()
         for record_dict in records.values():
             record = colrev.record.record.Record(record_dict)
@@ -98,7 +96,7 @@ class PDFGetMan(colrev.process.operation.Operation):
         )
 
     def get_data(self) -> dict:
-        """Get the data for pdf-get-man"""
+        """Get the data for pdf-get-man."""
         # pylint: disable=duplicate-code
 
         pdf_dir = self.review_manager.paths.pdf
@@ -124,7 +122,7 @@ class PDFGetMan(colrev.process.operation.Operation):
         return pdf_get_man_data
 
     def pdfs_retrieved_manually(self) -> bool:
-        """Check whether PDFs were retrieved manually"""
+        """Check whether PDFs were retrieved manually."""
         return self.review_manager.dataset.git_repo.has_record_changes()
 
     def pdf_get_man_record(
@@ -134,7 +132,7 @@ class PDFGetMan(colrev.process.operation.Operation):
         filepath: typing.Optional[Path] = None,
         PAD: int = 40,
     ) -> None:
-        """Record pdf-get-man decision"""
+        """Record pdf-get-man decision."""
         if filepath is not None:
             record.set_status(RecordState.pdf_imported)
             record.data.update(file=str(filepath.relative_to(self.review_manager.path)))
@@ -180,8 +178,7 @@ class PDFGetMan(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self) -> None:
-        """Get PDFs manually (main entrypoint)"""
-
+        """Get PDFs manually (main entrypoint)."""
         if utils.in_ci_environment() and not self.review_manager.in_test_environment():
             raise colrev_exceptions.ServiceNotAvailableException(
                 dep="colrev pdf-get-man",

--- a/colrev/ops/pdf_prep.py
+++ b/colrev/ops/pdf_prep.py
@@ -26,7 +26,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class PDFPrep(colrev.process.operation.Operation):
-    """Prepare PDFs"""
+    """Prepare PDFs."""
 
     to_prepare: int
     pdf_prepared: int
@@ -117,8 +117,7 @@ class PDFPrep(colrev.process.operation.Operation):
 
     # Note : no named arguments (multiprocessing)
     def prepare_pdf(self, item: dict) -> dict:
-        """Prepare a PDF (based on package_endpoints in the settings)"""
-
+        """Prepare a PDF (based on package_endpoints in the settings)."""
         record_dict = item["record"]
 
         if (
@@ -297,7 +296,7 @@ class PDFPrep(colrev.process.operation.Operation):
         return record_dict
 
     def update_colrev_pdf_ids(self) -> None:
-        """Update the colrev-pdf-ids"""
+        """Update the colrev-pdf-ids."""
         self.review_manager.logger.info("Update colrev_pdf_ids")
         records = self.review_manager.dataset.load_records_dict()
         pool = Pool(self.cpus)
@@ -351,8 +350,7 @@ class PDFPrep(colrev.process.operation.Operation):
         self.review_manager.logger.info(not_prepared_string)
 
     def setup_custom_script(self) -> None:
-        """Setup a custom pdf-prep script"""
-
+        """Setup a custom pdf-prep script."""
         filedata = colrev.env.utils.get_package_file_content(
             module="colrev.ops",
             filename=Path("custom_scripts/custom_pdf_prep_script.py"),
@@ -373,8 +371,7 @@ class PDFPrep(colrev.process.operation.Operation):
         self.review_manager.save_settings()
 
     def generate_tei(self) -> None:
-        """Generate TEI documents for included records"""
-
+        """Generate TEI documents for included records."""
         self.review_manager.logger.info(
             "Generate TEI documents for records with status=rev_included|rev_synthesized"
         )
@@ -406,8 +403,7 @@ class PDFPrep(colrev.process.operation.Operation):
         reprocess: bool = False,
         batch_size: int = 0,
     ) -> None:
-        """Prepare PDFs (main entrypoint)"""
-
+        """Prepare PDFs (main entrypoint)."""
         if utils.in_ci_environment() and not self.review_manager.in_test_environment():
             raise colrev_exceptions.ServiceNotAvailableException(
                 dep="colrev pdf-prep",

--- a/colrev/ops/pdf_prep_man.py
+++ b/colrev/ops/pdf_prep_man.py
@@ -23,7 +23,7 @@ from colrev.writer.write_utils import write_file
 
 
 class PDFPrepMan(colrev.process.operation.Operation):
-    """Prepare PDFs manually"""
+    """Prepare PDFs manually."""
 
     type = OperationsType.pdf_prep_man
 
@@ -42,8 +42,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
         self.verbose = True
 
     def discard(self) -> None:
-        """Discard records whose PDFs need manual preparation (set to pdf_not_available)"""
-
+        """Discard records whose PDFs need manual preparation (set to pdf_not_available)."""
         records = self.review_manager.dataset.load_records_dict()
         for record_dict in records.values():
             if record_dict[Fields.STATUS] == RecordState.pdf_needs_manual_preparation:
@@ -56,7 +55,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
         )
 
     def get_data(self) -> dict:
-        """Get the data for PDF prep man"""
+        """Get the data for PDF prep man."""
         # pylint: disable=duplicate-code
 
         records_headers = self.review_manager.dataset.load_records_dict(
@@ -82,11 +81,11 @@ class PDFPrepMan(colrev.process.operation.Operation):
         return pdf_prep_man_data
 
     def pdfs_prepared_manually(self) -> bool:
-        """Check whether PDFs were prepared manually"""
+        """Check whether PDFs were prepared manually."""
         return self.review_manager.dataset.git_repo.has_record_changes()
 
     def pdf_prep_man_stats(self) -> None:
-        """Determine PDF prep man statistics"""
+        """Determine PDF prep man statistics."""
         # pylint: disable=duplicate-code
 
         self.review_manager.logger.info(
@@ -146,8 +145,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
             tabulated.to_csv("manual_pdf_preparation_statistics.csv")
 
     def extract_needs_pdf_prep_man(self) -> None:
-        """Apply PDF prep man to csv/bib"""
-
+        """Apply PDF prep man to csv/bib."""
         prep_bib_path = self.review_manager.path / Path("data/pdf-prep-records.bib")
         prep_csv_path = self.review_manager.path / Path("data/pdf-prep-records.csv")
 
@@ -197,8 +195,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
         self.review_manager.logger.info(f"Created {prep_csv_path.name}")
 
     def apply_pdf_prep_man(self) -> None:
-        """Apply PDF prep man from csv/bib"""
-
+        """Apply PDF prep man from csv/bib."""
         if Path("data/pdf-prep-records.csv").is_file():
             self.review_manager.logger.info("Load prep-records.csv")
             bib_db_df = pd.read_csv("data/pdf-prep-records.csv")
@@ -235,8 +232,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
         self.review_manager.check_repo()
 
     def extract_coverpage(self, *, filepath: Path) -> None:
-        """Extract coverpage from PDF"""
-
+        """Extract coverpage from PDF."""
         Filepaths.COVERPAGES.mkdir(exist_ok=True)
 
         doc1 = pymupdf.Document(str(filepath))
@@ -248,8 +244,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
             )
 
     def extract_lastpage(self, *, filepath: Path) -> None:
-        """Extract last page from PDF"""
-
+        """Extract last page from PDF."""
         Filepaths.LASTPAGES.mkdir(exist_ok=True)
 
         doc1 = pymupdf.Document(str(filepath))
@@ -261,8 +256,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
             )
 
     def extract_pages(self, *, filepath: Path, pages_to_remove: list) -> None:
-        """Extract pages from PDF"""
-
+        """Extract pages from PDF."""
         doc1 = pymupdf.Document(str(filepath))
         if doc1.page_count > 0:
             colrev.record.record_pdf.PDFRecord.extract_pages_from_pdf(
@@ -271,8 +265,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
             )
 
     def set_pdf_man_prepared(self, record: colrev.record.record.Record) -> None:
-        """Set the PDF to manually prepared"""
-
+        """Set the PDF to manually prepared."""
         record.set_status(RecordState.pdf_prepared)
         record.reset_pdf_provenance_notes()
 
@@ -292,8 +285,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self) -> None:
-        """Prepare PDFs manually (main entrypoint)"""
-
+        """Prepare PDFs manually (main entrypoint)."""
         if utils.in_ci_environment() and not self.review_manager.in_test_environment():
             raise colrev_exceptions.ServiceNotAvailableException(
                 dep="colrev pdf-prep-man",

--- a/colrev/ops/prep.py
+++ b/colrev/ops/prep.py
@@ -79,7 +79,7 @@ FIELDS_TO_KEEP = FieldSet.STANDARDIZED_FIELD_KEYS + [
 
 # pylint: disable=too-many-instance-attributes
 class Prep(colrev.process.operation.Operation):
-    """Prepare records (metadata)"""
+    """Prepare records (metadata)."""
 
     timeout = 30
     max_retries_on_error = 3
@@ -315,8 +315,7 @@ class Prep(colrev.process.operation.Operation):
     def _preparation_break_condition(
         self, record: colrev.record.record_prep.PrepRecord
     ) -> bool:
-        """Check whether the break condition for the prep operation is given"""
-
+        """Check whether the break condition for the prep operation is given."""
         if DefectCodes.RECORD_NOT_IN_TOC in record.get_field_provenance_notes(
             Fields.JOURNAL
         ):
@@ -335,8 +334,7 @@ class Prep(colrev.process.operation.Operation):
     def _preparation_save_condition(
         self, record: colrev.record.record_prep.PrepRecord
     ) -> bool:
-        """Check whether the save condition for the prep operation is given"""
-
+        """Check whether the save condition for the prep operation is given."""
         if record.data[Fields.STATUS] in [
             RecordState.rev_prescreen_excluded,
             RecordState.md_prepared,
@@ -355,7 +353,7 @@ class Prep(colrev.process.operation.Operation):
         return False
 
     def _status_to_prepare(self, record: colrev.record.record_prep.PrepRecord) -> bool:
-        """Check whether the record needs to be prepared"""
+        """Check whether the record needs to be prepared."""
         return record.data.get(Fields.STATUS, "NA") in [
             RecordState.md_needs_manual_preparation,
             RecordState.md_imported,
@@ -511,8 +509,7 @@ class Prep(colrev.process.operation.Operation):
 
     # Note : no named arguments for multiprocessing
     def prepare(self, item: dict) -> dict:
-        """Prepare a record (based on package_endpoints in the settings)"""
-
+        """Prepare a record (based on package_endpoints in the settings)."""
         # https://docs.python.org/3/library/concurrent.futures.html
         # #concurrent.futures.Executor.map
         # Exceptions are raised at the end/when results are retrieved from the iterator
@@ -614,8 +611,7 @@ class Prep(colrev.process.operation.Operation):
                 self.review_manager.dataset.git_repo.add_changes(pdfs_origin_file)
 
     def set_ids(self) -> None:
-        """Set IDs (regenerate). In force-mode, all IDs are regenerated and PDFs are renamed"""
-
+        """Set IDs (regenerate). In force-mode, all IDs are regenerated and PDFs are renamed."""
         self.review_manager.logger.info("Set IDs")
         records = self.review_manager.dataset.load_records_dict()
         records = self.review_manager.dataset.set_ids()
@@ -624,8 +620,7 @@ class Prep(colrev.process.operation.Operation):
         self.review_manager.create_commit(msg="Set IDs")
 
     def setup_custom_script(self) -> None:
-        """Setup a custom prep script"""
-
+        """Setup a custom prep script."""
         filedata = colrev.env.utils.get_package_file_content(
             module="colrev.ops", filename=Path("custom_scripts/custom_prep_script.py")
         )
@@ -752,7 +747,7 @@ class Prep(colrev.process.operation.Operation):
     def _setup_prep_round(
         self, *, i: int, prep_round: colrev.settings.PrepRound
     ) -> None:
-        """Sets up the self.prep_package_endpoints"""
+        """Sets up the self.prep_package_endpoints."""
         # pylint: disable=redefined-outer-name,invalid-name,global-statement
         global PREP_COUNTER
         with PREP_COUNTER.get_lock():
@@ -982,8 +977,7 @@ class Prep(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, keep_ids: bool = False) -> None:
-        """Preparation of records (main entrypoint)"""
-
+        """Preparation of records (main entrypoint)."""
         self._print_startup_infos()
 
         try:

--- a/colrev/ops/prep_debug.py
+++ b/colrev/ops/prep_debug.py
@@ -30,7 +30,7 @@ PREP_COUNTER = Value("i", 0)
 
 # pylint: disable=too-many-instance-attributes
 class PrepDebug(colrev.ops.prep.Prep):
-    """Debug prepare records (metadata)"""
+    """Debug prepare records (metadata)."""
 
     debug_ids: typing.List[str]
     commit_sha: str
@@ -125,8 +125,7 @@ class PrepDebug(colrev.ops.prep.Prep):
 
     @colrev.process.operation.Operation.decorate()
     def run_debug(self, *, debug_ids: str = "NA") -> None:
-        """Preparation of records (main entrypoint)"""
-
+        """Preparation of records (main entrypoint)."""
         self.debug_ids = debug_ids.split(",")
 
         self.review_manager.logger.info("Start debug prep")

--- a/colrev/ops/prep_man.py
+++ b/colrev/ops/prep_man.py
@@ -22,7 +22,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class PrepMan(colrev.process.operation.Operation):
-    """Prepare records manually (metadata)"""
+    """Prepare records manually (metadata)."""
 
     type = OperationsType.prep_man
 
@@ -174,8 +174,7 @@ class PrepMan(colrev.process.operation.Operation):
         self.review_manager.dataset.save_records_dict(records)
 
     def prep_man_langs(self) -> None:
-        """Add missing language fields based on spreadsheets"""
-
+        """Add missing language fields based on spreadsheets."""
         self.lang_prep_csv_path.parent.mkdir(exist_ok=True, parents=True)
 
         records = self.review_manager.dataset.load_records_dict()
@@ -187,7 +186,7 @@ class PrepMan(colrev.process.operation.Operation):
             self._import_prep_man_langs(records)
 
     def prep_man_stats(self) -> None:
-        """Print statistics on prep_man"""
+        """Print statistics on prep_man."""
         # pylint: disable=duplicate-code
 
         crosstab_df = self._get_crosstab_df()
@@ -215,7 +214,7 @@ class PrepMan(colrev.process.operation.Operation):
             tabulated.to_csv("manual_preparation_statistics.csv")
 
     def get_data(self) -> dict:
-        """Get the data for prep-man"""
+        """Get the data for prep-man."""
         # pylint: disable=duplicate-code
 
         records_headers = self.review_manager.dataset.load_records_dict(
@@ -248,8 +247,7 @@ class PrepMan(colrev.process.operation.Operation):
         return md_prep_man_data
 
     def set_data(self, *, record_dict: dict) -> None:
-        """Set data in the prep_man operation"""
-
+        """Set data in the prep_man operation."""
         record = colrev.record.record_prep.PrepRecord(record_dict)
         record.set_masterdata_complete(
             source="prep_man",
@@ -266,8 +264,7 @@ class PrepMan(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self) -> None:
-        """Manually prepare records (main entrypoint)"""
-
+        """Manually prepare records (main entrypoint)."""
         if utils.in_ci_environment() and not self.review_manager.in_test_environment():
             raise colrev_exceptions.ServiceNotAvailableException(
                 dep="colrev prep-man",

--- a/colrev/ops/prescreen.py
+++ b/colrev/ops/prescreen.py
@@ -23,7 +23,7 @@ ConditionalPrescreen = (
 
 
 class Prescreen(colrev.process.operation.Operation):
-    """Prescreen records (based on metadata)"""
+    """Prescreen records (based on metadata)."""
 
     type = OperationsType.prescreen
 
@@ -42,8 +42,7 @@ class Prescreen(colrev.process.operation.Operation):
         self.verbose = True
 
     def export_table(self, *, export_table_format: str = "csv") -> None:
-        """Export a table with records to prescreen"""
-
+        """Export a table with records to prescreen."""
         endpoint = colrev.packages.prescreen_table.src.prescreen_table.TablePrescreen(
             prescreen_operation=self, settings={"endpoint": "export_table"}
         )
@@ -55,8 +54,7 @@ class Prescreen(colrev.process.operation.Operation):
         )
 
     def import_table(self, *, import_table_path: str) -> None:
-        """Import a table with prescreened records"""
-
+        """Import a table with prescreened records."""
         endpoint = colrev.packages.prescreen_table.src.prescreen_table.TablePrescreen(
             prescreen_operation=self, settings={"endpoint": "import_table"}
         )
@@ -86,8 +84,7 @@ class Prescreen(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def include_all_in_prescreen(self, *, persist: bool) -> None:
-        """Include all records in the prescreen"""
-
+        """Include all records in the prescreen."""
         if persist:
             self.review_manager.settings.prescreen.prescreen_package_endpoints = []
             self.review_manager.save_settings()
@@ -109,13 +106,11 @@ class Prescreen(colrev.process.operation.Operation):
         self._print_stats(selected_record_ids=selected_record_ids)
 
     def include_records(self, *, ids: str) -> None:
-        """Include records in the prescreen"""
-
+        """Include records in the prescreen."""
         self._prescreen_records(ids=ids, include=True)
 
     def exclude_records(self, *, ids: str) -> None:
-        """Exclude records in the prescreen"""
-
+        """Exclude records in the prescreen."""
         self._prescreen_records(ids=ids, include=False)
 
     def _prescreen_records(self, *, ids: str, include: bool) -> None:
@@ -150,8 +145,7 @@ class Prescreen(colrev.process.operation.Operation):
         )
 
     def get_data(self) -> dict:
-        """Get the data for prescreen"""
-
+        """Get the data for prescreen."""
         # pylint: disable=duplicate-code
 
         records_headers = self.review_manager.dataset.load_records_dict(
@@ -176,8 +170,7 @@ class Prescreen(colrev.process.operation.Operation):
         return prescreen_data
 
     def create_prescreen_split(self, *, create_split: int) -> list:
-        """Split the prescreen between researchers"""
-
+        """Split the prescreen between researchers."""
         prescreen_splits = []
 
         data = self.get_data()
@@ -197,8 +190,7 @@ class Prescreen(colrev.process.operation.Operation):
         return prescreen_splits
 
     def setup_custom_script(self) -> None:
-        """Setup a custom prescreen script"""
-
+        """Setup a custom prescreen script."""
         filedata = colrev.env.utils.get_package_file_content(
             module="colrev.ops",
             filename=Path("custom_scripts/custom_prescreen_script.py"),
@@ -286,7 +278,7 @@ class Prescreen(colrev.process.operation.Operation):
         prescreen_inclusion: bool,
         PAD: int = 40,
     ) -> None:
-        """Save the prescreen decision"""
+        """Save the prescreen decision."""
         if prescreen_inclusion:
             self.review_manager.report_logger.info(
                 f" {record.data['ID']}".ljust(PAD, " ") + "Included in prescreen"
@@ -328,8 +320,7 @@ class Prescreen(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, split_str: str = "NA") -> None:
-        """Prescreen records (main entrypoint)"""
-
+        """Prescreen records (main entrypoint)."""
         # pylint: disable=duplicate-code
         split = []
         if split_str != "NA":

--- a/colrev/ops/pull.py
+++ b/colrev/ops/pull.py
@@ -13,7 +13,7 @@ CHANGE_COUNTER = None
 
 
 class Pull(colrev.process.operation.Operation):
-    """Pull the project and records"""
+    """Pull the project and records."""
 
     type = OperationsType.format
 
@@ -25,8 +25,7 @@ class Pull(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self) -> None:
-        """Pull the CoLRev project and records (main entrypoint)"""
-
+        """Pull the CoLRev project and records (main entrypoint)."""
         self._pull_project()
 
     def _pull_project(self) -> None:

--- a/colrev/ops/push.py
+++ b/colrev/ops/push.py
@@ -16,7 +16,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class Push(colrev.process.operation.Operation):
-    """Push the project and record corrections"""
+    """Push the project and record corrections."""
 
     type = OperationsType.check
 
@@ -34,8 +34,7 @@ class Push(colrev.process.operation.Operation):
         project_only: bool = False,
         all_records: bool = False,
     ) -> None:
-        """Push a CoLRev project and records (main entrypoint)"""
-
+        """Push a CoLRev project and records (main entrypoint)."""
         if project_only:
             self._push_project()
 
@@ -84,8 +83,7 @@ class Push(colrev.process.operation.Operation):
         return change_sets
 
     def _push_record_corrections(self, all_records: bool) -> None:
-        """Push corrections of records"""
-
+        """Push corrections of records."""
         change_sets = self._get_change_sets()
         package_manager = PackageManager()
 

--- a/colrev/ops/remove.py
+++ b/colrev/ops/remove.py
@@ -30,7 +30,6 @@ class Remove(colrev.process.operation.Operation):
     @colrev.process.operation.Operation.decorate()
     def remove_records(self, *, ids: str) -> None:
         """Remove records from CoLRev project."""
-
         records = self.review_manager.dataset.load_records_dict()
 
         for record_id in ids.split(","):

--- a/colrev/ops/repare.py
+++ b/colrev/ops/repare.py
@@ -23,7 +23,7 @@ from colrev.writer.write_utils import write_file
 
 
 class Repare(colrev.process.operation.Operation):
-    """Repare a CoLRev project"""
+    """Repare a CoLRev project."""
 
     type = OperationsType.check
 
@@ -443,7 +443,7 @@ class Repare(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self) -> None:
-        """Repare a CoLRev project (main entrypoint)"""
+        """Repare a CoLRev project (main entrypoint)."""
         # Try: open settings, except: notify & start repare
 
         # ...

--- a/colrev/ops/screen.py
+++ b/colrev/ops/screen.py
@@ -19,7 +19,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class Screen(colrev.process.operation.Operation):
-    """Screen records (based on PDFs)"""
+    """Screen records (based on PDFs)."""
 
     type = OperationsType.screen
 
@@ -38,9 +38,7 @@ class Screen(colrev.process.operation.Operation):
         self.verbose = True
 
     def to_screen(self, record_dict: dict) -> bool:
-        """
-        This method checks if the record needs to be screened.
-        """
+        """This method checks if the record needs to be screened."""
         if RecordState.pdf_prepared == record_dict[Fields.STATUS]:
             return True
         if (
@@ -70,8 +68,7 @@ class Screen(colrev.process.operation.Operation):
         return True
 
     def include_all_in_screen(self, *, persist: bool) -> None:
-        """Include all records in the screen"""
-
+        """Include all records in the screen."""
         if persist:
             self.review_manager.settings.screen.screen_package_endpoints = []
             self.review_manager.save_settings()
@@ -116,20 +113,18 @@ class Screen(colrev.process.operation.Operation):
         )
 
     def get_screening_criteria(self) -> list:
-        """Get the list of screening criteria from settings"""
-
+        """Get the list of screening criteria from settings."""
         return list(self.review_manager.settings.screen.criteria.keys())
 
     def set_screening_criteria(
         self, screening_criteria: dict[str, colrev.settings.ScreenCriterion]
     ) -> None:
-        """Set the screening criteria in the settings"""
+        """Set the screening criteria in the settings."""
         self.review_manager.settings.screen.criteria = screening_criteria
         self.review_manager.save_settings()
 
     def get_data(self) -> dict:
-        """Get the data (records to screen)"""
-
+        """Get the data (records to screen)."""
         # pylint: disable=duplicate-code
         records = self.review_manager.dataset.load_records_dict()
 
@@ -148,8 +143,7 @@ class Screen(colrev.process.operation.Operation):
     def add_criterion(
         self, *, criterion_name: str, criterion: colrev.settings.ScreenCriterion
     ) -> None:
-        """Add a screening criterion to the records and settings"""
-
+        """Add a screening criterion to the records and settings."""
         if criterion_name in self.review_manager.settings.screen.criteria:
             print(f"Error: criterion {criterion_name} already in settings")
             return
@@ -200,7 +194,7 @@ class Screen(colrev.process.operation.Operation):
         print()
 
     def delete_criterion(self, criterion_to_delete: str) -> None:
-        """Delete a screening criterion from the records and settings"""
+        """Delete a screening criterion from the records and settings."""
         records = self.review_manager.dataset.load_records_dict()
 
         if criterion_to_delete in self.review_manager.settings.screen.criteria:
@@ -252,8 +246,7 @@ class Screen(colrev.process.operation.Operation):
         )
 
     def create_screen_split(self, *, create_split: int) -> list:
-        """Split the screen between researchers"""
-
+        """Split the screen between researchers."""
         data = self.get_data()
         nrecs = math.floor(data["nr_tasks"] / create_split)
 
@@ -272,8 +265,7 @@ class Screen(colrev.process.operation.Operation):
         return screen_splits
 
     def setup_custom_script(self) -> None:
-        """Setup a custom screen script"""
-
+        """Setup a custom screen script."""
         filedata = colrev.env.utils.get_package_file_content(
             module="colrev.ops",
             filename=Path("custom_scripts/custom_screen_script.py"),
@@ -365,8 +357,7 @@ class Screen(colrev.process.operation.Operation):
         screening_criteria: str,
         PAD: int = 40,
     ) -> None:
-        """Save the screen decision"""
-
+        """Save the screen decision."""
         PAD = 40
         if screen_inclusion:
             screening_criteria_list = self.get_screening_criteria()
@@ -425,8 +416,7 @@ class Screen(colrev.process.operation.Operation):
         return selected_auto_include_ids
 
     def add_abstracts_from_tei(self) -> None:
-        """Add abstracts from TEI files to records without abstracts"""
-
+        """Add abstracts from TEI files to records without abstracts."""
         records = self.review_manager.dataset.load_records_dict()
         for record_dict in records.values():
             if (
@@ -452,8 +442,7 @@ class Screen(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, split_str: str = "NA") -> None:
-        """Screen records for inclusion (main entrypoint)"""
-
+        """Screen records for inclusion (main entrypoint)."""
         self.review_manager.logger.info("Screen")
         self.review_manager.logger.info(
             "In the screen, records are included or excluded "

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -20,7 +20,7 @@ from colrev.writer.write_utils import write_file
 
 
 class Search(colrev.process.operation.Operation):
-    """Search for new records"""
+    """Search for new records."""
 
     type = OperationsType.search
 
@@ -59,8 +59,7 @@ class Search(colrev.process.operation.Operation):
     def _remove_forthcoming(
         self, source: colrev.search_file.ExtendedSearchFile
     ) -> None:
-        """Remove forthcoming papers from a SearchSource"""
-
+        """Remove forthcoming papers from a SearchSource."""
         if self.review_manager.settings.search.retrieve_forthcoming:
             return
 
@@ -88,7 +87,7 @@ class Search(colrev.process.operation.Operation):
 
     # pylint: disable=no-self-argument
     def _check_source_selection_exists(var_name: str) -> typing.Callable:  # type: ignore
-        """Check if the source selection exists"""
+        """Check if the source selection exists."""
 
         # pylint: disable=no-self-argument
         def check_accepts(func_in: typing.Callable) -> typing.Callable:
@@ -116,8 +115,7 @@ class Search(colrev.process.operation.Operation):
         return check_accepts
 
     def get_new_search_files(self) -> list[Path]:
-        """Retrieve new search files (not yet registered in settings)"""
-
+        """Retrieve new search files (not yet registered in settings)."""
         search_dir = self.review_manager.paths.search
         files = [
             f.relative_to(self.review_manager.path) for f in search_dir.glob("**/*")
@@ -202,8 +200,7 @@ class Search(colrev.process.operation.Operation):
     def _apply_source_heuristics(
         self, *, filepath: Path, search_sources: dict
     ) -> list[typing.Dict]:
-        """Apply heuristics to identify source"""
-
+        """Apply heuristics to identify source."""
         data = ""
         try:
             data = filepath.read_text()
@@ -223,12 +220,11 @@ class Search(colrev.process.operation.Operation):
         return results_list
 
     def add_most_likely_sources(self) -> None:
-        """Get the most likely SearchSources
+        """Get the most likely SearchSources.
 
         returns a dictionary:
         {"filepath": [SearchSource1,..]}
         """
-
         new_search_files = self.get_new_search_files()
         for filename in new_search_files:
             heuristic_list = self.get_new_source_heuristic(filename)
@@ -256,12 +252,11 @@ class Search(colrev.process.operation.Operation):
         self.review_manager.create_commit(msg="Add new search sources")
 
     def get_new_source_heuristic(self, filename: Path) -> list:
-        """Get the heuristic result list of SearchSources candidates
+        """Get the heuristic result list of SearchSources candidates.
 
         returns a dictionary:
         {"filepath": ({"search_source": SourceCandidate1", "confidence": 0.98},..]}
         """
-
         self.review_manager.logger.debug("Load available search_source endpoints...")
 
         search_sources = self.package_manager.discover_installed_packages(
@@ -283,8 +278,7 @@ class Search(colrev.process.operation.Operation):
     def add_source_and_search(
         self, search_file: colrev.search_file.ExtendedSearchFile
     ) -> None:
-        """Add a SearchSource and run the search"""
-
+        """Add a SearchSource and run the search."""
         search_file.save()
         self.review_manager.dataset.git_repo.add_changes(
             search_file.get_search_history_path()
@@ -311,8 +305,7 @@ class Search(colrev.process.operation.Operation):
         rerun: bool,
         skip_commit: bool = False,
     ) -> None:
-        """Search for records (main entrypoint)"""
-
+        """Search for records (main entrypoint)."""
         rerun_flag = "" if not rerun else f" ({Colors.GREEN}rerun{Colors.END})"
         self.review_manager.logger.info(f"Search{rerun_flag}")
         self.review_manager.logger.info(

--- a/colrev/ops/search_api_feed.py
+++ b/colrev/ops/search_api_feed.py
@@ -30,8 +30,7 @@ from colrev.writer.write_utils import write_file
 def create_api_source(
     *, platform: str, path: Path
 ) -> colrev.search_file.ExtendedSearchFile:
-    """Interactively add an API SearchSource"""
-
+    """Interactively add an API SearchSource."""
     print(f"Add {platform} as an API SearchSource")
     print()
 
@@ -65,7 +64,7 @@ def create_api_source(
 
 # Keep in mind the need for lock-mechanisms, e.g., in concurrent prep operations
 class SearchAPIFeed:
-    """A feed managing results from API searches"""
+    """A feed managing results from API searches."""
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
@@ -119,7 +118,7 @@ class SearchAPIFeed:
 
     @property
     def source_identifier(self) -> str:
-        """Get the source identifier"""
+        """Get the source identifier."""
         return self._source_identifier
 
     # The setter should avoid problems caused by a packages directly setting
@@ -164,7 +163,6 @@ class SearchAPIFeed:
         """Set incremental record ID
         If self.source_identifier is in record_dict, it is updated, otherwise added as a new record.
         """
-
         if self.source_identifier not in record.data:
             raise colrev_exceptions.NotFeedIdentifiableException()
 
@@ -180,8 +178,7 @@ class SearchAPIFeed:
         record: colrev.record.record.Record,
         prev_feed_record: colrev.record.record.Record,
     ) -> bool:
-        """Add a record to the feed and set its colrev_origin"""
-
+        """Add a record to the feed and set its colrev_origin."""
         self._set_id(record)
         if Fields.ENTRYTYPE not in record.data:
             record.data[Fields.ENTRYTYPE] = ENTRYTYPES.MISC
@@ -393,8 +390,7 @@ class SearchAPIFeed:
         retrieved_record: colrev.record.record.Record,
         prev_feed_record: colrev.record.record.Record,
     ) -> bool:
-        """Convenience function to update existing records (main data/records.bib)"""
-
+        """Convenience function to update existing records (main data/records.bib)."""
         colrev_origin = f"{self.origin_prefix}/{retrieved_record.data['ID']}"
         main_record = self._get_main_record(colrev_origin)
 
@@ -433,7 +429,7 @@ class SearchAPIFeed:
         return False
 
     def _print_post_run_search_infos(self) -> None:
-        """Print the search infos (after running the search)"""
+        """Print the search infos (after running the search)."""
         if self._nr_added > 0:
             self.logger.info(
                 f"{Colors.GREEN}Retrieved {self._nr_added} records{Colors.END}"
@@ -459,7 +455,7 @@ class SearchAPIFeed:
     def get_prev_feed_record(
         self, record: colrev.record.record.Record
     ) -> colrev.record.record.Record:
-        """Get the previous record dict version"""
+        """Get the previous record dict version."""
         record = deepcopy(record)
         self._set_id(record)
         prev_feed_record_dict = {}
@@ -470,14 +466,14 @@ class SearchAPIFeed:
     def _prep_retrieved_record(
         self, retrieved_record: colrev.record.record.Record
     ) -> None:
-        """Prepare the retrieved record for the search feed"""
+        """Prepare the retrieved record for the search feed."""
         for provenance_key in FieldSet.PROVENANCE_KEYS:
             if provenance_key in retrieved_record.data:
                 del retrieved_record.data[provenance_key]
 
     # TODO : difference to add_record_to_feed ??
     def add_update_record(self, retrieved_record: colrev.record.record.Record) -> bool:
-        """Add or update a record in the api_search_feed and records"""
+        """Add or update a record in the api_search_feed and records."""
         self._prep_retrieved_record(retrieved_record)
         prev_feed_record = self.get_prev_feed_record(retrieved_record)
 
@@ -499,15 +495,13 @@ class SearchAPIFeed:
         return added or updated
 
     def get_records(self) -> dict:
-        """Get the prepared (primary) records"""
-
+        """Get the prepared (primary) records."""
         self._retrieved_records_for_saving = True
 
         return self.records
 
     def save(self, *, skip_print: bool = False) -> None:
         """Save the feed file and records, printing post-run search infos."""
-
         if self.prep_mode:
             assert self._retrieved_records_for_saving, (
                 "You must call get_records() before calling save() "

--- a/colrev/ops/search_db.py
+++ b/colrev/ops/search_db.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Database search operations"""
+"""Database search operations."""
 
 from __future__ import annotations
 
@@ -80,8 +80,7 @@ def get_query_filename(
     add_to_git: bool = False,
     project_root: typing.Optional[Path] = None,
 ) -> Path:
-    """Get the corresponding filename for the search query"""
-
+    """Get the corresponding filename for the search query."""
     query_filename = Path("data/search/") / Path(f"{filename.stem}_query.txt")
     root = project_root or filename.resolve().parents[2]
     review_manager = _ReviewManagerStub(root)
@@ -108,8 +107,7 @@ def create_db_source(
     add_to_git: bool = True,
     logger: typing.Optional[logging.Logger] = logging.getLogger(__name__),
 ) -> colrev.search_file.ExtendedSearchFile:
-    """Interactively add a DB SearchSource"""
-
+    """Interactively add a DB SearchSource."""
     if not all(x in ["search_file"] for x in list(params)):
         raise NotImplementedError  # or parameter error
 

--- a/colrev/ops/status.py
+++ b/colrev/ops/status.py
@@ -15,7 +15,7 @@ from colrev.constants import OperationsType
 
 
 class Status(colrev.process.operation.Operation):
-    """Determine the status of the project"""
+    """Determine the status of the project."""
 
     type = OperationsType.check
 
@@ -26,8 +26,7 @@ class Status(colrev.process.operation.Operation):
         )
 
     def get_analytics(self) -> dict:
-        """Get status analytics"""
-
+        """Get status analytics."""
         analytics_dict = {}
         git_repo = self.review_manager.dataset.git_repo.repo
 
@@ -83,8 +82,7 @@ class Status(colrev.process.operation.Operation):
     def get_review_status_report(
         self, *, records: typing.Optional[dict] = None, colors: bool = True
     ) -> str:
-        """Get the review status report"""
-
+        """Get the review status report."""
         status_stats = self.review_manager.get_status_stats(records=records)
 
         template = colrev.env.utils.get_template(template_path="ops/commit/status.txt")

--- a/colrev/ops/trace.py
+++ b/colrev/ops/trace.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class Trace(colrev.process.operation.Operation):
-    """Trace a record through history"""
+    """Trace a record through history."""
 
     type = OperationsType.check
 
@@ -75,8 +75,7 @@ class Trace(colrev.process.operation.Operation):
 
     @colrev.process.operation.Operation.decorate()
     def main(self, *, record_id: str) -> None:
-        """Trace a record (main entrypoint)"""
-
+        """Trace a record (main entrypoint)."""
         self.review_manager.logger.info(f"Trace record by ID: {record_id}")
         # Ensure the path uses forward slashes, which is compatible with Git's path handling
 

--- a/colrev/ops/upgrade.py
+++ b/colrev/ops/upgrade.py
@@ -32,7 +32,7 @@ from colrev.writer.write_utils import to_string
 
 
 class Upgrade(colrev.process.operation.Operation):
-    """Upgrade a CoLRev project"""
+    """Upgrade a CoLRev project."""
 
     repo: git.Repo
 
@@ -74,11 +74,11 @@ class Upgrade(colrev.process.operation.Operation):
         self.repo.index.add(["settings.json"])
 
     def load_records_dict(self) -> dict:
-        """
-        Load the records dictionary from a file and parse it using the bibtex parser.
+        """Load the records dictionary from a file and parse it using the bibtex parser.
 
         Returns:
             dict: The loaded records dictionary.
+
         """
         records = colrev.loader.load_utils.load(
             filename=Path("data/records.bib"),
@@ -88,11 +88,11 @@ class Upgrade(colrev.process.operation.Operation):
         return records
 
     def save_records_dict(self, records: dict) -> None:
-        """
-        Save the records dictionary to a file and add it to the repository index.
+        """Save the records dictionary to a file and add it to the repository index.
 
         Args:
             records (dict): The records dictionary to save.
+
         """
         bibtex_str = to_string(records_dict=records, implementation="bib")
         with open("data/records.bib", "w", encoding="utf-8") as out:
@@ -100,8 +100,7 @@ class Upgrade(colrev.process.operation.Operation):
         self.repo.index.add(["data/records.bib"])
 
     def main(self) -> None:
-        """Upgrade a CoLRev project (main entrypoint)"""
-
+        """Upgrade a CoLRev project (main entrypoint)."""
         try:
             self.repo = git.Repo(str(self.review_manager.path))
             self.repo.iter_commits()
@@ -794,7 +793,6 @@ class Upgrade(colrev.process.operation.Operation):
 
     def _migrate_0_14_0(self) -> bool:
         """Migrate GitHub Actions workflow files from Poetry to uv and update working directories."""
-
         if Path(".github/workflows").is_dir():
 
             workflow_file = Path("ops/init/colrev_update.yml")
@@ -944,7 +942,7 @@ class Upgrade(colrev.process.operation.Operation):
 
 
 class CoLRevVersion:
-    """Class for handling the CoLRev version"""
+    """Class for handling the CoLRev version."""
 
     def __init__(self, version_string: str) -> None:
         if "+" in version_string:

--- a/colrev/ops/validate.py
+++ b/colrev/ops/validate.py
@@ -20,7 +20,7 @@ from colrev.writer.write_utils import write_file
 
 
 class Validate(colrev.process.operation.Operation):
-    """Validate changes"""
+    """Validate changes."""
 
     type = OperationsType.check
 
@@ -33,7 +33,7 @@ class Validate(colrev.process.operation.Operation):
         self.cpus = 4
 
     def _load_prior_records_dict(self, *, commit_sha: str) -> dict:
-        """If commit is "": return the last committed version of records"""
+        """If commit is "": return the last committed version of records."""
         git_repo = self.review_manager.dataset.git_repo.repo
         # Ensure the path uses forward slashes, which is compatible with Git's path handling
         records_file_path = self.review_manager.paths.RECORDS_FILE_GIT
@@ -131,8 +131,7 @@ class Validate(colrev.process.operation.Operation):
         return change_diff
 
     def _validate_prep_changes(self, *, report: dict) -> None:
-        """Validate preparation changes"""
-
+        """Validate preparation changes."""
         self.review_manager.logger.info("Load records...")
 
         load_operation = self.review_manager.get_load_operation(
@@ -186,8 +185,7 @@ class Validate(colrev.process.operation.Operation):
             merge_candidates_file.unlink()
 
     def _validate_dedupe_changes(self, *, report: dict, commit_sha: str) -> None:
-        """Validate dedupe changes"""
-
+        """Validate dedupe changes."""
         # at some point, we may allow users to validate
         # all duplicates/non-duplicates (across commits)
 
@@ -278,8 +276,7 @@ class Validate(colrev.process.operation.Operation):
         report["dedupe"] = change_diff
 
     def _get_changed_records(self, *, target_commit: str) -> typing.List[dict]:
-        """Get the records that changed in a selected commit"""
-
+        """Get the records that changed in a selected commit."""
         dataset = self.review_manager.dataset
         git_repo = dataset.git_repo.repo
         revlist = (
@@ -331,7 +328,7 @@ class Validate(colrev.process.operation.Operation):
     def _load_changed_records(
         self, *, commit_sha: typing.Optional[str] = None
     ) -> list[dict]:
-        """Load the records that were changed in the target commit"""
+        """Load the records that were changed in the target commit."""
         if commit_sha is None:
             self.review_manager.logger.info("Loading data...")
             records = self.review_manager.dataset.load_records_dict()
@@ -345,8 +342,7 @@ class Validate(colrev.process.operation.Operation):
         return changed_records
 
     def _validate_properties(self, *, commit_sha: str) -> dict:
-        """Validate properties"""
-
+        """Validate properties."""
         # option: --history: check all preceding commits (create a list...)
 
         git_repo = self.review_manager.dataset.git_repo.repo
@@ -486,8 +482,7 @@ class Validate(colrev.process.operation.Operation):
         # current_branch_name: str = "",
         # other_branch_name: str = "",
     ) -> dict:
-        """Validate presceen/screen between merged branches"""
-
+        """Validate presceen/screen between merged branches."""
         prescreen_validation = {"commit_sha": commit_sha, "prescreen": []}
         for rid, record_dict in current_branch_records.items():
             prescreen_validation["prescreen"].append(  # type: ignore
@@ -511,8 +506,7 @@ class Validate(colrev.process.operation.Operation):
         return prescreen_validation
 
     def _validate_merge_changes(self) -> dict:
-        """Validate merge changes (reconciliation between branches)"""
-
+        """Validate merge changes (reconciliation between branches)."""
         merge_validation = []
 
         git_repo = self.review_manager.dataset.git_repo.repo
@@ -574,8 +568,7 @@ class Validate(colrev.process.operation.Operation):
         return {"merge": merge_validation}
 
     def _get_target_commit(self, *, scope: str, filter_setting: str = "") -> str:
-        """Get the commit from commit sha or tree hash"""
-
+        """Get the commit from commit sha or tree hash."""
         commit = ""
         if filter_setting == "contributor":
             return commit
@@ -691,8 +684,7 @@ class Validate(colrev.process.operation.Operation):
         )
 
     def remove_md_origins(self, origins_to_remove: dict) -> None:
-        """Remove origin records for md_ files"""
-
+        """Remove origin records for md_ files."""
         records = self.review_manager.dataset.load_records_dict()
         origins_in_use = [
             o for record in records.values() for o in record[Fields.ORIGIN]
@@ -722,8 +714,7 @@ class Validate(colrev.process.operation.Operation):
         filter_setting: str,
         properties: bool = False,
     ) -> dict:
-        """Validate a commit (main entrypoint)"""
-
+        """Validate a commit (main entrypoint)."""
         target_commit = self._get_target_commit(
             scope=scope, filter_setting=filter_setting
         )

--- a/colrev/package_manager/__init__.py
+++ b/colrev/package_manager/__init__.py
@@ -1,4 +1,4 @@
-"""Package manager"""
+"""Package manager."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/package_manager/check.py
+++ b/colrev/package_manager/check.py
@@ -158,7 +158,6 @@ def _check_project_plugins_colrev(data: dict) -> bool:
 
 def _check_project_entry_points_colrev_keys(data: dict) -> bool:
     """Check if all colrev entry-points in pyproject.toml are valid."""
-
     colrev_data = data.get("project", {}).get("entry-points", {}).get("colrev", {})
     return all(key in BASECLASS_MAP for key in colrev_data)
 
@@ -206,7 +205,6 @@ def _check_build_system(data: dict) -> bool:
 
 def _check_colrev_discovers_package(data: dict) -> bool:
     """Check whether CoLRev can discover this package as a CoLRev package."""
-
     package_name = data.get("project", {}).get("name")
     if not package_name:
         print("No project.name found – cannot check CoLRev package discovery.")
@@ -299,7 +297,6 @@ def _validate_structure(data: dict, checks_dict: dict) -> list[str]:
 
 def main() -> None:
     """Run checks of a CoLRev project."""
-
     file_path = "pyproject.toml"
 
     try:

--- a/colrev/package_manager/colrev_internal_packages.py
+++ b/colrev/package_manager/colrev_internal_packages.py
@@ -107,8 +107,7 @@ def _get_colrev_path() -> Path:
 
 
 def get_internal_packages_dict() -> dict:
-    """Get a dictionary of internal CoLRev packages"""
-
+    """Get a dictionary of internal CoLRev packages."""
     colrev_path = _get_colrev_path()
     packages_dir = colrev_path / Path("packages")
 

--- a/colrev/package_manager/doc_registry_manager.py
+++ b/colrev/package_manager/doc_registry_manager.py
@@ -27,7 +27,7 @@ INTERNAL_PACKAGES = (
 
 # pylint: disable=too-many-instance-attributes
 class PackageDoc:
-    """PackageDoc"""
+    """PackageDoc."""
 
     package_id: str
     version: str
@@ -129,13 +129,11 @@ class PackageDoc:
         return True
 
     def has_endpoint(self, endpoint_type: EndpointType) -> bool:
-        """Check if the package has a specific endpoint type"""
-
+        """Check if the package has a specific endpoint type."""
         return endpoint_type.value in self.endpoints
 
     def _get_authors_for_docs(self) -> str:
-        """Get the authors for the documentation  (without emails in <>)"""
-
+        """Get the authors for the documentation  (without emails in <>)."""
         return ", ".join(author["name"] for author in self.authors)
 
     def _get_docs_short_description(self) -> str:
@@ -270,8 +268,7 @@ class PackageDoc:
         return header_info
 
     def import_package_docs(self) -> None:
-        """Import the package documentation"""
-
+        """Import the package documentation."""
         with open(
             Filepaths.COLREV_PATH
             / Path(f"docs/source/manual/packages/{self.docs_rst_path}"),
@@ -286,7 +283,7 @@ class PackageDoc:
             file.write(output)
 
     def get_endpoint_item(self, endpoint_type: EndpointType) -> dict:
-        """Get the endpoint item for the package
+        """Get the endpoint item for the package.
 
         Format:
         {
@@ -296,7 +293,6 @@ class PackageDoc:
             "search_types": search_types,
         }
         """
-
         status = (
             self.dev_status.replace("stable", "|STABLE|")
             .replace("maturing", "|MATURING|")
@@ -314,7 +310,7 @@ class PackageDoc:
         return endpoint_item
 
     def get_docs_item(self) -> dict:
-        """Get the documentation item for the package
+        """Get the documentation item for the package.
 
         Format:
         {
@@ -345,7 +341,7 @@ class PackageDoc:
 
 # pylint: disable=too-few-public-methods
 class DocRegistryManager:
-    """DocRegistryManager"""
+    """DocRegistryManager."""
 
     # Overview page of packages: rst
     docs_packages_index_path = Filepaths.COLREV_PATH / Path(
@@ -469,7 +465,6 @@ class DocRegistryManager:
 
     def _write_docs_for_index(self) -> None:
         """Writes data from self.docs_for_index to the packages.rst file."""
-
         docs_packages_index_path_content = self.docs_packages_index_path.read_text(
             encoding="utf-8"
         )
@@ -498,7 +493,7 @@ class DocRegistryManager:
                 file.write(line + "\n")
 
     def _update_pypi_packages(self) -> None:
-        """Retrieves CoLRev packages from PyPI"""
+        """Retrieves CoLRev packages from PyPI."""
 
         def ask_package_action(package_name: str) -> str:
             questions = [
@@ -561,7 +556,6 @@ class DocRegistryManager:
 
     def update(self) -> None:
         """Update the package endpoints and the package status."""
-
         self._update_pypi_packages()
         self._load_packages()
 

--- a/colrev/package_manager/init.py
+++ b/colrev/package_manager/init.py
@@ -112,7 +112,7 @@ def _create_built_in_package() -> bool:
 
 # pylint: disable=unused-argument
 def validate_version(answers: list, version: str) -> bool:
-    """Validate the version"""
+    """Validate the version."""
     # return false if the version is not a valid version number
     if version == "":
         return True
@@ -124,7 +124,7 @@ def validate_version(answers: list, version: str) -> bool:
 
 # pylint: disable=unused-argument
 def validate_module_name(answers: list, name: str) -> bool:
-    """Validate the module name"""
+    """Validate the module name."""
     if name == "":  # Accept default module name
         return True
     # return false if the name is not a valid python module name
@@ -588,7 +588,6 @@ def _add_to_packages_json(package_data: dict) -> None:
 
 def main() -> None:
     """Main function to create a CoLRev package."""
-
     built_in = _create_built_in_package()
     current_dir = Path.cwd()
     if any(Path(current_dir).iterdir()):

--- a/colrev/package_manager/package.py
+++ b/colrev/package_manager/package.py
@@ -23,7 +23,7 @@ BASECLASS_OVERVIEW = base_classes.BASECLASS_OVERVIEW
 
 
 class Package:
-    """A Python package for CoLRev"""
+    """A Python package for CoLRev."""
 
     def __init__(self, package_identifier: str) -> None:
         try:
@@ -54,13 +54,11 @@ class Package:
         self.version = self.package.metadata["Version"]
 
     def has_endpoint(self, endpoint_type: EndpointType) -> bool:
-        """Check if the package has a specific endpoint type"""
-
+        """Check if the package has a specific endpoint type."""
         return endpoint_type.value in [e.name for e in self.package.entry_points]
 
     def get_endpoint(self, endpoint_type: EndpointType) -> str:
-        """Get the endpoint for a package type"""
-
+        """Get the endpoint for a package type."""
         if endpoint_type.value not in [e.name for e in self.package.entry_points]:
             raise colrev_exceptions.MissingDependencyError(
                 f"Package {self.name} does not have a {endpoint_type} endpoint"
@@ -88,7 +86,7 @@ class Package:
             )
 
     def get_endpoint_class(self, package_type: EndpointType) -> typing.Any:
-        """Get the endpoint class for a package type"""
+        """Get the endpoint class for a package type."""
         if not self.has_endpoint(package_type):
             raise colrev_exceptions.MissingDependencyError(
                 f"Package {self.name} does not have a {package_type} endpoint"
@@ -104,8 +102,7 @@ class Package:
     def add_to_type_identifier_endpoint_dict(
         self, type_identifier_endpoint_dict: dict
     ) -> None:
-        """Add the package to the type_identifier_endpoint_dict dict"""
-
+        """Add the package to the type_identifier_endpoint_dict dict."""
         for endpoint_type in EndpointType:
             if self.has_endpoint(endpoint_type):
                 type_identifier_endpoint_dict[endpoint_type][self.name] = (

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -25,7 +25,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class ReviewTypePackageBaseClass(abc.ABC):
-    """The base class for ReviewType packages
+    """The base class for ReviewType packages.
 
     The following cli command calls the initialize method of a ReviewType package:
 
@@ -48,11 +48,11 @@ class ReviewTypePackageBaseClass(abc.ABC):
 
     @abstractmethod
     def initialize(self, settings: colrev.settings.Settings) -> dict:
-        """Initialize the review type"""
+        """Initialize the review type."""
 
 
 class SearchSourcePackageBaseClass(ABC):
-    """The base class for SearchSource packages
+    """The base class for SearchSource packages.
 
     The following cli commands call specific methods of a SearchSource package:
 
@@ -221,7 +221,8 @@ class PrescreenPackageBaseClass(ABC):
 
     The following cli command calls the run_prescreen method of a Prescreen package:
 
-    ``colrev prescreen`` -> calls ``package.run_prescreen()``"""
+    ``colrev prescreen`` -> calls ``package.run_prescreen()``
+    """
 
     ci_supported: bool
 
@@ -279,7 +280,8 @@ class PDFGetManPackageBaseClass(ABC):
 
     The following cli command calls the pdf_get_man method of a PDFGetMan package:
 
-    ``colrev pdf-get-man`` -> calls ``package.pdf_get_man()``"""
+    ``colrev pdf-get-man`` -> calls ``package.pdf_get_man()``
+    """
 
     ci_supported: bool
 

--- a/colrev/package_manager/package_manager.py
+++ b/colrev/package_manager/package_manager.py
@@ -18,7 +18,7 @@ from colrev.constants import Filepaths
 
 
 class PackageManager:
-    """The PackageManager provides functionality for package lookup and discovery"""
+    """The PackageManager provides functionality for package lookup and discovery."""
 
     def _get_package_identifiers(self) -> list:
         group = "colrev"
@@ -46,8 +46,7 @@ class PackageManager:
         return type_identifier_endpoint_dict
 
     def discover_packages(self, *, package_type: EndpointType) -> typing.Dict:
-        """Discover packages (registered in the CoLRev environment)"""
-
+        """Discover packages (registered in the CoLRev environment)."""
         # [{'package_endpoint_identifier': 'colrev.abi_inform_proquest',
         #   'status': '|EXPERIMENTAL|',
         #   'short_description': 'ABI/INFORM (ProQuest) ...'},
@@ -57,8 +56,7 @@ class PackageManager:
             return package_endpoints[package_type.value]
 
     def discover_installed_packages(self, *, package_type: EndpointType) -> typing.Dict:
-        """Discover installed packages"""
-
+        """Discover installed packages."""
         # {EndpointType.review_type:
         #   {'colrev.blank': {'endpoint': 'colrev.packages.review_types.blank.BlankReview'},
         #     ...
@@ -70,14 +68,12 @@ class PackageManager:
     def get_package_endpoint_class(  # type: ignore
         self, *, package_type: EndpointType, package_identifier: str
     ):
-        """Load a package endpoint"""
-
+        """Load a package endpoint."""
         package = colrev.package_manager.package.Package(package_identifier)
         return package.get_endpoint_class(package_type)
 
     def is_installed(self, package_name: str, *, uv: bool = False) -> bool:
-        """Check if a package is installed"""
-
+        """Check if a package is installed."""
         fixed_package_name = package_name.replace("_", "-").replace(".", "-")
 
         if uv:
@@ -149,8 +145,7 @@ class PackageManager:
         review_manager: colrev.review_manager.ReviewManager,
         uv: bool = False,
     ) -> None:
-        """Install all packages required for the CoLRev project"""
-
+        """Install all packages required for the CoLRev project."""
         review_manager.logger.info("Install project")
         packages = self._get_packages_to_install(review_manager=review_manager, uv=uv)
         if len(packages) == 0:
@@ -167,8 +162,7 @@ class PackageManager:
         editable: bool = False,
         uv: bool = False,
     ) -> None:
-        """Install packages using uv if available, otherwise fallback to pip"""
-
+        """Install packages using uv if available, otherwise fallback to pip."""
         if uv:
             package_manager = ["uv", "pip"]
         else:

--- a/colrev/package_manager/package_settings.py
+++ b/colrev/package_manager/package_settings.py
@@ -8,7 +8,7 @@ from pydantic import Field
 
 
 class DefaultSettings(BaseModel):
-    """Endpoint settings"""
+    """Endpoint settings."""
 
     endpoint: str = Field()
 

--- a/colrev/packages/__init__.py
+++ b/colrev/packages/__init__.py
@@ -1,4 +1,4 @@
-"""Built-in packages for CoLRev"""
+"""Built-in packages for CoLRev."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: ABI/INFORM (ProQuest)"""
+"""SearchSource: ABI/INFORM (ProQuest)."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.writer.write_utils import write_file
 
 
 class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """ABI/INFORM (ProQuest)"""
+    """ABI/INFORM (ProQuest)."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -49,8 +49,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for ABI/INFORM (ProQuest)"""
-
+        """Source heuristic for ABI/INFORM (ProQuest)."""
         result = {"confidence": 0.0}
 
         if "proquest.com" in data:  # nosec
@@ -68,8 +67,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint"""
-
+        """Add SearchSource as an endpoint."""
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
@@ -82,8 +80,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of ABI/INFORM"""
-
+        """Run a search of ABI/INFORM."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -131,7 +128,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -255,8 +252,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -279,8 +275,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for ABI/INFORM (ProQuest)"""
-
+        """Source-specific preparation for ABI/INFORM (ProQuest)."""
         if (
             record.data.get(Fields.JOURNAL, "")
             .lower()

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: ACM Digital Library"""
+"""SearchSource: ACM Digital Library."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ if typing.TYPE_CHECKING:
 
 
 class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
-    """ACM digital Library"""
+    """ACM digital Library."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -51,8 +51,7 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for ACM dDigital Library"""
-
+        """Source heuristic for ACM dDigital Library."""
         result = {"confidence": 0.0}
         # Simple heuristic:
         if "publisher = {Association for Computing Machinery}," in data:
@@ -65,8 +64,7 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
     def add_endpoint(
         cls, params: str, path: Path, logger: typing.Optional[logging.Logger] = None
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             for item in params.split(";"):
@@ -93,8 +91,7 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of ACM Digital Library"""
-
+        """Run a search of ACM Digital Library."""
         if self.search_source.search_type == SearchType.DB:
             if self.search_source.search_results_path.suffix in [".bib"]:
                 run_db_search(
@@ -114,12 +111,11 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
@@ -155,6 +151,5 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for ACM Digital Library"""
-
+        """Source-specific preparation for ACM Digital Library."""
         return record

--- a/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
+++ b/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Adding of journal rankings to metadata"""
+"""Adding of journal rankings to metadata."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from colrev.constants import Fields
 
 
 class AddJournalRanking(base_classes.PrepPackageBaseClass):
-    """Prepares records based on journal rankings"""
+    """Prepares records based on journal rankings."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     source_correction_hint = "check with the developer"
@@ -44,8 +44,7 @@ class AddJournalRanking(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Add Journalranking to Metadata"""
-
+        """Add Journalranking to Metadata."""
         if record.data.get(Fields.JOURNAL, "") == "":
             return record
 

--- a/colrev/packages/ais_library/src/ais_load_utils.py
+++ b/colrev/packages/ais_library/src/ais_load_utils.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Load utils for AIS"""
+"""Load utils for AIS."""
 
 from __future__ import annotations
 
@@ -34,7 +34,6 @@ def enl_entrytype_setter(record_dict: dict) -> None:
 
 def bib_field_mapper(record_dict: dict) -> None:
     """Map the fields for BibTeX files."""
-
     record_dict.pop("type", None)
     record_dict.pop("IG", None)
 

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: AIS electronic Library"""
+"""SearchSource: AIS electronic Library."""
 
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ from colrev.packages.ais_library.src import aisel_api
 
 
 class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
-    """AIS electronic Library (AISeL)"""
+    """AIS electronic Library (AISeL)."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -87,8 +87,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for AIS electronic Library (AISeL)"""
-
+        """Source heuristic for AIS electronic Library (AISeL)."""
         result = {"confidence": 0.0}
         # TBD: aisel does not return bibtex?!
         nr_ais_links = data.count("https://aisel.aisnet.org/")
@@ -170,7 +169,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -225,8 +224,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
-
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
 
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
@@ -277,8 +275,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         ais_feed.save()
 
     def search(self, rerun: bool) -> None:
-        """Run a search of AISeLibrary"""
-
+        """Run a search of AISeLibrary."""
         self._validate_source()
 
         if self.search_source.search_type == SearchType.API:
@@ -307,7 +304,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -334,8 +331,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         # pylint: disable=colrev-missed-constant-usage
         if self.search_source.search_results_path.suffix in [".txt", ".enl"]:
             return self._load_enl(
@@ -476,8 +472,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for the AIS electronic Library (AISeL)"""
-
+        """Source-specific preparation for the AIS electronic Library (AISeL)."""
         self._fix_entrytype(record=record)
         self._unify_container_titles(record=record)
         self._format_fields(record=record)

--- a/colrev/packages/ais_library/src/aisel_api.py
+++ b/colrev/packages/ais_library/src/aisel_api.py
@@ -34,7 +34,6 @@ class AISeLAPI:
 
     def _get(self, url: str, *, timeout: int) -> requests.Response:
         """Execute a GET request and raise a custom exception on failure."""
-
         try:
             response = self.session.get(url, headers=self.headers, timeout=timeout)
             response.raise_for_status()

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: arXiv"""
+"""SearchSource: arXiv."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ from colrev.packages.arxiv.src import arxiv_api
 
 
 class ArXivSource(base_classes.SearchSourcePackageBaseClass):
-    """arXiv"""
+    """arXiv."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -64,7 +64,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for ArXiv"""
+        """Source heuristic for ArXiv."""
         result = {"confidence": 0.0}
 
         return result
@@ -76,7 +76,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -122,7 +122,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         search_operation: colrev.ops.search.Search,
         source: colrev.search_file.ExtendedSearchFile,
     ) -> None:
-        """Validate the SearchSource (parameters etc.)"""
+        """Validate the SearchSource (parameters etc.)."""
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
 
         if source.search_results_path.name != self._arxiv_md_filename.name:
@@ -137,7 +137,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         self.logger.debug(f"SearchSource {source.search_results_path} validated")
 
     def check_availability(self) -> None:
-        """Check status (availability) of the ArXiv API"""
+        """Check status (availability) of the ArXiv API."""
         try:
             self.api.check_availability(timeout=30)
         except arxiv_api.ArxivAPIError as exc:
@@ -152,7 +152,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata fromArXiv based on similarity with the record provided"""
+        """Retrieve masterdata fromArXiv based on similarity with the record provided."""
         # https://info.arxiv.org/help/api/user-manual.html#_query_interface
         # id_list
         return record
@@ -232,7 +232,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
     #     arxiv_feed.save()
 
     def search(self, rerun: bool) -> None:
-        """Run a search of ArXiv"""
+        """Run a search of ArXiv."""
         arxiv_feed = colrev.ops.search_api_feed.SearchAPIFeed(
             source_identifier=self.source_identifier,
             search_source=self.search_source,
@@ -253,7 +253,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
             )
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
+        """Load the records from the SearchSource file."""
         # for API-based searches
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
@@ -279,7 +279,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for ArXiv"""
+        """Source-specific preparation for ArXiv."""
         if Fields.AUTHOR in record.data:
             record.data[Fields.AUTHOR] = (
                 colrev.record.record_prep.PrepRecord.format_author_field(

--- a/colrev/packages/arxiv/src/arxiv_api.py
+++ b/colrev/packages/arxiv/src/arxiv_api.py
@@ -33,7 +33,6 @@ class ArxivAPI:
 
     def check_availability(self, *, timeout: int) -> None:
         """Check the health endpoint of the arXiv API."""
-
         try:
             response = self.session.get(
                 "https://export.arxiv.org/api/"

--- a/colrev/packages/arxiv/src/record_transformer.py
+++ b/colrev/packages/arxiv/src/record_transformer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Utility to transform items from arXiv into records"""
+"""Utility to transform items from arXiv into records."""
 
 from __future__ import annotations
 
@@ -24,8 +24,7 @@ FIELDS_TO_REMOVE = [
 
 
 def parse_record(entry: dict) -> dict:
-    """Transform an arXiv item into a record"""
-
+    """Transform an arXiv item into a record."""
     entry[Fields.ENTRYTYPE] = "techreport"
     entry["arxivid"] = entry.pop("id").replace("http://arxiv.org/abs/", "")
     entry[Fields.AUTHOR] = " and ".join([a["name"] for a in entry.pop("authors")])

--- a/colrev/packages/bibliography_export/src/bibliography_export.py
+++ b/colrev/packages/bibliography_export/src/bibliography_export.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Export of references in different bibliographical formats as a data operation"""
+"""Export of references in different bibliographical formats as a data operation."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from colrev.writer.write_utils import write_file
 
 
 class BibFormats(Enum):
-    """Enum of available bibliography formats"""
+    """Enum of available bibliography formats."""
 
     # pylint: disable=invalid-name
     zotero = "zotero"
@@ -42,7 +42,7 @@ class BibFormats(Enum):
 class BibliographyExportSettings(
     colrev.package_manager.package_settings.DefaultSettings, BaseModel
 ):
-    """Settings for BibliographyExport"""
+    """Settings for BibliographyExport."""
 
     endpoint: str
     version: str
@@ -50,7 +50,7 @@ class BibliographyExportSettings(
 
 
 class BibliographyExport(base_classes.DataPackageBaseClass):
-    """Export the sample references in Endpoint format"""
+    """Export the sample references in Endpoint format."""
 
     settings: BibliographyExportSettings
     settings_class = BibliographyExportSettings
@@ -114,8 +114,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
 
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add bibliography as an endpoint"""
-
+        """Add bibliography as an endpoint."""
         add_package = {
             "endpoint": "colrev.bibliography_export",
             "version": "0.1",
@@ -158,8 +157,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         silent_mode: bool,
     ) -> None:
-        """Update the data/bibliography"""
-
+        """Update the data/bibliography."""
         if silent_mode:
             return
 
@@ -199,7 +197,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
+        """Update the record_status_matrix."""
         # Note : automatically set all to True / synthesized
         for syn_id in list(synthesized_record_status_matrix.keys()):
             synthesized_record_status_matrix[syn_id][endpoint_identifier] = True
@@ -207,8 +205,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         data_endpoint = "Data operation [bibliography export data endpoint]: "
 
         advice = {

--- a/colrev/packages/blank/src/blank.py
+++ b/colrev/packages/blank/src/blank.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Blank literature review"""
+"""Blank literature review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class BlankReview(base_classes.ReviewTypePackageBaseClass):
-    """Blank review"""
+    """Blank review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -36,8 +36,7 @@ class BlankReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a blank review"""
-
+        """Initialize a blank review."""
         settings.data.data_package_endpoints = []
         settings.sources = []
         settings.prep.prep_rounds[0].prep_package_endpoints = []

--- a/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
+++ b/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""CliPrepMan"""
+"""CliPrepMan."""
 
 import logging
 import typing
@@ -17,7 +17,7 @@ from colrev.packages.crossref.src import crossref_api
 
 
 class CliPrepMan(PrepManPackageBaseClass):
-    """CLI for manual preparation of records"""
+    """CLI for manual preparation of records."""
 
     def __init__(
         self,
@@ -33,7 +33,6 @@ class CliPrepMan(PrepManPackageBaseClass):
         self, similar_records: typing.List[colrev.record.record_prep.PrepRecord]
     ) -> list:
         """Generate choices for the user to select a record to merge."""
-
         choices = []
         for i, r in enumerate(similar_records):
             title = r.data.get(Fields.TITLE, "No Title")
@@ -102,7 +101,6 @@ class CliPrepMan(PrepManPackageBaseClass):
 
     def prepare_manual(self, records: dict) -> dict:
         """Run the prep-man operation."""
-
         for record in records.values():
             # if record[Fields.STATUS] != RecordState.md_needs_manual_preparation:
             #     continue
@@ -115,8 +113,7 @@ class CliPrepMan(PrepManPackageBaseClass):
 
 
 def main() -> None:
-    """Main function to run the CLI"""
-
+    """Main function to run the CLI."""
     print("CLI initialized")
 
     def _select_target_ids(records: dict[str, dict]) -> list[str]:

--- a/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""CLI interface for manual retrieval of PDFs"""
+"""CLI interface for manual retrieval of PDFs."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.constants import RecordState
 
 
 class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
-    """Get PDFs manually based on a CLI"""
+    """Get PDFs manually based on a CLI."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -185,8 +185,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
         )
 
     def print_record(self, *, record_dict: dict) -> None:
-        """Print the record for pdf-get-man (cli)"""
-
+        """Print the record for pdf-get-man (cli)."""
         ret_str = f"  ID:       {record_dict['ID']} ({record_dict['ENTRYTYPE']})"
         ret_str += (
             f"\n  title:    {Colors.GREEN}{record_dict.get('title', 'no title')}{Colors.END}"
@@ -263,8 +262,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
         self.review_manager.update_status_yaml()
 
     def pdf_get_man(self, records: dict) -> dict:
-        """Get the PDF manually based on a cli"""
-
+        """Get the PDF manually based on a cli."""
         self.logger.info("Retrieve PDFs manually")
         pdf_get_operation = self.review_manager.get_pdf_get_operation()
         pdf_dir = self.pdf_dir

--- a/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""CLI interface for manual preparation of PDFs"""
+"""CLI interface for manual preparation of PDFs."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ from colrev.constants import RecordState
 
 
 class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
-    """Manually prepare PDFs based on a CLI (not yet implemented)"""
+    """Manually prepare PDFs based on a CLI (not yet implemented)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -235,7 +235,7 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
                 raise QuitPressedException()
 
     def _print_pdf_prep_man(self, record: colrev.record.record.Record) -> None:
-        """Print the record for pdf-prep-man operations"""
+        """Print the record for pdf-prep-man operations."""
         # pylint: disable=too-many-branches
         ret_str = ""
         if Fields.FILE in record.data:
@@ -347,8 +347,7 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
         return records
 
     def pdf_prep_man(self, records: dict) -> dict:
-        """Prepare PDF manually based on a cli"""
-
+        """Prepare PDF manually based on a cli."""
         self.logger.info("Loading data for pdf_prep_man")
         pdf_prep_man_data = self.pdf_prep_man_operation.get_data()
         records = self.review_manager.dataset.load_records_dict()
@@ -384,4 +383,4 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
 
 
 class QuitPressedException(Exception):
-    """Quit-pressed exception"""
+    """Quit-pressed exception."""

--- a/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
+++ b/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Prescreen based on CLI"""
+"""Prescreen based on CLI."""
 
 from __future__ import annotations
 
@@ -22,8 +22,7 @@ from colrev.constants import RecordState
 
 
 def _print_prescreen_record(record_dict: dict) -> None:
-    """Print the record for prescreen operations"""
-
+    """Print the record for prescreen operations."""
     ret_str = f"  ID: {record_dict['ID']} ({record_dict[Fields.ENTRYTYPE]})"
     ret_str += (
         f"\n  {Colors.GREEN}{record_dict.get(Fields.TITLE, 'no title')}{Colors.END}"
@@ -54,7 +53,7 @@ def _print_prescreen_record(record_dict: dict) -> None:
 
 
 class CoLRevCLIPrescreen(base_classes.PrescreenPackageBaseClass):
-    """CLI-based prescreen"""
+    """CLI-based prescreen."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -133,8 +132,7 @@ class CoLRevCLIPrescreen(base_classes.PrescreenPackageBaseClass):
         records: dict,
         split: list,
     ) -> dict:
-        """Prescreen records based on a cli"""
-
+        """Prescreen records based on a cli."""
         if not split:
             split = []
 

--- a/colrev/packages/colrev_cli_screen/src/screen_cli.py
+++ b/colrev/packages/colrev_cli_screen/src/screen_cli.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Screen based on CLI"""
+"""Screen based on CLI."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from colrev.constants import ScreenCriterionType
 
 
 class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
-    """Screen documents using a CLI"""
+    """Screen documents using a CLI."""
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-few-public-methods
@@ -288,8 +288,7 @@ class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
         return records
 
     def run_screen(self, records: dict, split: list) -> dict:
-        """Screen records based on a cli"""
-
+        """Screen records based on a cli."""
         records = self._screen_cli(split)
 
         return records

--- a/colrev/packages/colrev_curation/src/colrev_curation.py
+++ b/colrev/packages/colrev_curation/src/colrev_curation.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Colrev curated data as part of the data operations"""
+"""Colrev curated data as part of the data operations."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from colrev.constants import RecordState
 class ColrevCurationSettings(
     colrev.package_manager.package_settings.DefaultSettings, BaseModel
 ):
-    """Colrev Curation settings"""
+    """Colrev Curation settings."""
 
     endpoint: str
     version: str
@@ -35,7 +35,7 @@ class ColrevCurationSettings(
 
 
 class ColrevCuration(base_classes.DataPackageBaseClass):
-    """CoLRev Curation"""
+    """CoLRev Curation."""
 
     settings: ColrevCurationSettings
     ci_supported: bool = Field(default=True)
@@ -62,8 +62,7 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
-
+        """Add as an endpoint."""
         add_source = {
             "endpoint": "colrev.colrev_curation",
             "version": "0.1",
@@ -263,7 +262,8 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
 
     def _source_comparison(self, *, silent_mode: bool) -> None:
         """Exports a table to support analyses of records that are not
-        in all sources (for curated repositories)"""
+        in all sources (for curated repositories).
+        """
         dedupe_dir = self.review_manager.paths.dedupe
         dedupe_dir.mkdir(exist_ok=True, parents=True)
         source_comparison_xlsx = dedupe_dir / Path("source_comparison.xlsx")
@@ -307,8 +307,7 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,  # pylint: disable=unused-argument
         silent_mode: bool,
     ) -> None:
-        """Update the CoLRev curation"""
-
+        """Update the CoLRev curation."""
         if self.settings.curated_masterdata:
             self._update_stats_in_readme(
                 records=records,
@@ -321,16 +320,14 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
-
+        """Update the record_status_matrix."""
         for item in synthesized_record_status_matrix:
             synthesized_record_status_matrix[item][endpoint_identifier] = True
 
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         records = self.review_manager.dataset.load_records_dict()
         advice = {
             "msg": "TODO (add curation-specific advice...)",

--- a/colrev/packages/colrev_curation/src/curation_prep.py
+++ b/colrev/packages/colrev_curation/src/curation_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Preparation of curations"""
+"""Preparation of curations."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ from colrev.constants import RecordState
 
 
 class CurationPrep(base_classes.PrepPackageBaseClass):
-    """Preparation of curations"""
+    """Preparation of curations."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -57,8 +57,7 @@ class CurationPrep(base_classes.PrepPackageBaseClass):
     def _get_applicable_curation_restrictions(
         self, *, record: colrev.record.record.Record
     ) -> dict:
-        """Get the applicable curation restrictions"""
-
+        """Get the applicable curation restrictions."""
         if not str(record.data.get(Fields.YEAR, "NA")).isdigit():
             return {}
 
@@ -80,7 +79,7 @@ class CurationPrep(base_classes.PrepPackageBaseClass):
     def apply_curation_restrictions(
         self, *, record: colrev.record.record.Record
     ) -> None:
-        """Apply the curation restrictions"""
+        """Apply the curation restrictions."""
         applicable_curation_restrictions = self._get_applicable_curation_restrictions(
             record=record
         )
@@ -138,8 +137,7 @@ class CurationPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare records in a CoLRev curation"""
-
+        """Prepare records in a CoLRev curation."""
         record.data.pop(Fields.CITED_BY, None)
 
         if record.data[Fields.STATUS] == RecordState.rev_prescreen_excluded:

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: CoLRev project"""
+"""SearchSource: CoLRev project."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ from colrev.constants import SearchType
 
 
 class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """CoLRev projects"""
+    """CoLRev projects."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -57,7 +57,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     # pylint: disable=colrev-missed-constant-usage
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
 
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
@@ -81,8 +81,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         # Always API search
         params = input(
             "Enter the URL of the CoLRev project (e.g., git@github.com:...): "
@@ -180,8 +179,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         return data_copy
 
     def search(self, rerun: bool) -> None:
-        """Run a search of a CoLRev project"""
-
+        """Run a search of a CoLRev project."""
         # pylint: disable=too-many-locals
 
         self._validate_source()
@@ -271,13 +269,12 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for CoLRev projects"""
-
+        """Source heuristic for CoLRev projects."""
         result = {"confidence": 0.0}
         if "colrev_project" in data:
             result["confidence"] = 1.0
@@ -285,8 +282,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         return result
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -307,6 +303,5 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for CoLRev projects"""
-
+        """Source-specific preparation for CoLRev projects."""
         return record

--- a/colrev/packages/conceptual_review/src/conceptual_review.py
+++ b/colrev/packages/conceptual_review/src/conceptual_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Conceptual review"""
+"""Conceptual review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class ConceptualReview(base_classes.ReviewTypePackageBaseClass):
-    """Conceptual review"""
+    """Conceptual review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -37,8 +37,7 @@ class ConceptualReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a conceptual review"""
-
+        """Initialize a conceptual review."""
         settings.data.data_package_endpoints = [
             {
                 "endpoint": "colrev.paper_md",

--- a/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
+++ b/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Conditional prescreen"""
+"""Conditional prescreen."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from colrev.constants import RecordState
 
 
 class ConditionalPrescreen(base_classes.PrescreenPackageBaseClass):
-    """Conditional prescreen (currently: include all)"""
+    """Conditional prescreen (currently: include all)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -40,8 +40,7 @@ class ConditionalPrescreen(base_classes.PrescreenPackageBaseClass):
         records: dict,
         split: list,  # pylint: disable=unused-argument
     ) -> dict:
-        """Prescreen records based on predefined conditions (rules)"""
-
+        """Prescreen records based on predefined conditions (rules)."""
         pad = 50
         for record in records.values():
             if record[Fields.STATUS] != RecordState.md_processed:

--- a/colrev/packages/crossref/src/crossref_api.py
+++ b/colrev/packages/crossref/src/crossref_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Crossref API"""
+"""Crossref API."""
 
 from __future__ import annotations
 
@@ -35,16 +35,16 @@ SESSION = requests_cache.CachedSession(
 
 
 class CrossrefAPIError(Exception):
-    """Crossref API Error"""
+    """Crossref API Error."""
 
 
 class MaxOffsetError(CrossrefAPIError):
-    """Max Offset Error"""
+    """Max Offset Error."""
 
 
 # pylint: disable=too-few-public-methods
 class HTTPRequest:
-    """HTTP Request"""
+    """HTTP Request."""
 
     def __init__(self, *, timeout: int, cache: bool = True) -> None:
         self.rate_limits = {"x-rate-limit-limit": 50, "x-rate-limit-interval": 1}
@@ -88,7 +88,6 @@ class HTTPRequest:
         skip_throttle: bool = False,
     ) -> requests.Response:
         """Retrieve data from a given endpoint."""
-
         if only_headers is True:
             return requests.head(endpoint, timeout=2)
 
@@ -109,7 +108,7 @@ class HTTPRequest:
 
 
 class Endpoint:
-    """Endpoint"""
+    """Endpoint."""
 
     cursor_as_iter_method = False
 
@@ -167,7 +166,6 @@ class Endpoint:
     @property
     def version(self) -> str:
         """API version."""
-
         request_params = dict(self.request_params)
         request_url = str(self.request_url)
 
@@ -219,7 +217,6 @@ class Endpoint:
     @property
     def url(self) -> str:
         """Retrieve the url that will be used as a HTTP request."""
-
         request_params = self._escaped_pagging()
         sorted_request_params = sorted(request_params.items())
 
@@ -309,7 +306,7 @@ class Endpoint:
 
 
 class CrossrefAPI:
-    """Crossref API"""
+    """Crossref API."""
 
     ISSN_REGEX = r"^\d{4}-?\d{3}[\dxX]$"
     YEAR_SCOPE_REGEX = r"^\d{4}-\d{4}$"
@@ -351,8 +348,7 @@ class CrossrefAPI:
             self.cache = cache
 
     def check_availability(self) -> None:
-        """Check the availability of the API"""
-
+        """Check the availability of the API."""
         try:
             # pylint: disable=duplicate-code
             test_rec = {
@@ -384,8 +380,7 @@ class CrossrefAPI:
             ) from exc
 
     def get_url(self) -> str:
-        """Get the url for the Crossref API"""
-
+        """Get the url for the Crossref API."""
         url = self.url
         if not self.rerun and self.last_updated:
             # see https://api.staging.crossref.org/swagger-ui/
@@ -398,20 +393,17 @@ class CrossrefAPI:
         return url
 
     def get_len_total(self) -> int:
-        """Get the total number of records from Crossref based on the parameters"""
-
+        """Get the total number of records from Crossref based on the parameters."""
         endpoint = Endpoint(self.url, email=self.email, cache=self.cache)
         return endpoint.get_nr()
 
     def get_number_of_records(self) -> int:
-        """Get the number of records from Crossref based on the parameters"""
-
+        """Get the number of records from Crossref based on the parameters."""
         endpoint = Endpoint(self.get_url(), email=self.email, cache=self.cache)
         return endpoint.get_nr()
 
     def get_records(self) -> typing.Iterator[colrev.record.record.Record]:
-        """Get records from Crossref based on the parameters"""
-
+        """Get records from Crossref based on the parameters."""
         url = self.get_url()
 
         endpoint = Endpoint(url, email=self.email, cache=self.cache)
@@ -525,8 +517,7 @@ class CrossrefAPI:
         jour_vol_iss_list: bool = False,
         top_n: int = 1,
     ) -> list:
-        """Retrieve records from Crossref based on a query"""
-
+        """Retrieve records from Crossref based on a query."""
         record = record_input.copy_prep_rec()
         record_list: list[colrev.record.record.Record] = []
         candidates: list[colrev.record.record.Record] = []
@@ -605,8 +596,7 @@ class CrossrefAPI:
 def query_doi(
     *, doi: str, email: str = "my@email.edu"
 ) -> colrev.record.record_prep.PrepRecord:
-    """Get records from Crossref based on a doi query"""
-
+    """Get records from Crossref based on a doi query."""
     try:
         endpoint = Endpoint("https://api.crossref.org/works/" + doi, email=email)
 

--- a/colrev/packages/crossref/src/crossref_prep.py
+++ b/colrev/packages/crossref/src/crossref_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on Crossref API as a prep operation"""
+"""Consolidation of metadata based on Crossref API as a prep operation."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.constants import SearchType
 
 
 class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on crossref.org metadata"""
+    """Prepares records based on crossref.org metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -78,7 +78,7 @@ class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
         ]
 
     def check_availability(self) -> None:
-        """Check status (availability) of the Crossref API"""
+        """Check status (availability) of the Crossref API."""
         self.crossref_source.check_availability()
 
     # pylint: disable=unused-argument
@@ -89,8 +89,7 @@ class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record based on Crossref metadata"""
-
+        """Prepare a record based on Crossref metadata."""
         if any(
             crossref_prefix in o
             for crossref_prefix in self.crossref_prefixes

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Crossref"""
+"""SearchSource: Crossref."""
 
 from __future__ import annotations
 
@@ -36,7 +36,7 @@ from colrev.packages.crossref.src.crossref_api import query_doi
 
 
 class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Crossref API"""
+    """Crossref API."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -120,8 +120,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Crossref"""
-
+        """Source heuristic for Crossref."""
         result = {"confidence": 0.0}
         return result
 
@@ -204,7 +203,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint"""
+        """Add SearchSource as an endpoint."""
         params_dict = cls._parse_params(params)
         search_type = cls._select_search_type(params_dict)
 
@@ -273,7 +272,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def check_availability(self) -> None:
-        """Check status (availability) of the Crossref API"""
+        """Check status (availability) of the Crossref API."""
         self.api.check_availability()
 
     def _prep_crossref_record(
@@ -312,7 +311,8 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         feed: colrev.ops.search_api_feed.SearchAPIFeed,
     ) -> None:
         """Restore the url from the feed if it exists
-        (url-resolution is not always available)"""
+        (url-resolution is not always available).
+        """
         prev_record = feed.get_prev_feed_record(record)
         prev_url = prev_record.data.get(Fields.URL, None)
         if prev_url is None:
@@ -423,8 +423,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         crossref_feed.save()
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Crossref"""
-
+        """Run a search of Crossref."""
         crossref_feed = colrev.ops.search_api_feed.SearchAPIFeed(
             source_identifier=self.source_identifier,
             search_source=self.search_source,
@@ -447,8 +446,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
             raise NotImplementedError
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -463,8 +461,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Crossref"""
-
+        """Source-specific preparation for Crossref."""
         return record
 
     def _get_masterdata_record(
@@ -585,8 +582,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 30,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from Crossref based on similarity with the record provided"""
-
+        """Retrieve masterdata from Crossref based on similarity with the record provided."""
         # To test the metadata provided for a particular DOI use:
         # https://api.crossref.org/works/DOI
         if len(record.data.get(Fields.TITLE, "")) < 5 and Fields.DOI not in record.data:

--- a/colrev/packages/crossref/src/record_transformer.py
+++ b/colrev/packages/crossref/src/record_transformer.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Utility to transform crossref/doi.org items to records"""
+"""Utility to transform crossref/doi.org items to records."""
 
 from __future__ import annotations
 
@@ -184,8 +184,7 @@ def _remove_fields(*, record_dict: dict) -> dict:
 
 
 def json_to_record(*, item: dict) -> colrev.record.record_prep.PrepRecord:
-    """Convert a crossref item to a record dict"""
-
+    """Convert a crossref item to a record dict."""
     try:
         record_dict = _item_to_record(item=deepcopy(item))
         record_dict = _set_forthcoming(record_dict=record_dict)

--- a/colrev/packages/curated_masterdata/src/curated_masterdata.py
+++ b/colrev/packages/curated_masterdata/src/curated_masterdata.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Curated metadata project"""
+"""Curated metadata project."""
 
 import logging
 import typing
@@ -18,7 +18,7 @@ from colrev.constants import SearchType
 
 
 class CuratedMasterdata(base_classes.ReviewTypePackageBaseClass):
-    """Curated masterdata"""
+    """Curated masterdata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -40,8 +40,7 @@ class CuratedMasterdata(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a curated masterdata repository"""
-
+        """Initialize a curated masterdata repository."""
         self.logger.info("Initializing curated masterdata repository")
 
         # replace readme

--- a/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
+++ b/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Dedupe functionality dedicated to curated metadata repositories"""
+"""Dedupe functionality dedicated to curated metadata repositories."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ from colrev.constants import RecordState
 
 
 class CurationDedupeSettings(BaseModel):
-    """Settings for CurationDedupe"""
+    """Settings for CurationDedupe."""
 
     endpoint: str
     selected_source: str
@@ -35,7 +35,8 @@ class CurationDedupeSettings(BaseModel):
 class CurationDedupe(base_classes.DedupePackageBaseClass):
     """Deduplication endpoint for curations with full journals/proceedings
     retrieved from different sources (identifying duplicates in groups of
-    volumes/issues or years)"""
+    volumes/issues or years).
+    """
 
     settings_class = CurationDedupeSettings
     settings: CurationDedupeSettings
@@ -60,7 +61,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         record_a: colrev.record.record.Record,
         record_b: colrev.record.record.Record,
     ) -> bool:
-        """Check if a record has an overlapping colrev_id with the other record"""
+        """Check if a record has an overlapping colrev_id with the other record."""
         try:
             own_colrev_ids = record_a.get_colrev_id()
             other_colrev_ids = record_b.get_colrev_id()
@@ -525,8 +526,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         )
 
     def run_dedupe(self) -> None:
-        """Run the curation dedupe procedure"""
-
+        """Run the curation dedupe procedure."""
         self.dedupe_operation.merge_based_on_global_ids(apply=True)
 
         records = self.review_manager.dataset.load_records_dict()

--- a/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
+++ b/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Deduplication of remaining records in curated metadata repositories"""
+"""Deduplication of remaining records in curated metadata repositories."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.constants import RecordState
 
 
 class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
-    """Deduplication of remaining records in a curated metadata repository"""
+    """Deduplication of remaining records in a curated metadata repository."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -280,8 +280,7 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
         return results
 
     def run_dedupe(self) -> None:
-        """Run the dedupe procedure for remaining records in curations"""
-
+        """Run the dedupe procedure for remaining records in curations."""
         # pylint: disable=too-many-branches
         # pylint: disable=too-many-statements
 

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: DBLP"""
+"""SearchSource: DBLP."""
 
 from __future__ import annotations
 
@@ -36,7 +36,7 @@ from colrev.packages.dblp.src import dblp_api
 
 
 class DBLPSearchSourceSettings(colrev.search_file.ExtendedSearchFile, BaseModel):
-    """Settings for DBLPSearchSource"""
+    """Settings for DBLPSearchSource."""
 
     # pylint: disable=duplicate-code
     # pylint: disable=too-many-instance-attributes
@@ -55,7 +55,7 @@ class DBLPSearchSourceSettings(colrev.search_file.ExtendedSearchFile, BaseModel)
 
 
 class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """DBLP API"""
+    """DBLP API."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -93,8 +93,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for DBLP"""
-
+        """Source heuristic for DBLP."""
         result = {"confidence": 0.0}
         # Simple heuristic:
         # pylint: disable=colrev-missed-constant-usage
@@ -115,8 +114,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -195,7 +193,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def check_availability(self) -> None:
-        """Check status (availability) of DBLP API"""
+        """Check status (availability) of DBLP API."""
         api = dblp_api.DBLPAPI(
             params={},
             email=self.email,
@@ -309,7 +307,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         dblp_feed.save()
 
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
 
@@ -339,8 +337,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.logger.debug("SearchSource %s validated", source.search_results_path)
 
     def search(self, rerun: bool) -> None:
-        """Run a search of DBLP"""
-
+        """Run a search of DBLP."""
         self._validate_source()
 
         dblp_feed = colrev.ops.search_api_feed.SearchAPIFeed(
@@ -368,8 +365,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
@@ -400,8 +396,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for DBLP"""
-
+        """Source-specific preparation for DBLP."""
         if record.data.get(Fields.AUTHOR, FieldValues.UNKNOWN) != FieldValues.UNKNOWN:
             # DBLP appends identifiers to non-unique authors
             record.update_field(
@@ -424,8 +419,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 60,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from DBLP based on similarity with the record provided"""
-
+        """Retrieve masterdata from DBLP based on similarity with the record provided."""
         if any(self.origin_prefix in o for o in record.data[Fields.ORIGIN]):
             # Already linked to a crossref record
             return record

--- a/colrev/packages/dblp/src/dblp_api.py
+++ b/colrev/packages/dblp/src/dblp_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""DBLP API"""
+"""DBLP API."""
 
 import html
 import json
@@ -19,7 +19,7 @@ from colrev.constants import Fields
 
 
 class DBLPAPI:
-    """Connector for the DBLP API"""
+    """Connector for the DBLP API."""
 
     # https://dblp.org/search/publ/api?q=ADD_TITLE&format=json
     _api_url_venues = "https://dblp.org/search/venue/api?q="
@@ -54,8 +54,7 @@ class DBLPAPI:
         self.set_total()
 
     def check_availability(self) -> None:
-        """Check if the DBLP API is available"""
-
+        """Check if the DBLP API is available."""
         try:
             # pylint: disable=duplicate-code
             test_rec = {
@@ -228,8 +227,7 @@ class DBLPAPI:
         return item
 
     def get_query_url(self) -> str:
-        """Get the query"""
-
+        """Get the query."""
         if "scope" in self.params:
             # Note : journal_abbreviated is the abbreviated venue_key
             query = self.params["scope"]["journal_abbreviated"]
@@ -243,8 +241,7 @@ class DBLPAPI:
         raise ValueError("No query or scope provided")
 
     def set_next_url(self) -> None:
-        """Set the next URL"""
-
+        """Set the next URL."""
         self.url = self.get_query_url()
         if self.total > self.batch_size:
             self.url += "+" + str(self.year)
@@ -257,14 +254,13 @@ class DBLPAPI:
         self.url += f"&format=json&h={self.batch_size}&f={self.batch_size_cumulative}"
 
     def processed_all_urls(self) -> bool:
-        """Check if all URLs have been processed"""
-
+        """Check if all URLs have been processed."""
         if self.total < self.batch_size:
             return True
         return self.year > datetime.now().year
 
     def set_total(self) -> None:
-        """Get the total number of records"""
+        """Get the total number of records."""
         total = -1
         try:
             ret = self.session.request(
@@ -288,8 +284,7 @@ class DBLPAPI:
         self.total = total
 
     def retrieve_records(self) -> list:
-        """Retrieve records from DBLP"""
-
+        """Retrieve records from DBLP."""
         # try:
         while True:
             # print(self.url)
@@ -353,7 +348,7 @@ class DBLPAPI:
         return retrieved_records
 
     def set_url_from_query(self) -> None:
-        """Set the URL from a query"""
+        """Set the URL from a query."""
         query = re.sub(
             r"[\W]+", " ", self.params["query"].replace(" ", "+").replace("-", "+")
         )

--- a/colrev/packages/dblp/src/dblp_metadata_prep.py
+++ b/colrev/packages/dblp/src/dblp_metadata_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on DBLP API as a prep operation"""
+"""Consolidation of metadata based on DBLP API as a prep operation."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.constants import SearchType
 
 
 class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on dblp.org metadata"""
+    """Prepares records based on dblp.org metadata."""
 
     ci_supported: bool = Field(default=True)
     settings_class = colrev.package_manager.package_settings.DefaultSettings
@@ -72,7 +72,7 @@ class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
         ]
 
     def check_availability(self) -> None:
-        """Check status (availability) of the DBLP API"""
+        """Check status (availability) of the DBLP API."""
         self.dblp_source.check_availability()
 
     # pylint: disable=unused-argument
@@ -83,8 +83,7 @@ class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record by retrieving its metadata from DBLP"""
-
+        """Prepare a record by retrieving its metadata from DBLP."""
         if any(
             dblp_prefix in o
             for dblp_prefix in self.dblp_prefixes

--- a/colrev/packages/dedupe/src/dedupe.py
+++ b/colrev/packages/dedupe/src/dedupe.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Default deduplication module for CoLRev"""
+"""Default deduplication module for CoLRev."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ from colrev.constants import RecordState
 
 
 class Dedupe(base_classes.DedupePackageBaseClass):
-    """Default deduplication"""
+    """Default deduplication."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -59,8 +59,7 @@ class Dedupe(base_classes.DedupePackageBaseClass):
         shutil.move(str(maybe_file), str(target_path))
 
     def run_dedupe(self) -> None:
-        """Run default dedupe"""
-
+        """Run default dedupe."""
         records = self.review_manager.dataset.load_records_dict()
         records_df = pd.DataFrame.from_dict(records, orient="index")
         records_df = records_df[

--- a/colrev/packages/descriptive_review/src/descriptive_review.py
+++ b/colrev/packages/descriptive_review/src/descriptive_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Descriptive review"""
+"""Descriptive review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class DescriptiveReview(base_classes.ReviewTypePackageBaseClass):
-    """Descriptive review"""
+    """Descriptive review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -36,8 +36,7 @@ class DescriptiveReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a descriptive review"""
-
+        """Initialize a descriptive review."""
         settings.data.data_package_endpoints = [
             {"endpoint": "colrev.prisma", "version": "1.0"},
             {"endpoint": "colrev.profile"},

--- a/colrev/packages/doi_org/src/doi_org.py
+++ b/colrev/packages/doi_org/src/doi_org.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Connector to doi.org (API)"""
+"""Connector to doi.org (API)."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ from colrev.packages.crossref.src import record_transformer
 
 
 class DOIConnector:
-    """Connector for the DOI.org API"""
+    """Connector for the DOI.org API."""
 
     heuristic_status = SearchSourceHeuristicStatus.oni
 
@@ -40,8 +40,7 @@ class DOIConnector:
         timeout: int = 60,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.record.record.Record:
-        """Retrieve the metadata from DOI.org based on a record (similarity)"""
-
+        """Retrieve the metadata from DOI.org based on a record (similarity)."""
         if Fields.DOI not in record.data:
             return record
 
@@ -98,8 +97,7 @@ class DOIConnector:
         record: colrev.record.record.Record,
         timeout: int = 30,
     ) -> None:
-        """Get the website link from DOI resolution API"""
-
+        """Get the website link from DOI resolution API."""
         if Fields.DOI not in record.data:
             return
 

--- a/colrev/packages/download_from_website/src/download_from_website.py
+++ b/colrev/packages/download_from_website/src/download_from_website.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Retrieval of PDFs from the website (URL)"""
+"""Retrieval of PDFs from the website (URL)."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.constants import Fields
 
 
 class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
-    """Get PDFs from the website"""
+    """Get PDFs from the website."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -179,8 +179,7 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
     def get_pdf(
         self, record: colrev.record.record.Record
     ) -> colrev.record.record.Record:
-        """Get PDFs from website (URL)"""
-
+        """Get PDFs from website (URL)."""
         if Fields.URL not in record.data:
             return record
 

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: EBSCOHost"""
+"""SearchSource: EBSCOHost."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """EBSCOHost"""
+    """EBSCOHost."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -55,16 +55,14 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
     def validate_source(
         cls, search_source: colrev.search_file.ExtendedSearchFile
     ) -> None:
-        """Validate the search source"""
-
+        """Validate the search source."""
         if search_source.search_type == SearchType.DB:
             print(f"Validating search string: {search_source.search_string}")
             parse(search_source.search_string, platform="ebsco")
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for EBSCOHost"""
-
+        """Source heuristic for EBSCOHost."""
         result = {"confidence": 0.0}
 
         if data.count("@") >= 1:
@@ -81,8 +79,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint"""
-
+        """Add SearchSource as an endpoint."""
         params_dict = {}
         if params:
             params_dict = {params.split("=")[0]: params.split("=")[1]}
@@ -96,8 +93,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of EbscoHost"""
-
+        """Run a search of EbscoHost."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -114,7 +110,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -134,8 +130,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             return self._load_bib(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -147,8 +142,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for EBSCOHost"""
-
+        """Source-specific preparation for EBSCOHost."""
         record.format_if_mostly_upper(Fields.AUTHOR, case=Fields.TITLE)
         record.format_if_mostly_upper(Fields.TITLE, case=Fields.TITLE)
 

--- a/colrev/packages/enlit/src/enlit.py
+++ b/colrev/packages/enlit/src/enlit.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""ENLIT"""
+"""ENLIT."""
 
 from pathlib import Path
 
@@ -101,7 +101,6 @@ def _load_included_records(
 
 def main() -> None:
     """Main function to run the ENLIT script."""
-
     review_manager = ReviewManager()
     review_manager.logger.info("Start ENLIT")
 

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: ERIC"""
+"""SearchSource: ERIC."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ from colrev.packages.eric.src import eric_api
 
 
 class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """ERIC API"""
+    """ERIC API."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -69,8 +69,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for ERIC"""
-
+        """Source heuristic for ERIC."""
         result = {"confidence": 0.1}
 
         if "OWN - ERIC" in data:
@@ -108,8 +107,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search -a)"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search -a)."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -177,8 +175,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         eric_feed.save()
 
     def search(self, rerun: bool) -> None:
-        """Run a search of ERIC"""
-
+        """Run a search of ERIC."""
         eric_feed = colrev.ops.search_api_feed.SearchAPIFeed(
             source_identifier=self.source_identifier,
             search_source=self.search_source,
@@ -205,7 +202,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -275,8 +272,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".nbib":
             return self._load_nbib(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -295,8 +291,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for ERIC"""
-
+        """Source-specific preparation for ERIC."""
         if Fields.ISSN in record.data:
             record.data[Fields.ISSN] = record.data[Fields.ISSN].lstrip("ISSN-")
 

--- a/colrev/packages/eric/src/eric_api.py
+++ b/colrev/packages/eric/src/eric_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""ERIC API"""
+"""ERIC API."""
 
 import typing
 
@@ -15,7 +15,7 @@ from colrev.constants import Fields
 
 
 class ERICAPI:
-    """Connector for the ERIC API"""
+    """Connector for the ERIC API."""
 
     API_FIELDS = [
         "title",
@@ -114,7 +114,7 @@ class ERICAPI:
         return record
 
     def get_query_return(self) -> typing.Iterator[colrev.record.record.Record]:
-        """Get the records from a query"""
+        """Get the records from a query."""
         full_url = self._build_search_url()
 
         response = requests.get(full_url, timeout=90)

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Europe PMC"""
+"""SearchSource: Europe PMC."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ from colrev.packages.europe_pmc.src import europe_pmc_api
 
 
 class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Europe PMC"""
+    """Europe PMC."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -105,8 +105,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         most_similar_only: bool = True,
         timeout: int = 60,
     ) -> list:
-        """Retrieve records from Europe PMC based on a query"""
-
+        """Retrieve records from Europe PMC based on a query."""
         try:
             api = europe_pmc_api.EPMCAPI(
                 params={"query": quote(record_input.data[Fields.TITLE])},
@@ -161,8 +160,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,  # pylint: disable=unused-argument
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from Europe PMC based on similarity with the record provided"""
-
+        """Retrieve masterdata from Europe PMC based on similarity with the record provided."""
         # pylint: disable=too-many-branches
         # pylint: disable=too-many-return-statements
 
@@ -223,8 +221,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         return record
 
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
-
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
 
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
@@ -240,8 +237,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.logger.debug("SearchSource %s validated", source.search_results_path)
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Europe PMC"""
-
+        """Run a search of Europe PMC."""
         self._validate_source()
         # https://europepmc.org/RestfulWebService
 
@@ -313,8 +309,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Europe PMC"""
-
+        """Source heuristic for Europe PMC."""
         result = {"confidence": 0.0}
         # pylint: disable=colrev-missed-constant-usage
         if "europe_pmc_id" in data:
@@ -333,8 +328,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -392,8 +386,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             return self._load_bib(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -405,7 +398,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Europe PMC"""
+        """Source-specific preparation for Europe PMC."""
         record.data[Fields.AUTHOR].rstrip(".")
         record.data[Fields.TITLE].rstrip(".")
         return record

--- a/colrev/packages/europe_pmc/src/europe_pmc_api.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Europe PMC API"""
+"""Europe PMC API."""
 
 import typing
 from xml.etree.ElementTree import Element  # nosec
@@ -20,7 +20,7 @@ class EuropePMCAPIError(Exception):
 
 
 class EPMCAPI:
-    """Connector for the Europe PMC API"""
+    """Connector for the Europe PMC API."""
 
     def __init__(self, params: dict, email: str, session: requests.Session) -> None:
         self.params = params
@@ -34,8 +34,7 @@ class EPMCAPI:
         self.headers = {"user-agent": f"{__name__} (mailto:{email})"}
 
     def get_records(self) -> typing.Iterator[colrev.record.record_prep.PrepRecord]:
-        """Get records from the Europe PMC API"""
-
+        """Get records from the Europe PMC API."""
         try:
             ret = self.session.request(
                 "GET", self.url, headers=self.headers, timeout=60

--- a/colrev/packages/europe_pmc/src/europe_pmc_prep.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on Europe PMC API as a prep operation"""
+"""Consolidation of metadata based on Europe PMC API as a prep operation."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from colrev.constants import SearchType
 
 
 class EuropePMCMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on Europe PCM metadata"""
+    """Prepares records based on Europe PCM metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -72,7 +72,6 @@ class EuropePMCMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record based on Europe PMC metadata"""
-
+        """Prepare a record based on Europe PMC metadata."""
         self.epmc_source.prep_link_md(prep_operation=self.prep_operation, record=record)
         return record

--- a/colrev/packages/exclude_collections/src/exclude_collections.py
+++ b/colrev/packages/exclude_collections/src/exclude_collections.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Exclude collections as a prep operation"""
+"""Exclude collections as a prep operation."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from colrev.constants import Fields
 
 
 class ExcludeCollectionsPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records by excluding collection entries (e.g., proceedings)"""
+    """Prepares records by excluding collection entries (e.g., proceedings)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -45,8 +45,7 @@ class ExcludeCollectionsPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare records by excluding collections (proceedings)"""
-
+        """Prepare records by excluding collections (proceedings)."""
         if record.data[Fields.ENTRYTYPE].lower() == "proceedings":
             record.prescreen_exclude(reason="collection/proceedings")
 

--- a/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
+++ b/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Exclude complementary materials as a prep operation"""
+"""Exclude complementary materials as a prep operation."""
 
 from __future__ import annotations
 
@@ -20,7 +20,8 @@ from colrev.constants import Fields
 
 class ExcludeComplementaryMaterialsPrep(base_classes.PrepPackageBaseClass):
     """Prepares records by excluding complementary materials
-    (tables of contents, editorial boards, about our authors)"""
+    (tables of contents, editorial boards, about our authors).
+    """
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -60,8 +61,7 @@ class ExcludeComplementaryMaterialsPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the records by excluding complementary materials"""
-
+        """Prepare the records by excluding complementary materials."""
         if (
             any(
                 complementary_materials_keyword

--- a/colrev/packages/exclude_languages/src/exclude_languages.py
+++ b/colrev/packages/exclude_languages/src/exclude_languages.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Exclude records based on language as a prep operation"""
+"""Exclude records based on language as a prep operation."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.constants import RecordState
 
 
 class ExcludeLanguagesPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records by excluding ones that are not in the languages_to_include"""
+    """Prepares records by excluding ones that are not in the languages_to_include."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -84,8 +84,7 @@ class ExcludeLanguagesPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record by excluding records whose metadata is not in English"""
-
+        """Prepare the record by excluding records whose metadata is not in English."""
         # Note : other languages are not yet supported
         # because the dedupe does not yet support cross-language merges
 

--- a/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
+++ b/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Exclude records with non-latin alphabets as a prep operation"""
+"""Exclude records with non-latin alphabets as a prep operation."""
 
 from __future__ import annotations
 
@@ -20,7 +20,8 @@ from colrev.constants import Fields
 
 class ExcludeNonLatinAlphabetsPrep(base_classes.PrepPackageBaseClass):
     """Prepares records by excluding ones that have a non-latin alphabet
-    (in the title, author, journal, or booktitle field)"""
+    (in the title, author, journal, or booktitle field).
+    """
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -57,8 +58,7 @@ class ExcludeNonLatinAlphabetsPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the records by excluding records whose metadata is not in Latin alphabet"""
-
+        """Prepare the records by excluding records whose metadata is not in Latin alphabet."""
         if self.prep_operation.polish:
             return record
 

--- a/colrev/packages/export_man_prep/src/prep_man_export.py
+++ b/colrev/packages/export_man_prep/src/prep_man_export.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Export of bib/pdfs as a prep-man operation"""
+"""Export of bib/pdfs as a prep-man operation."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ from colrev.writer.write_utils import write_file
 class ExportManPrepSettings(
     colrev.package_manager.package_settings.DefaultSettings, BaseModel
 ):
-    """Settings for ExportManPrep"""
+    """Settings for ExportManPrep."""
 
     endpoint: str
     pdf_handling_mode: str = "symlink"
@@ -44,7 +44,7 @@ class ExportManPrepSettings(
 
 
 class ExportManPrep(base_classes.PrepManPackageBaseClass):
-    """Manual preparation based on exported and imported metadata (and PDFs if any)"""
+    """Manual preparation based on exported and imported metadata (and PDFs if any)."""
 
     settings: ExportManPrepSettings
     ci_supported: bool = Field(default=False)
@@ -373,8 +373,7 @@ class ExportManPrep(base_classes.PrepManPackageBaseClass):
         print(f"Once completed, run {Colors.ORANGE}colrev prep-man{Colors.END} again.")
 
     def prepare_manual(self, records: dict) -> dict:
-        """Prepare records manually by extracting the subset of records to a separate BiBTex file"""
-
+        """Prepare records manually by extracting the subset of records to a separate BiBTex file."""
         if not self.prep_man_bib_path.is_file():
             self._create_info_dataframe(records=records)
             self._export_prep_man(records=records)

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: directory containing PDF files (based on GROBID)"""
+"""SearchSource: directory containing PDF files (based on GROBID)."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ from colrev.writer.write_utils import write_file
 
 
 class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Files directories (PDFs based on GROBID)"""
+    """Files directories (PDFs based on GROBID)."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -347,8 +347,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         return False
 
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
-
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
 
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
@@ -409,7 +408,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def _index_file(
@@ -652,8 +651,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             files_dir_feed.save(skip_print=not last_round)
 
     def search(self, rerun: bool) -> None:
-        """Run a search of a Files directory"""
-
+        """Run a search of a Files directory."""
         self.rerun = rerun
         self._validate_source()
 
@@ -701,8 +699,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for PDF directories (GROBID)"""
-
+        """Source heuristic for PDF directories (GROBID)."""
         result = {"confidence": 0.0}
 
         if filename.suffix == ".pdf" and not bws.BackwardSearchSource.heuristic(
@@ -720,8 +717,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         filename = utils.get_unique_filename(
             base_path=path,
             file_path_string="files",
@@ -766,8 +762,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
             pass
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
@@ -856,8 +851,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for files"""
-
+        """Source-specific preparation for files."""
         if Fields.FILE not in record.data:
             return record
 

--- a/colrev/packages/genai/src/genai_data.py
+++ b/colrev/packages/genai/src/genai_data.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Data based on GenAI"""
+"""Data based on GenAI."""
 
 from __future__ import annotations
 
@@ -23,14 +23,14 @@ from colrev.constants import RecordState
 
 
 class GenAIData(base_classes.DataPackageBaseClass):
-    """GenAI-based data"""
+    """GenAI-based data."""
 
     ci_supported: bool = Field(default=False)
 
     class GenAIDataSettings(
         colrev.package_manager.package_settings.DefaultSettings, BaseModel
     ):
-        """GenAI data settings"""
+        """GenAI data settings."""
 
         endpoint: str
         version: str
@@ -67,8 +67,7 @@ class GenAIData(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
-
+        """Add as an endpoint."""
         add_package = {
             "endpoint": "colrev.prisma",
             "version": "0.1",
@@ -161,8 +160,7 @@ class GenAIData(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         silent_mode: bool,
     ) -> None:
-        """Update the data/prisma diagram"""
-
+        """Update the data/prisma diagram."""
         self._run_prompt()
 
     def update_record_status_matrix(
@@ -170,8 +168,7 @@ class GenAIData(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
-
+        """Update the record_status_matrix."""
         # Note : automatically set all to True / synthesized
         for syn_id in list(synthesized_record_status_matrix.keys()):
             synthesized_record_status_matrix[syn_id][endpoint_identifier] = True
@@ -179,8 +176,7 @@ class GenAIData(base_classes.DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         # data_endpoint = "Data operation [prisma data endpoint]: "
 
         # path_str = ",".join(

--- a/colrev/packages/genai/src/genai_prescreen.py
+++ b/colrev/packages/genai/src/genai_prescreen.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Prescreen based on GenAI"""
+"""Prescreen based on GenAI."""
 
 from __future__ import annotations
 
@@ -24,9 +24,7 @@ from colrev.constants import RecordState
 
 
 class PreScreenDecision(BaseModel):
-    """
-    Class for a prescreen
-    """
+    """Class for a prescreen."""
 
     SYSTEM_PROMPT: typing.ClassVar[str] = (
         "You are an expert screener of scientific literature. "
@@ -42,7 +40,7 @@ class PreScreenDecision(BaseModel):
 
 
 class GenAIPrescreen(base_classes.PrescreenPackageBaseClass):
-    """GenAI-based prescreen"""
+    """GenAI-based prescreen."""
 
     ci_supported: bool = Field(default=True)
     export_todos_only: bool = True
@@ -50,7 +48,7 @@ class GenAIPrescreen(base_classes.PrescreenPackageBaseClass):
     class GenAIPrescreenSettings(
         colrev.package_manager.package_settings.DefaultSettings, BaseModel
     ):
-        """Settings for GenAIPrescreen"""
+        """Settings for GenAIPrescreen."""
 
         # pylint: disable=invalid-name
         # pylint: disable=too-many-instance-attributes
@@ -81,8 +79,7 @@ class GenAIPrescreen(base_classes.PrescreenPackageBaseClass):
         records: dict,
         split: list,
     ) -> dict:
-        """Prescreen records based on GenAI"""
-
+        """Prescreen records based on GenAI."""
         if self.review_manager.settings.prescreen.explanation == "":
             print(
                 f"\n{Colors.ORANGE}Provide a short explanation of the prescreen{Colors.END} "

--- a/colrev/packages/genai/src/genai_screen.py
+++ b/colrev/packages/genai/src/genai_screen.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Screen based on GenAI"""
+"""Screen based on GenAI."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ from colrev.constants import RecordState
 
 
 class GenAIScreen(base_classes.ScreenPackageBaseClass):
-    """Screen documents using GenAI"""
+    """Screen documents using GenAI."""
 
     ci_supported: bool = Field(default=False)
     export_todos_only: bool = True
@@ -38,8 +38,7 @@ class GenAIScreen(base_classes.ScreenPackageBaseClass):
 
     # pylint: disable=unused-argument
     def run_screen(self, records: dict, split: list) -> dict:
-        """Screen records based on GenAI"""
-
+        """Screen records based on GenAI."""
         # screening_criteria = self.review_manager.settings.screen.criteria
         for record_dict in records.values():
             record = colrev.record.record.Record(record_dict)

--- a/colrev/packages/general_polish/src/general_polish.py
+++ b/colrev/packages/general_polish/src/general_polish.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Genral polishing rules"""
+"""Genral polishing rules."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ from colrev.constants import Fields
 
 
 class GeneralPolishPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records by applying polishing rules"""
+    """Prepares records by applying polishing rules."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -67,8 +67,7 @@ class GeneralPolishPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record by applying polishing rules"""
-
+        """Prepare the record by applying polishing rules."""
         if Fields.TITLE in record.data:
             acronyms = [
                 x

--- a/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
+++ b/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Retrieving DOIs from a papers website/url as a prep operation"""
+"""Retrieving DOIs from a papers website/url as a prep operation."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ from colrev.constants import Fields
 
 
 class DOIFromURLsPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records by retrieving its DOI from the website (URL)"""
+    """Prepares records by retrieving its DOI from the website (URL)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -72,8 +72,7 @@ class DOIFromURLsPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record by retrieving its DOI from the website (url) if available"""
-
+        """Prepare the record by retrieving its DOI from the website (url) if available."""
         if (Fields.URL not in record.data and Fields.FULLTEXT not in record.data) or (
             Fields.DOI in record.data
         ):

--- a/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
+++ b/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on CiteAs API as a prep operation"""
+"""Consolidation of metadata based on CiteAs API as a prep operation."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from colrev.constants import Fields
 
 
 class CiteAsPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on citeas.org metadata"""
+    """Prepares records based on citeas.org metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -98,8 +98,7 @@ class CiteAsPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record based on citeas"""
-
+        """Prepare the record based on citeas."""
         if record.data.get(Fields.ENTRYTYPE, "NA") not in ["misc", "software"]:
             return record
         if Fields.TITLE not in record.data:

--- a/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
+++ b/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on DOI metadata as a prep operation"""
+"""Consolidation of metadata based on DOI metadata as a prep operation."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from colrev.constants import Fields
 
 
 class DOIMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on doi.org metadata"""
+    """Prepares records based on doi.org metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -51,8 +51,7 @@ class DOIMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record by retrieving its metadata from doi.org"""
-
+        """Prepare the record by retrieving its metadata from doi.org."""
         if Fields.DOI not in record.data:
             return record
         doi_connector.DOIConnector.retrieve_doi_metadata(

--- a/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
+++ b/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Completion of metadata based on year-volume-issue dependency as a prep operation"""
+"""Completion of metadata based on year-volume-issue dependency as a prep operation."""
 
 from __future__ import annotations
 
@@ -51,7 +51,7 @@ def _index_record(record: dict, vol_nr_dict: dict) -> None:
 
 
 class YearVolIssPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on year-volume-issue dependency"""
+    """Prepares records based on year-volume-issue dependency."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -226,8 +226,7 @@ class YearVolIssPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record based on year-volume-issue dependency"""
-
+        """Prepare a record based on year-volume-issue dependency."""
         if record.data.get(Fields.YEAR, "NA").isdigit():
             return record
 

--- a/colrev/packages/github/src/github_prep.py
+++ b/colrev/packages/github/src/github_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on GitHub REST API as a prep operation"""
+"""Consolidation of metadata based on GitHub REST API as a prep operation."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from colrev.constants import SearchType
 
 
 class GithubMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on GitHub metadata"""
+    """Prepares records based on GitHub metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -74,8 +74,7 @@ class GithubMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record based on GitHub metadata"""
-
+        """Prepare a record based on GitHub metadata."""
         self.github_search_source.prep_link_md(
             prep_operation=self.prep_operation, record=record
         )

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: GitHub"""
+"""SearchSource: GitHub."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ from colrev.packages.github.src import record_transformer
 
 
 def is_github_api_key(previous: dict, answer: str) -> bool:
-    """Validate GitHub API key format"""
+    """Validate GitHub API key format."""
     api_key_pattern = re.compile(r"[a-zA-Z0-9_-]{40}")
     if api_key_pattern.fullmatch(answer):
         return True
@@ -39,7 +39,7 @@ def is_github_api_key(previous: dict, answer: str) -> bool:
 
 
 class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """GitHub API"""
+    """GitHub API."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -74,8 +74,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for GitHub"""
-
+        """Source heuristic for GitHub."""
         result = {"confidence": 0.0}
 
         return result
@@ -100,8 +99,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         cls._get_api_key()
         params_dict = {}
         if params:
@@ -205,8 +203,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         github_connection.close()
 
     def search(self, rerun: bool = False) -> None:
-        """Run a search on GitHub"""
-
+        """Run a search on GitHub."""
         if self.search_source.search_type == SearchType.API:
             github_feed = colrev.ops.search_api_feed.SearchAPIFeed(
                 source_identifier=self.source_identifier,
@@ -218,7 +215,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
             self._run_api_search(github_feed)
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -233,7 +230,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for GitHub"""
+        """Source-specific preparation for GitHub."""
         return record
 
     def prep_link_md(
@@ -243,8 +240,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Prepare the record based on GitHub"""
-
+        """Prepare the record based on GitHub."""
         if Fields.URL not in record.data:
             return record
 

--- a/colrev/packages/github/src/record_transformer.py
+++ b/colrev/packages/github/src/record_transformer.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Utility to transform github repositories into records"""
+"""Utility to transform github repositories into records."""
 
 from __future__ import annotations
 
@@ -19,14 +19,14 @@ from colrev.constants import Fields
 
 
 def _set_title(*, record_dict: dict, citation_data: str) -> None:
-    """Set repository title"""
+    """Set repository title."""
     title = re.search(r"^\s*title:\s*(.+)\s*$", citation_data, re.M)
     if title:
         record_dict[Fields.TITLE] = title.group(1).strip().replace('"', "")
 
 
 def _set_authors(*, record_dict: dict, citation_data: str) -> None:
-    """Set repository authors"""
+    """Set repository authors."""
     authors = re.findall(
         r'- family-names:\s*"(.+)"\s*\n\s*given-names:\s*"(.+)"',
         citation_data,
@@ -40,14 +40,14 @@ def _set_authors(*, record_dict: dict, citation_data: str) -> None:
 
 
 def _set_url(*, record_dict: dict, citation_data: str) -> None:
-    """Set repository URL"""
+    """Set repository URL."""
     url = re.search(r"^\s*url:\s*(.+)\s*$", citation_data, re.M)
     if url:
         record_dict[Fields.URL] = url.group(1).strip().replace('"', "")
 
 
 def _set_year_and_release_date(*, record_dict: dict, citation_data: str) -> None:
-    """Set release date"""
+    """Set release date."""
     release_date = re.search(r"^\s*date-released:\s*(.+)\s*$", citation_data, re.M)
     if release_date:
         record_dict[Fields.DATE] = release_date.group(1).strip()
@@ -55,7 +55,7 @@ def _set_year_and_release_date(*, record_dict: dict, citation_data: str) -> None
 
 
 def _set_version(record_dict: dict, citation_data: str) -> None:
-    """Set current software version"""
+    """Set current software version."""
     version = re.search(r"^\s*version:\s*(.+)\s*$", citation_data, re.M)
     if version:
         record_dict[Fields.GITHUB_VERSION] = version.group(1).strip()
@@ -225,8 +225,7 @@ def _update_record_based_on_citation_cff(
 def repo_to_record(
     *, repo: Github.Repository.Repository
 ) -> colrev.record.record.Record:
-    """Convert a GitHub repository to a record"""
-
+    """Convert a GitHub repository to a record."""
     record_dict = {
         Fields.ENTRYTYPE: "software",
         Fields.TITLE: repo.name,

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Creation of a github-page for the review as part of the data operations"""
+"""Creation of a github-page for the review as part of the data operations."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.writer.write_utils import write_file
 class GHPagesSettings(
     colrev.package_manager.package_settings.DefaultSettings, BaseModel
 ):
-    """Settings for GithubPages"""
+    """Settings for GithubPages."""
 
     endpoint: str
     version: str
@@ -40,7 +40,7 @@ class GHPagesSettings(
 
 
 class GithubPages(base_classes.DataPackageBaseClass):
-    """Export the literature review into a Github Page"""
+    """Export the literature review into a Github Page."""
 
     settings: GHPagesSettings
     settings_class = GHPagesSettings
@@ -72,7 +72,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
+        """Add as an endpoint."""
         add_source = {
             "endpoint": "colrev.github_pages",
             "version": "0.1",
@@ -239,7 +239,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,  # pylint: disable=unused-argument
         silent_mode: bool,
     ) -> None:
-        """Update the data/github pages"""
+        """Update the data/github pages."""
         # pylint: disable=too-many-branches
 
         if utils.in_ci_environment():
@@ -334,7 +334,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
+        """Update the record_status_matrix."""
         # Note : automatically set all to True / synthesized
         for syn_id in synthesized_record_status_matrix:
             synthesized_record_status_matrix[syn_id][endpoint_identifier] = True

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: GoogleScholar"""
+"""SearchSource: GoogleScholar."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """GoogleScholar"""
+    """GoogleScholar."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -48,8 +48,7 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for GoogleScholar"""
-
+        """Source heuristic for GoogleScholar."""
         result = {"confidence": 0.0}
         if data.count("https://scholar.google.com/scholar?q=relat") > 0.9 * data.count(
             "\n@"
@@ -78,8 +77,7 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
@@ -92,8 +90,7 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of GoogleScholar"""
-
+        """Run a search of GoogleScholar."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -111,12 +108,11 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
 
             def bib_field_mapper(record_dict: dict) -> None:
@@ -209,7 +205,7 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for GoogleScholar"""
+        """Source-specific preparation for GoogleScholar."""
         if "cites: https://scholar.google.com/scholar?cites=" in record.data.get(
             "note", ""
         ):

--- a/colrev/packages/grobid_tei/src/grobid_tei.py
+++ b/colrev/packages/grobid_tei/src/grobid_tei.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Creation of TEI as a PDF preparation operation"""
+"""Creation of TEI as a PDF preparation operation."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 
 class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
-    """Prepare PDFs by creating an annotated TEI document"""
+    """Prepare PDFs by creating an annotated TEI document."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -51,8 +51,7 @@ class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
         record: colrev.record.record_pdf.PDFRecord,
         pad: int,  # pylint: disable=unused-argument
     ) -> colrev.record.record_pdf.PDFRecord:
-        """Prepare the analysis of PDFs by creating a TEI (based on GROBID)"""
-
+        """Prepare the analysis of PDFs by creating a TEI (based on GROBID)."""
         if not record.data.get(Fields.FILE, "NA").endswith(".pdf"):
             return record
 
@@ -67,8 +66,7 @@ class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
 
 
 def convert(pdf_dir: Path, tei_dir: Path) -> None:
-    """Convenience function to convert PDFs to TEI using GROBID"""
-
+    """Convenience function to convert PDFs to TEI using GROBID."""
     print(f"Converting PDFs in {pdf_dir} to TEI in {tei_dir}...")
 
     # pylint: disable=import-outside-toplevel

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: IEEEXplore"""
+"""SearchSource: IEEEXplore."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """IEEEXplore"""
+    """IEEEXplore."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -78,8 +78,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for IEEEXplore"""
-
+        """Source heuristic for IEEEXplore."""
         result = {"confidence": 0.1}
 
         if "Date Added To Xplore" in data:
@@ -96,8 +95,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -168,8 +166,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of IEEEXplore"""
-
+        """Run a search of IEEEXplore."""
         if self.search_source.search_type == SearchType.API:
             ieee_feed = colrev.ops.search_api_feed.SearchAPIFeed(
                 source_identifier=self.source_identifier,
@@ -227,7 +224,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -324,7 +321,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def ensure_append_only(cls, filename: Path) -> bool:
-        """Ensure that the SearchSource file is append-only"""
+        """Ensure that the SearchSource file is append-only."""
         return filename.suffix in [".ris"]
 
     @classmethod
@@ -367,8 +364,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".ris":
             return self._load_ris(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -385,8 +381,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for IEEEXplore"""
-
+        """Source-specific preparation for IEEEXplore."""
         if Fields.AUTHOR in record.data:
             record.data[Fields.AUTHOR] = (
                 colrev.record.record_prep.PrepRecord.format_author_field(

--- a/colrev/packages/ieee/src/ieee_api.py
+++ b/colrev/packages/ieee/src/ieee_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""IEEE Xplore API"""
+"""IEEE Xplore API."""
 
 import json
 import math
@@ -15,7 +15,7 @@ from colrev.constants import Fields
 
 
 class XPLORE:
-    """XPLORE API class"""
+    """XPLORE API class."""
 
     # pylint: disable=too-many-instance-attributes
     # API ENDPOINT (all non-Open Access)
@@ -156,21 +156,22 @@ class XPLORE:
 
     def startingResult(self, start: int) -> None:
         """Set the start position in the results
-        string start   Start position in the returned data"""
-
+        string start   Start position in the returned data.
+        """
         self.startRecord = math.ceil(start) if (start > 0) else 1
 
     def maximumResults(self, maximum: int) -> None:
         """Set the maximum number of results
-        string maximum   Max number of results to return"""
+        string maximum   Max number of results to return.
+        """
         self.resultSetMax = math.ceil(maximum) if (maximum > 0) else 25
         self.resultSetMax = min(self.resultSetMax, self.resultSetMaxCap)
 
     def resultsFilter(self, filterParam: str, value: str) -> None:
         """Set a filter on results
         string filterParam   Field used for filtering
-        string value    Text to filter on"""
-
+        string value    Text to filter on.
+        """
         filterParam = filterParam.strip().lower()
         value = value.strip()
 
@@ -185,25 +186,26 @@ class XPLORE:
     def resultsSorting(self, field: str, order: str) -> None:
         """Setting sort order for results
         string field   Data field used for sorting
-        string order   Sort order for results (ascending or descending)"""
+        string order   Sort order for results (ascending or descending).
+        """
         field = field.strip().lower()
         order = order.strip()
         self.sortField = field
         self.sortOrder = order
 
     def queryText(self, value: str) -> None:
-        """Text to query across metadata fields, abstract and document text"""
+        """Text to query across metadata fields, abstract and document text."""
         self._add_parameter("querytext", value)
 
     def articleNumber(self, value: str) -> None:
-        """Article number to query"""
+        """Article number to query."""
         self._add_parameter("article_number", value)
 
     def _search_field(self, field: str, value: str) -> None:
         """Shortcut method for assigning search parameters and values
         string field   Field used for searching
-        string value   Text to query"""
-
+        string value   Text to query.
+        """
         field = field.strip().lower()
         if field in self.ALLOWED_SEARCH_FIELDS:
             self._add_parameter(field, value)
@@ -211,11 +213,11 @@ class XPLORE:
             print("Searches against field " + field + " are not supported")
 
     def facetText(self, value: str) -> None:
-        """Facet text to query"""
+        """Facet text to query."""
         self._add_parameter("facet", value)
 
     def _add_parameter(self, parameter: str, value: str) -> None:
-        """Add parameter"""
+        """Add parameter."""
         value = value.strip()
 
         if len(value) > 0:
@@ -235,15 +237,15 @@ class XPLORE:
                 self.usingFacet = True
 
     def openAccess(self, article: str) -> None:
-        """Open Access document"""
+        """Open Access document."""
         self.usingOpenAccess = True
         self.queryProvided = True
         self.articleNumber(article)
 
     def _build_open_access_query(self) -> str:
         """Creates the URL for the Open Access Document API call
-        return string: full URL for querying the API"""
-
+        return string: full URL for querying the API.
+        """
         url = self.OPEN_ACCESS_ENDPOINT
         url += str(self.parameters["article_number"]) + "/fulltext"
         url += "?apikey=" + str(self.apiKey)
@@ -253,8 +255,8 @@ class XPLORE:
 
     def _build_query(self) -> str:
         """Creates the URL for the non-Open Access Document API call
-        return string: full URL for querying the API"""
-
+        return string: full URL for querying the API.
+        """
         url = self.ENDPOINT
         url += "?apikey=" + str(self.apiKey)
         url += "&format=json"
@@ -294,7 +296,8 @@ class XPLORE:
     def _query_api(self, url: str) -> str:
         """Creates the URL for the API call
         string url  Full URL to pass to API
-        return string: Results from API"""
+        return string: Results from API.
+        """
         with urllib.request.urlopen(url) as con:
             content = con.read()
         return content
@@ -352,8 +355,7 @@ class XPLORE:
         return record_dict
 
     def get_records(self) -> list:
-        """Calls the API to receive the records"""
-
+        """Calls the API to receive the records."""
         if self.usingOpenAccess is True:
             url = self._build_open_access_query()
 

--- a/colrev/packages/importer/src/importer.py
+++ b/colrev/packages/importer/src/importer.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Importer"""
+"""Importer."""
 
 import shutil
 from pathlib import Path
@@ -318,7 +318,7 @@ def _import_records(
 
 
 def main() -> None:
-    """Main function for import"""
+    """Main function for import."""
     review_manager = colrev.review_manager.ReviewManager()
     import_type = _get_import_type()
     # import_path = _get_import_path()

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: JSTOR"""
+"""SearchSource: JSTOR."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """JSTOR"""
+    """JSTOR."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -48,8 +48,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for JSTOR"""
-
+        """Source heuristic for JSTOR."""
         result = {"confidence": 0.1}
 
         if "www.jstor.org:" in data:
@@ -67,8 +66,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
@@ -81,8 +79,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of JSTOR"""
-
+        """Run a search of JSTOR."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -100,7 +97,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -202,8 +199,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".ris":
             return self._load_ris(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -215,6 +211,5 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for JSTOR"""
-
+        """Source-specific preparation for JSTOR."""
         return record

--- a/colrev/packages/literature_review/src/literature_review.py
+++ b/colrev/packages/literature_review/src/literature_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Simple literature review"""
+"""Simple literature review."""
 
 import logging
 import typing
@@ -16,7 +16,7 @@ import colrev.package_manager.package_settings
 
 #
 class LiteratureReview(base_classes.ReviewTypePackageBaseClass):
-    """Literature review (simple)"""
+    """Literature review (simple)."""
 
     ci_supported: bool = Field(default=True)
     settings: colrev.package_manager.package_settings.DefaultSettings
@@ -38,8 +38,7 @@ class LiteratureReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a literature review"""
-
+        """Initialize a literature review."""
         settings.data.data_package_endpoints = [
             {
                 "endpoint": "colrev.paper_md",

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: LocalIndex"""
+"""SearchSource: LocalIndex."""
 
 from __future__ import annotations
 
@@ -36,7 +36,7 @@ from colrev.ops.search_api_feed import create_api_source
 
 
 class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """LocalIndex"""
+    """LocalIndex."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -81,7 +81,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
 
@@ -190,8 +190,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         local_index_feed.save()
 
     def search(self, rerun: bool) -> None:
-        """Run a search of local-index"""
-
+        """Run a search of local-index."""
         self._validate_source()
 
         local_index_feed = colrev.ops.search_api_feed.SearchAPIFeed(
@@ -217,8 +216,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for local-index"""
-
+        """Source heuristic for local-index."""
         result = {"confidence": 0.0}
         if Fields.CURATION_ID in data:
             result["confidence"] = 1.0
@@ -232,8 +230,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         # always API search
 
         if len(params) == 0:
@@ -261,8 +258,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
 
             def field_mapper(record_dict: dict) -> None:
@@ -305,8 +301,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for local-index"""
-
+        """Source-specific preparation for local-index."""
         return record
 
     def _add_cpid(self, *, record: colrev.record.record.Record, path: Path) -> bool:
@@ -462,8 +457,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from LocalIndex based on similarity with the record provided"""
-
+        """Retrieve masterdata from LocalIndex based on similarity with the record provided."""
         retrieved_record = self._retrieve_record_from_local_index(
             record, path=prep_operation.review_manager.path
         )
@@ -562,8 +556,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         return selected_changes
 
     def apply_correction(self, *, change_itemsets: list) -> None:
-        """Apply a correction by opening a pull request in the original repository"""
-
+        """Apply a correction by opening a pull request in the original repository."""
         local_base_repos = self._get_local_base_repos(change_itemsets=change_itemsets)
 
         for local_base_repo_url, local_base_repo_path in local_base_repos.items():
@@ -861,8 +854,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         return success
 
     def _apply_correction(self, *, source_url: str, change_list: list) -> None:
-        """Apply a (list of) corrections"""
-
+        """Apply a (list of) corrections."""
         # TBD: other modes of accepting changes?
         # e.g., only-metadata, no-changes, all(including optional fields)
 

--- a/colrev/packages/local_index/src/local_index_pdf_get.py
+++ b/colrev/packages/local_index/src/local_index_pdf_get.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Retrieval of PDFs from the LocalIndex"""
+"""Retrieval of PDFs from the LocalIndex."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.constants import Fields
 
 
 class LocalIndexPDFGet(base_classes.PDFGetPackageBaseClass):
-    """Get PDFs from LocalIndex"""
+    """Get PDFs from LocalIndex."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -44,8 +44,7 @@ class LocalIndexPDFGet(base_classes.PDFGetPackageBaseClass):
     def get_pdf(
         self, record: colrev.record.record.Record
     ) -> colrev.record.record.Record:
-        """Get PDFs from the local-index"""
-
+        """Get PDFs from the local-index."""
         local_index = colrev.env.local_index.LocalIndex(verbose_mode=self.verbose_mode)
 
         try:

--- a/colrev/packages/local_index/src/local_index_prep.py
+++ b/colrev/packages/local_index/src/local_index_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Conslidation of metadata based on LocalIndex as a prep operation"""
+"""Conslidation of metadata based on LocalIndex as a prep operation."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from colrev.constants import SearchType
 
 
 class LocalIndexPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on LocalIndex metadata"""
+    """Prepares records based on LocalIndex metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -78,8 +78,7 @@ class LocalIndexPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record metadata based on local-index"""
-
+        """Prepare the record metadata based on local-index."""
         # don't move to  jour_iss_number_year prep
         # because toc-retrieval relies on adequate toc items!
         if (

--- a/colrev/packages/meta_analysis/src/meta_analysis.py
+++ b/colrev/packages/meta_analysis/src/meta_analysis.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Meta-analysis"""
+"""Meta-analysis."""
 
 import logging
 import typing
@@ -21,7 +21,7 @@ from colrev.packages.pdf_backward_search.src.pdf_backward_search import (
 
 
 class MetaAnalysis(base_classes.ReviewTypePackageBaseClass):
-    """Meta-analysis"""
+    """Meta-analysis."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -42,8 +42,7 @@ class MetaAnalysis(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a meta-analysis"""
-
+        """Initialize a meta-analysis."""
         settings.sources.append(OpenCitationsSearchSource.get_default_source())
         settings.sources.append(BackwardSearchSource.get_default_source())
 

--- a/colrev/packages/methodological_review/src/methodological_review.py
+++ b/colrev/packages/methodological_review/src/methodological_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Methodological review"""
+"""Methodological review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class MethodologicalReview(base_classes.ReviewTypePackageBaseClass):
-    """Methodological review"""
+    """Methodological review."""
 
     ci_supported: bool = Field(default=True)
     settings_class: colrev.package_manager.package_settings.DefaultSettings
@@ -36,8 +36,7 @@ class MethodologicalReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a methodological review"""
-
+        """Initialize a methodological review."""
         settings.data.data_package_endpoints = [
             {"endpoint": "colrev.prisma", "version": "1.0"},
             {

--- a/colrev/packages/narrative_review/src/narrative_review.py
+++ b/colrev/packages/narrative_review/src/narrative_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Narrative review"""
+"""Narrative review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class NarrativeReview(base_classes.ReviewTypePackageBaseClass):
-    """Narrative review"""
+    """Narrative review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -36,8 +36,7 @@ class NarrativeReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a narrative review"""
-
+        """Initialize a narrative review."""
         settings.data.data_package_endpoints = [
             {
                 "endpoint": "colrev.paper_md",

--- a/colrev/packages/obsidian/src/obsidian.py
+++ b/colrev/packages/obsidian/src/obsidian.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Creation of an Obsidian database as part of the data operations"""
+"""Creation of an Obsidian database as part of the data operations."""
 
 from __future__ import annotations
 
@@ -19,14 +19,14 @@ from colrev.constants import Fields
 
 
 class Obsidian(base_classes.DataPackageBaseClass):
-    """Export the sample into an Obsidian database"""
+    """Export the sample into an Obsidian database."""
 
     ci_supported: bool = Field(default=False)
 
     class ObsidianSettings(
         colrev.package_manager.package_settings.DefaultSettings, BaseModel
     ):
-        """Settings for Obsidian"""
+        """Settings for Obsidian."""
 
         endpoint: str
         version: str
@@ -86,8 +86,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
-
+        """Add as an endpoint."""
         add_source = {
             "endpoint": "colrev.obsidian",
             "version": "0.1",
@@ -216,8 +215,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,  # pylint: disable=unused-argument
         silent_mode: bool,
     ) -> None:
-        """Update the obsidian vault"""
-
+        """Update the obsidian vault."""
         if silent_mode:
             return
 
@@ -230,8 +228,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
-
+        """Update the record_status_matrix."""
         missing_records = self._get_obsidian_missing(
             included=list(synthesized_record_status_matrix.keys())
         )
@@ -246,8 +243,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         data_endpoint = "Data operation [obisdian data endpoint]: "
 
         advice = {

--- a/colrev/packages/ocrmypdf/src/ocrmypdf.py
+++ b/colrev/packages/ocrmypdf/src/ocrmypdf.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""OCR as a PDF preparation operation"""
+"""OCR as a PDF preparation operation."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.constants import PDFDefectCodes
 
 
 class OCRMyPDF(base_classes.PDFPrepPackageBaseClass):
-    """Prepare PDFs by applying OCR based on OCRmyPDF"""
+    """Prepare PDFs by applying OCR based on OCRmyPDF."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -94,8 +94,7 @@ class OCRMyPDF(base_classes.PDFPrepPackageBaseClass):
         record: colrev.record.record_pdf.PDFRecord,
         pad: int,  # pylint: disable=unused-argument
     ) -> colrev.record.record_pdf.PDFRecord:
-        """Prepare the PDF by applying OCR"""
-
+        """Prepare the PDF by applying OCR."""
         if (
             Fields.FILE not in record.data
             or not record.data[Fields.FILE].endswith(".pdf")

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: OpenAlex"""
+"""SearchSource: OpenAlex."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.packages.open_alex.src import open_alex_api
 
 
 class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """OpenAlex API"""
+    """OpenAlex API."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -53,8 +53,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for OpenAlex"""
-
+        """Source heuristic for OpenAlex."""
         result = {"confidence": 0.0}
 
         return result
@@ -66,15 +65,13 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         raise colrev_exceptions.PackageParameterError(
             f"Cannot add OpenAlex endpoint with query {params}"
         )
 
     def check_availability(self) -> None:
-        """Check status (availability) of the OpenAlex API"""
-
+        """Check status (availability) of the OpenAlex API."""
         try:
             _, email = (
                 colrev.env.environment_manager.EnvironmentManager.get_name_mail_from_git()
@@ -154,8 +151,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 30,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from OpenAlex based on similarity with the record provided"""
-
+        """Retrieve masterdata from OpenAlex based on similarity with the record provided."""
         if "colrev.open_alex.id" in record.data:
             # Note: not yet implemented
             # https://github.com/OpenAPC/openapc-de/blob/master/python/import_dois.py
@@ -169,15 +165,13 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         return record
 
     def search(self, rerun: bool) -> None:
-        """Run a search of OpenAlex"""
-
+        """Run a search of OpenAlex."""
         # https://docs.openalex.org/api-entities/works
 
         raise NotImplementedError
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -191,6 +185,5 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for OpenAlex"""
-
+        """Source-specific preparation for OpenAlex."""
         return record

--- a/colrev/packages/open_alex/src/open_alex_api.py
+++ b/colrev/packages/open_alex/src/open_alex_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Open Alex API"""
+"""Open Alex API."""
 
 import pyalex
 import requests
@@ -123,7 +123,7 @@ class OpenAlexAPI:
         return record
 
     def get_record(self, *, open_alex_id: str) -> colrev.record.record.Record:
-        """Get a record from OpenAlex"""
+        """Get a record from OpenAlex."""
         try:
             item = Works()[open_alex_id]
         except requests.exceptions.RequestException as exc:  # pragma: no cover

--- a/colrev/packages/open_alex/src/open_alex_metadata_prep.py
+++ b/colrev/packages/open_alex/src/open_alex_metadata_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on OpenAlex API as a prep operation"""
+"""Consolidation of metadata based on OpenAlex API as a prep operation."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.constants import SearchType
 
 
 class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on OpenAlex metadata"""
+    """Prepares records based on OpenAlex metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -70,7 +70,7 @@ class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
         ]
 
     def check_availability(self) -> None:
-        """Check status (availability) of the OpenAlex API"""
+        """Check status (availability) of the OpenAlex API."""
         self.open_alex_source.check_availability()
 
     # pylint: disable=unused-argument
@@ -81,8 +81,7 @@ class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record based on OpenAlex metadata"""
-
+        """Prepare a record based on OpenAlex metadata."""
         if any(
             crossref_prefix in o
             for crossref_prefix in self.open_alex_prefixes

--- a/colrev/packages/open_citations_forward_search/src/open_citations_api.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_api.py
@@ -29,7 +29,6 @@ class OpenCitationsAPI:
 
     def get(self, url: str, *, timeout: int) -> requests.Response:
         """Execute a GET request and raise a custom exception on failure."""
-
         try:
             response = self.session.get(url, headers=self.headers, timeout=timeout)
             response.raise_for_status()

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: OpenCitations"""
+"""SearchSource: OpenCitations."""
 
 from __future__ import annotations
 
@@ -29,7 +29,7 @@ from colrev.packages.open_citations_forward_search.src import open_citations_api
 
 class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Forward search based on OpenCitations
-    Scope: all included papers with colrev_status in (rev_included, rev_synthesized)
+    Scope: all included papers with colrev_status in (rev_included, rev_synthesized).
     """
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
@@ -62,7 +62,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def get_default_source(cls) -> colrev.search_file.ExtendedSearchFile:
-        """Get the default SearchSource settings"""
+        """Get the default SearchSource settings."""
         return colrev.search_file.ExtendedSearchFile(
             version=cls.CURRENT_SYNTAX_VERSION,
             platform="colrev.open_citations_forward_search",
@@ -76,8 +76,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
-
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
 
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
@@ -149,8 +148,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         return forward_citations
 
     def search(self, rerun: bool) -> None:
-        """Run a forward search based on OpenCitations"""
-
+        """Run a forward search based on OpenCitations."""
         # pylint: disable=too-many-branches
 
         self._validate_source()
@@ -207,8 +205,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for forward searches (OpenCitations)"""
-
+        """Source heuristic for forward searches (OpenCitations)."""
         result = {"confidence": 0.0}
 
         return result
@@ -220,8 +217,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint"""
-
+        """Add SearchSource as an endpoint."""
         search_source = cls.get_default_source()
         return search_source
 
@@ -232,12 +228,11 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -251,5 +246,5 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for forward searches (OpenCitations)"""
+        """Source-specific preparation for forward searches (OpenCitations)."""
         return record

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Connector to OpenLibrary (API)"""
+"""Connector to OpenLibrary (API)."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ from colrev.packages.open_library.src import open_library_api
 
 
 class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
-    """OpenLibrary API"""
+    """OpenLibrary API."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -69,8 +69,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
     def check_availability(self) -> None:
-        """Check the status (availability) of the OpenLibrary API"""
-
+        """Check the status (availability) of the OpenLibrary API."""
         test_rec = {
             Fields.ENTRYTYPE: "book",
             Fields.ISBN: "9781446201435",
@@ -200,8 +199,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for OpenLibrary"""
-
+        """Source heuristic for OpenLibrary."""
         result = {"confidence": 0.0}
 
         return result
@@ -213,11 +211,11 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         raise NotImplementedError
 
     def search(self, rerun: bool) -> None:
-        """Run a search of OpenLibrary"""
+        """Run a search of OpenLibrary."""
 
         # if self.search_source.search_type == SearchType.DB:
         #     if utils.in_ci_environment():
@@ -232,8 +230,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from OpenLibrary based on similarity with the record provided"""
-
+        """Retrieve masterdata from OpenLibrary based on similarity with the record provided."""
         if any(self.origin_prefix in o for o in record.data[Fields.ORIGIN]):
             # Already linked to an open-library record
             return record
@@ -274,8 +271,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         return record
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -289,6 +285,5 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for OpenLibrary"""
-
+        """Source-specific preparation for OpenLibrary."""
         return record

--- a/colrev/packages/open_library/src/open_library_api.py
+++ b/colrev/packages/open_library/src/open_library_api.py
@@ -28,7 +28,6 @@ class OpenLibraryAPI:
 
     def get(self, url: str, *, timeout: int) -> requests.Response:
         """Perform a GET request and raise a custom error on failure."""
-
         try:
             response = self.session.request(
                 "GET", url, headers=self.headers, timeout=timeout

--- a/colrev/packages/open_library/src/open_library_prep.py
+++ b/colrev/packages/open_library/src/open_library_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on OpenLibrary API as a prep operation"""
+"""Consolidation of metadata based on OpenLibrary API as a prep operation."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from colrev.constants import SearchType
 
 
 class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on openlibrary.org metadata"""
+    """Prepares records based on openlibrary.org metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -64,7 +64,7 @@ class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
         )
 
     def check_availability(self) -> None:
-        """Check status (availability) of the OpenLibrary API"""
+        """Check status (availability) of the OpenLibrary API."""
         self.open_library_connector.check_availability()
 
     # pylint: disable=unused-argument
@@ -75,8 +75,7 @@ class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record metadata based on OpenLibrary"""
-
+        """Prepare the record metadata based on OpenLibrary."""
         if record.data.get(Fields.ENTRYTYPE, "NA") != "book":
             return record
 

--- a/colrev/packages/osf/src/__init__.py
+++ b/colrev/packages/osf/src/__init__.py
@@ -1,4 +1,4 @@
-"""Package for osf"""
+"""Package for osf."""
 
 __author__ = "Gerit Wagner"
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Searchsource:OSF"""
+"""Searchsource:OSF."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ from colrev.packages.osf.src.osf_api import OSFApiQuery
 
 
 class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """OSF"""
+    """OSF."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -71,8 +71,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for OSF"""
-
+        """Source heuristic for OSF."""
         result = {"confidence": 0.1}
 
         return result
@@ -84,8 +83,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search -a)"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search -a)."""
         params_dict: typing.Dict[str, str] = {}
         if params and isinstance(params, str) and params.startswith("http"):
             params_dict = {Fields.URL: params}
@@ -149,7 +147,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         return api_key
 
     def search(self, rerun: bool) -> None:
-        """Run a search of OSF"""
+        """Run a search of OSF."""
         osf_feed = colrev.ops.search_api_feed.SearchAPIFeed(
             source_identifier=self.source_identifier,
             search_source=self.search_source,
@@ -186,21 +184,18 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 60,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
-
+        """Not implemented."""
         return record
 
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Needs manual preparation"""
-
+        """Needs manual preparation."""
         return record
 
     def load(self) -> dict:
         """Load the records."""
-
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,

--- a/colrev/packages/osf/src/osf_api.py
+++ b/colrev/packages/osf/src/osf_api.py
@@ -54,8 +54,8 @@ class OSFApiQuery:
     def _query_api(self, url: str) -> str:
         """Creates the URL for the API call
         string url  Full URL to pass to API
-        return string: Results from API"""
-
+        return string: Results from API.
+        """
         response = requests.get(url, headers=self.headers, timeout=60)
         return response.text
 
@@ -170,7 +170,6 @@ class OSFApiQuery:
 
     def retrieve_records(self) -> typing.Generator:
         """Call the API with the query parameters and return the results."""
-
         if self.next_url is None:
             url = self._build_query()
         else:
@@ -191,7 +190,6 @@ class OSFApiQuery:
 
     def overall(self) -> int:
         """Return the overall number of records."""
-
         url = self._build_query()
         data = self._query_api(url)
         response = json.loads(data)
@@ -201,7 +199,6 @@ class OSFApiQuery:
 
     def _build_query(self) -> str:
         """Creates the URL for querying the API with support for nested filter parameters."""
-
         filters = []
         # Add in filters with the correct formatting
         for key, value in self.params.items():
@@ -212,5 +209,5 @@ class OSFApiQuery:
         return url
 
     def pages_completed(self) -> bool:
-        """Check if all pages have been completed"""
+        """Check if all pages have been completed."""
         return self.next_url is None

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Creation of a markdown paper as part of the data operations"""
+"""Creation of a markdown paper as part of the data operations."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ from colrev.writer.write_utils import write_file
 
 
 class PaperMarkdownSettings(BaseModel):
-    """Paper settings"""
+    """Paper settings."""
 
     endpoint: str
     version: str
@@ -58,7 +58,7 @@ class PaperMarkdownSettings(BaseModel):
 
 # pylint: disable=too-many-instance-attributes
 class PaperMarkdown(base_classes.DataPackageBaseClass):
-    """Synthesize the literature in a markdown paper
+    """Synthesize the literature in a markdown paper.
 
     The paper (paper.md) is created automatically.
     Records are added for synthesis after the <!-- NEW_RECORD_SOURCE -->
@@ -140,8 +140,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
-
+        """Add as an endpoint."""
         add_source = {
             "endpoint": "colrev.paper_md",
             "version": "0.1",
@@ -624,7 +623,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         silent_mode: bool,
     ) -> typing.Dict:
-        """Update the paper (add new records after the NEW_RECORD_SOURCE_TAG)"""
+        """Update the paper (add new records after the NEW_RECORD_SOURCE_TAG)."""
         review_manager = self.review_manager
 
         if not self.settings.paper_path.is_file():
@@ -713,8 +712,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
             ) from exc
 
     def build_paper(self) -> None:
-        """Build the paper (based on pandoc)"""
-
+        """Build the paper (based on pandoc)."""
         if not self.review_manager.paths.records.is_file():
             self.review_manager.paths.records.touch()
 
@@ -767,8 +765,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         silent_mode: bool,
     ) -> None:
-        """Update the data/paper"""
-
+        """Update the data/paper."""
         if (
             self.review_manager.dataset.git_repo.repo_initialized()
             and self.review_manager.dataset.git_repo.has_changes(
@@ -829,7 +826,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
+        """Update the record_status_matrix."""
         # Update status / synthesized_record_status_matrix
         synthesized = self._get_synthesized_papers(
             paper=self.settings.paper_path,
@@ -844,8 +841,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         advice = {
             "msg": "Data operation [paper_md endpoint]: "
             + "\n    1. Edit the paper (data/data/paper.md)"
@@ -858,7 +854,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
 
 
 class PaperMarkdownRecordSourceTagError(Exception):
-    """NEW_RECORD_SOURCE_TAG not found in paper.md"""
+    """NEW_RECORD_SOURCE_TAG not found in paper.md."""
 
     def __init__(self, msg: str) -> None:
         self.message = f" {msg}"

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: backward search (based on PDFs and GROBID)"""
+"""SearchSource: backward search (based on PDFs and GROBID)."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ from colrev.packages.pdf_backward_search.src import pdf_backward_search_api
 
 class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
     """Backward search extracting references from PDFs using GROBID
-    Scope: all included papers with colrev_status in (rev_included, rev_synthesized)
+    Scope: all included papers with colrev_status in (rev_included, rev_synthesized).
     """
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
@@ -81,8 +81,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def get_default_source(cls) -> colrev.search_file.ExtendedSearchFile:
-        """Get the default SearchSource settings"""
-
+        """Get the default SearchSource settings."""
         return colrev.search_file.ExtendedSearchFile(
             version=cls.CURRENT_SYNTAX_VERSION,
             platform="colrev.pdf_backward_search",
@@ -97,7 +96,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         )
 
     def _validate_source(self) -> None:
-        """Validate the SearchSource (parameters etc.)"""
+        """Validate the SearchSource (parameters etc.)."""
         source = self.search_source
         self.logger.debug(f"Validate SearchSource {source.search_results_path}")
 
@@ -385,8 +384,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         return colrev.record.record.Record(item)
 
     def search(self, rerun: bool) -> None:
-        """Run a search of PDFs (backward search based on GROBID)"""
-
+        """Run a search of PDFs (backward search based on GROBID)."""
         self._validate_source()
 
         # Do not run in continuous-integration environment
@@ -470,8 +468,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for PDF backward searches (GROBID)"""
-
+        """Source heuristic for PDF backward searches (GROBID)."""
         result = {"confidence": 0.0}
         if str(filename).endswith("_ref_list.pdf"):
             result["confidence"] = 1.0
@@ -568,8 +565,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             for item in params.split(";"):
@@ -594,8 +590,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -614,15 +609,14 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def prepare(
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for PDF backward searches (GROBID)"""
-
+        """Source-specific preparation for PDF backward searches (GROBID)."""
         record.format_if_mostly_upper(Fields.TITLE, case="sentence")
         record.format_if_mostly_upper(Fields.JOURNAL, case=Fields.TITLE)
         record.format_if_mostly_upper(Fields.BOOKTITLE, case=Fields.TITLE)

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search_api.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search_api.py
@@ -28,7 +28,6 @@ class PDFBackwardSearchAPI:
 
     def get(self, url: str, *, timeout: int) -> requests.Response:
         """Execute a GET request and raise a custom exception on failure."""
-
         try:
             response = self.session.get(url, headers=self.headers, timeout=timeout)
             response.raise_for_status()

--- a/colrev/packages/plos/src/plos_api.py
+++ b/colrev/packages/plos/src/plos_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Plos API"""
+"""Plos API."""
 
 import contextlib
 import datetime
@@ -42,11 +42,11 @@ class PlosAPIError(Exception):
 
 
 class MaxOffsetError(PlosAPIError):
-    """Max Offset Error"""
+    """Max Offset Error."""
 
 
 class HTTPRequest:
-    """HTTP Resquest"""
+    """HTTP Resquest."""
 
     def __init__(self, *, timeout: int) -> None:
         # https://api.plos.org/solr/faq/
@@ -103,7 +103,7 @@ class HTTPRequest:
 
 
 class Endpoint:
-    """Endpoint"""
+    """Endpoint."""
 
     CURSOR_AS_ITER_METHOD = False
 
@@ -158,7 +158,7 @@ class Endpoint:
 
     @property
     def version(self) -> str:
-        """API version"""
+        """API version."""
         request_params = dict(self.request_params)
         request_url = str(self.request_url)
 
@@ -262,7 +262,7 @@ class Endpoint:
 
 
 class PlosAPI:
-    """PLOS Api"""
+    """PLOS Api."""
 
     ISSN_REGEX = r"^\d{4}-?\d{3}[\dxX]$"
     YEAR_SCOPE_REGEX = r"^\d{4}-\d{4}$"
@@ -288,7 +288,7 @@ class PlosAPI:
         self.rerun = rerun
 
     def get_url(self) -> str:
-        """Get the url from the Plos API"""
+        """Get the url from the Plos API."""
         url = self.url
         if not self.rerun and self.last_updated:
             # Changes the last updated date
@@ -306,13 +306,13 @@ class PlosAPI:
         return url
 
     def get_len_total(self) -> int:
-        """Get the total number of records from Plos based on the parameters"""
+        """Get the total number of records from Plos based on the parameters."""
         endpoint = Endpoint(self.url, email=self.email)
 
         return endpoint.get_nr()
 
     def get_len(self) -> int:
-        """Get the number of records from Crossref based on the parameters"""
+        """Get the number of records from Crossref based on the parameters."""
         endpoint = Endpoint(self.get_url(), email=self.email)
         return endpoint.get_nr()
 
@@ -338,7 +338,7 @@ class PlosAPI:
         return similarity
 
     def get_records(self) -> typing.Iterator[colrev.record.record.Record]:
-        """Get records from PLOS based on the parameters"""
+        """Get records from PLOS based on the parameters."""
         url = self.get_url()
 
         endpoint = Endpoint(url, email=self.email)
@@ -354,7 +354,7 @@ class PlosAPI:
             ) from exc
 
     def query_doi(self, *, doi: str) -> colrev.record.record_prep.PrepRecord:
-        """Get records from PLOS based on a id query"""
+        """Get records from PLOS based on a id query."""
         try:
             endpoint = Endpoint(
                 self._api_url

--- a/colrev/packages/plos/src/plos_record_transformer.py
+++ b/colrev/packages/plos/src/plos_record_transformer.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Utility to transform plos/doi.org items to records"""
+"""Utility to transform plos/doi.org items to records."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ def _get_year(*, item: dict) -> str:
 
 
 def format_author(author: str) -> str:
-    """Convert authors to colrev format"""
+    """Convert authors to colrev format."""
     particles = {"de", "del", "la", "van", "von", "der", "di", "da", "le"}
 
     if author.startswith("{{") and author.endswith("}}"):
@@ -183,7 +183,7 @@ def _format_fields(*, record_dict: dict) -> dict:
 
 
 def json_to_record(*, item: dict) -> colrev.record.record_prep.PrepRecord:
-    "Convert a PLOS item to a record dict"
+    """Convert a PLOS item to a record dict."""
     try:
         record_dict = _item_to_record(item=deepcopy(item))
         record_dict = _set_forthcoming(record_dict=record_dict)

--- a/colrev/packages/plos/src/plos_search_source.py
+++ b/colrev/packages/plos/src/plos_search_source.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: plos"""
+"""SearchSource: plos."""
 
 import datetime
 import logging
@@ -30,7 +30,7 @@ from colrev.packages.plos.src import plos_api
 
 # pylint: disable=unused-argument
 class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """PLOS API"""
+    """PLOS API."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -59,8 +59,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Heuristic to identify to which SearchSource a search file belongs (for DB searches)"""
-
+        """Heuristic to identify to which SearchSource a search file belongs (for DB searches)."""
         result = {"confidence": 0.0}
         return result
 
@@ -86,7 +85,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
     ) -> colrev.search_file.ExtendedSearchFile:
         """Add the SearchSource as an endpoint based on a query (passed to colrev search -a)
         params:
-        - search_file="..." to add a DB search
+        - search_file="..." to add a DB search.
         """
         params_dict: dict = {}
         search_type = cls._select_search_type(params_dict)
@@ -169,8 +168,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         record: colrev.record.record.Record,
         feed: colrev.ops.search_api_feed.SearchAPIFeed,
     ) -> None:
-        "Restore the url from the feed if it exist"
-
+        """Restore the url from the feed if it exist."""
         prev_record = feed.get_prev_feed_record(record)
         prev_url = prev_record.data.get(Fields.URL, None)
 
@@ -264,7 +262,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of the SearchSource"""
+        """Run a search of the SearchSource."""
         self._validate_source()
         # Create the Object SearchAPIFeed which mange the search on the API
 
@@ -285,8 +283,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
             raise NotImplementedError
 
     def load(self) -> dict:
-        """Load records from the SearchSource (and convert to .bib)"""
-
+        """Load records from the SearchSource (and convert to .bib)."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -301,8 +298,7 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         self,
         record: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record.Record:
-        """Run the custom source-prep operation"""
-
+        """Run the custom source-prep operation."""
         return record
 
     def prep_link_md(
@@ -312,6 +308,5 @@ class PlosSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 30,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from Plos based on similarity with the record provided"""
-
+        """Retrieve masterdata from Plos based on similarity with the record provided."""
         return record

--- a/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
+++ b/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Jupyter notebook for prep-man operation"""
+"""Jupyter notebook for prep-man operation."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ import colrev.record.record
 
 
 class CurationJupyterNotebookManPrep(base_classes.PrepManPackageBaseClass):
-    """Manual preparation based on a Jupyter Notebook"""
+    """Manual preparation based on a Jupyter Notebook."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -45,8 +45,7 @@ class CurationJupyterNotebookManPrep(base_classes.PrepManPackageBaseClass):
             )
 
     def prepare_manual(self, records: dict) -> dict:
-        """Prepare records manually based on  a Jupyter notebeook"""
-
+        """Prepare records manually based on  a Jupyter notebeook."""
         input(
             "Navigate to the jupyter notebook available at\n"
             "prep_man/prep_man_curation.ipynb\n"

--- a/colrev/packages/prescreen_table/src/prescreen_table.py
+++ b/colrev/packages/prescreen_table/src/prescreen_table.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Prescreen based on a table"""
+"""Prescreen based on a table."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.constants import RecordState
 
 
 class TablePrescreen(base_classes.PrescreenPackageBaseClass):
-    """Table-based prescreen (exported and imported)"""
+    """Table-based prescreen (exported and imported)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -47,8 +47,7 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         split: list,
         export_table_format: str = "csv",
     ) -> None:
-        """Export a prescreen table"""
-
+        """Export a prescreen table."""
         # gh_issue https://github.com/CoLRev-Environment/colrev/issues/73
         # add delta (records not yet in the table)
         # instead of overwriting
@@ -131,8 +130,7 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         records: dict,
         import_table_path: str = "prescreen.csv",
     ) -> None:
-        """Import a prescreen table"""
-
+        """Import a prescreen table."""
         # pylint: disable=too-many-branches
 
         self.logger.info("Load %s", import_table_path)
@@ -226,8 +224,7 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         records: dict,
         split: list,
     ) -> dict:
-        """Prescreen records based on screening tables"""
-
+        """Prescreen records based on screening tables."""
         if input("create prescreen table [y,n]?") == "y":
             self.export_table(records=records, split=split)
 

--- a/colrev/packages/prisma/src/prisma.py
+++ b/colrev/packages/prisma/src/prisma.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Creation of a PRISMA chart as part of the data operations"""
+"""Creation of a PRISMA chart as part of the data operations."""
 
 from __future__ import annotations
 
@@ -27,14 +27,14 @@ if typing.TYPE_CHECKING:
 
 
 class PRISMA(base_classes.DataPackageBaseClass):
-    """Create a PRISMA diagram"""
+    """Create a PRISMA diagram."""
 
     ci_supported: bool = Field(default=False)
 
     class PRISMASettings(
         colrev.package_manager.package_settings.DefaultSettings, BaseModel
     ):
-        """PRISMA settings"""
+        """PRISMA settings."""
 
         endpoint: str
         version: str
@@ -83,8 +83,7 @@ class PRISMA(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
-
+        """Add as an endpoint."""
         add_package = {
             "endpoint": "colrev.prisma",
             "version": "0.1",
@@ -234,8 +233,7 @@ class PRISMA(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,  # pylint: disable=unused-argument
         silent_mode: bool,
     ) -> None:
-        """Update the data/prisma diagram"""
-
+        """Update the data/prisma diagram."""
         self._export_csv(silent_mode=silent_mode)
         self._export_diagram(silent_mode=silent_mode)
 
@@ -244,8 +242,7 @@ class PRISMA(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
-
+        """Update the record_status_matrix."""
         # Note : automatically set all to True / synthesized
         for syn_id in list(synthesized_record_status_matrix.keys()):
             synthesized_record_status_matrix[syn_id][endpoint_identifier] = True
@@ -253,8 +250,7 @@ class PRISMA(base_classes.DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         data_endpoint = "Data operation [prisma data endpoint]: "
 
         path_str = ",".join(

--- a/colrev/packages/profile/src/profile.py
+++ b/colrev/packages/profile/src/profile.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Creation of a profile of studies as part of the data operations"""
+"""Creation of a profile of studies as part of the data operations."""
 
 from __future__ import annotations
 
@@ -19,14 +19,14 @@ from colrev.constants import RecordState
 
 
 class Profile(base_classes.DataPackageBaseClass):
-    """Create a profile"""
+    """Create a profile."""
 
     ci_supported: bool = Field(default=False)
 
     class ProfileSettings(
         colrev.package_manager.package_settings.DefaultSettings, BaseModel
     ):
-        """Profile settings"""
+        """Profile settings."""
 
         endpoint: str
         version: str
@@ -55,8 +55,7 @@ class Profile(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
-
+        """Add as an endpoint."""
         add_package = {
             "endpoint": "colrev.profile",
             "version": "0.1",
@@ -66,8 +65,7 @@ class Profile(base_classes.DataPackageBaseClass):
         )
 
     def _update_profile(self, silent_mode: bool) -> None:
-        """Create a profile of the sample"""
-
+        """Create a profile of the sample."""
         self.logger.info("Create sample profile")
 
         def prep_records(*, records: dict) -> pd.DataFrame:
@@ -185,8 +183,7 @@ class Profile(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,  # pylint: disable=unused-argument
         silent_mode: bool,
     ) -> None:
-        """Update the data/profile"""
-
+        """Update the data/profile."""
         self._update_profile(silent_mode=silent_mode)
 
     def update_record_status_matrix(
@@ -194,8 +191,7 @@ class Profile(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
-
+        """Update the record_status_matrix."""
         # Note : automatically set all to True / synthesized
         for syn_id in list(synthesized_record_status_matrix.keys()):
             synthesized_record_status_matrix[syn_id][endpoint_identifier] = True
@@ -203,8 +199,7 @@ class Profile(base_classes.DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         data_endpoint = "Data operation [profile data endpoint]: "
 
         advice = {

--- a/colrev/packages/prospero/src/prospero_api.py
+++ b/colrev/packages/prospero/src/prospero_api.py
@@ -120,7 +120,7 @@ class PROSPEROAPI:
         return records
 
     def _format_author(self, author_string: str) -> str:
-        """Convert authors to colrev format"""
+        """Convert authors to colrev format."""
         particles = {"de", "del", "la", "van", "von", "der", "di", "da", "le"}
 
         if author_string.startswith("{{") and author_string.endswith("}}"):
@@ -224,7 +224,6 @@ class PROSPEROAPI:
 
     def get_next_record(self) -> typing.Iterator[dict]:
         """Extract record details from Prospero and yield them as dictionaries."""
-
         try:
             self._navigate_to_search_page()
 

--- a/colrev/packages/prospero/src/prospero_search_source.py
+++ b/colrev/packages/prospero/src/prospero_search_source.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """SearchSource: PROSPERO
-import colrev.search_file
+import colrev.search_file.
 
 A CoLRev SearchSource plugin to scrape and import records from PROSPERO.
 """
@@ -28,7 +28,7 @@ from colrev.ops.search_api_feed import create_api_source
 
 
 class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Prospero Search Source for retrieving protocol data"""
+    """Prospero Search Source for retrieving protocol data."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -48,7 +48,6 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the ProsperoSearchSource plugin."""
-
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file
@@ -89,7 +88,6 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
         """Source heuristic for Prospero."""
-
         result = {"confidence": 0.0}
         return result
 
@@ -108,8 +106,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
     def get_search_word(self) -> str:
-        """
-        Get the search query from settings or prompt the user.
+        """Get the search query from settings or prompt the user.
         If there's no 'query' in the search_parameters, we ask the user.
         """
         if self.search_word is not None:
@@ -157,7 +154,6 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     def search(self, rerun: bool) -> None:
         """Scrape Prospero using Selenium, save .bib file with results."""
-
         self._validate_source()
 
         prospero_feed = colrev.ops.search_api_feed.SearchAPIFeed(
@@ -192,8 +188,7 @@ class ProsperoSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     # pylint: disable=unused-argument
     def load(self) -> dict:
-        """
-        The interface requires a load method.
+        """The interface requires a load method.
         We only handle .bib files here,
         so we raise NotImplementedError for other formats.
         """

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: PsycINFO"""
+"""SearchSource: PsycINFO."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """PsycINFO"""
+    """PsycINFO."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -48,8 +48,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for PsycINFO"""
-
+        """Source heuristic for PsycINFO."""
         result = {"confidence": 0.1}
 
         # Note : no features in bib file for identification
@@ -68,8 +67,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
@@ -82,8 +80,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Psycinfo"""
-
+        """Run a search of Psycinfo."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -101,7 +98,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -184,8 +181,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".ris":
             return self._load_ris(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -200,6 +196,5 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for PsycINFO"""
-
+        """Source-specific preparation for PsycINFO."""
         return record

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Pubmed"""
+"""SearchSource: Pubmed."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ from colrev.packages.pubmed.src import pubmed_api
 
 
 class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Pubmed"""
+    """Pubmed."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -78,8 +78,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
     def validate_source(
         cls, search_source: colrev.search_file.ExtendedSearchFile
     ) -> None:
-        """Validate the SearchSource (parameters etc.)"""
-
+        """Validate the SearchSource (parameters etc.)."""
         print(f"Validate SearchSource {search_source.search_results_path}")
 
         if search_source.version != cls.CURRENT_SYNTAX_VERSION:
@@ -110,8 +109,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Pubmed"""
-
+        """Source heuristic for Pubmed."""
         result = {"confidence": 0.0}
 
         # Simple heuristic:
@@ -135,8 +133,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -215,8 +212,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def check_availability(self) -> None:
-        """Check status (availability) of the Pubmed API"""
-
+        """Check status (availability) of the Pubmed API."""
         try:
             # pylint: disable=duplicate-code
             test_rec = {
@@ -334,8 +330,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Retrieve masterdata from Pubmed based on similarity with the record provided"""
-
+        """Retrieve masterdata from Pubmed based on similarity with the record provided."""
         # To test the metadata provided for a particular pubmed-id use:
         # https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=10075143&rettype=xml&retmode=text
 
@@ -436,8 +431,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         pubmed_feed.save()
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Pubmed"""
-
+        """Run a search of Pubmed."""
         pubmed_feed = colrev.ops.search_api_feed.SearchAPIFeed(
             source_identifier=self.source_identifier,
             search_source=self.search_source,
@@ -526,8 +520,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".csv":
             return self._load_csv(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -549,8 +542,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Pubmed"""
-
+        """Source-specific preparation for Pubmed."""
         if "colrev.pubmed.first_author" in record.data:
             record.remove_field(key="colrev.pubmed.first_author")
 

--- a/colrev/packages/pubmed/src/pubmed_api.py
+++ b/colrev/packages/pubmed/src/pubmed_api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Pubmed API"""
+"""Pubmed API."""
 
 import datetime
 import logging
@@ -24,7 +24,7 @@ class PubmedAPIError(Exception):
 
 
 class PubmedAPI:
-    """Connector for the Pubmed API"""
+    """Connector for the Pubmed API."""
 
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-instance-attributes
@@ -155,8 +155,7 @@ class PubmedAPI:
         return retrieved_record_dict
 
     def query_id(self, *, pubmed_id: str) -> colrev.record.record.Record:
-        """Retrieve records from Pubmed based on a query"""
-
+        """Retrieve records from Pubmed based on a query."""
         try:
             database = "pubmed"
             url = (
@@ -237,7 +236,6 @@ class PubmedAPI:
 
     def get_query_return(self) -> typing.Iterator[colrev.record.record.Record]:
         """Retrieve records from PubMed based on self.url (term already included)."""
-
         total_results = None
         seen = set()
 

--- a/colrev/packages/pubmed/src/pubmed_metadata_prep.py
+++ b/colrev/packages/pubmed/src/pubmed_metadata_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on the Pubmed API as a prep operation"""
+"""Consolidation of metadata based on the Pubmed API as a prep operation."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.constants import SearchType
 
 
 class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on Pubmed metadata"""
+    """Prepares records based on Pubmed metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -73,7 +73,7 @@ class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
         ]
 
     def check_availability(self) -> None:
-        """Check status (availability) of the Pubmed API"""
+        """Check status (availability) of the Pubmed API."""
         self.pubmed_source.check_availability()
 
     # pylint: disable=unused-argument
@@ -84,8 +84,7 @@ class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record based on Pubmed metadata"""
-
+        """Prepare a record based on Pubmed metadata."""
         if any(
             pubmed_prefix in o
             for pubmed_prefix in self.pubmed_prefixes

--- a/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
+++ b/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Qualitative systematic review"""
+"""Qualitative systematic review."""
 
 import logging
 import typing
@@ -21,7 +21,7 @@ from colrev.packages.pdf_backward_search.src.pdf_backward_search import (
 
 
 class QualitativeSystematicReview(base_classes.ReviewTypePackageBaseClass):
-    """Qualitative systematic review"""
+    """Qualitative systematic review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -43,8 +43,7 @@ class QualitativeSystematicReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a qualitative systematic review"""
-
+        """Initialize a qualitative systematic review."""
         settings.sources.append(OpenCitationsSearchSource.get_default_source())
         settings.sources.append(BackwardSearchSource.get_default_source())
 

--- a/colrev/packages/ref_check/src/ref_check.py
+++ b/colrev/packages/ref_check/src/ref_check.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""DataPackageBaseClass: RefCheck"""
+"""DataPackageBaseClass: RefCheck."""
 
 import logging
 import typing
@@ -12,7 +12,7 @@ from colrev.package_manager.package_base_classes import DataPackageBaseClass
 
 
 class RefCheck(DataPackageBaseClass):
-    """RefCheck Class"""
+    """RefCheck Class."""
 
     def __init__(
         self,
@@ -31,15 +31,16 @@ class RefCheck(DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         silent_mode: bool,
     ) -> None:
-        """
-        Update the data by running the data operation. This includes data extraction,
+        """Update the data by running the data operation. This includes data extraction,
         analysis, and synthesis.
 
-        Parameters:
+        Parameters
+        ----------
         records (dict): The records to be updated.
         synthesized_record_status_matrix (dict): The status matrix for the synthesized records.
         silent_mode (bool): Whether the operation is run in silent mode
         (for checks of review_manager/status).
+
         """
 
     def update_record_status_matrix(
@@ -48,9 +49,8 @@ class RefCheck(DataPackageBaseClass):
         endpoint_identifier: str,
     ) -> None:
         """Update the record status matrix,
-        i.e., indicate whether the record is rev_synthesized for the given endpoint_identifier
+        i.e., indicate whether the record is rev_synthesized for the given endpoint_identifier.
         """
-
         records = self.review_manager.dataset.load_records_dict()
 
         for syn_id in synthesized_record_status_matrix:
@@ -64,8 +64,7 @@ class RefCheck(DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on how to operate the data package endpoint"""
-
+        """Get advice on how to operate the data package endpoint."""
         advice = {
             "msg": "Data operation [ref_check endpoint]: "
             + "\n    Prepare record metadata (or mark as IGNORE:...)",

--- a/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
+++ b/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Removal of broken IDs as a prep operation"""
+"""Removal of broken IDs as a prep operation."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from colrev.constants import Fields
 
 
 class RemoveBrokenIDPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records by removing invalid IDs DOIs/ISBNs"""
+    """Prepares records by removing invalid IDs DOIs/ISBNs."""
 
     ci_supported: bool = Field(default=True)
 
@@ -49,8 +49,7 @@ class RemoveBrokenIDPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record by removing broken IDs (invalid DOIs/ISBNs)"""
-
+        """Prepare the record by removing broken IDs (invalid DOIs/ISBNs)."""
         if self.prep_operation.polish and not self.review_manager.force_mode:
             return record
 

--- a/colrev/packages/remove_coverpage/src/remove_cover_page.py
+++ b/colrev/packages/remove_coverpage/src/remove_cover_page.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Cover-page removal as a PDF preparation operation"""
+"""Cover-page removal as a PDF preparation operation."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.constants import Filepaths
 
 
 class PDFCoverPage(base_classes.PDFPrepPackageBaseClass):
-    """Prepare PDFs by removing unnecessary cover pages (e.g. researchgate, publishers)"""
+    """Prepare PDFs by removing unnecessary cover pages (e.g. researchgate, publishers)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -179,8 +179,7 @@ class PDFCoverPage(base_classes.PDFPrepPackageBaseClass):
         record: colrev.record.record_pdf.PDFRecord,
         pad: int,  # pylint: disable=unused-argument
     ) -> colrev.record.record_pdf.PDFRecord:
-        """Prepare the PDF by removing coverpages (if any)"""
-
+        """Prepare the PDF by removing coverpages (if any)."""
         if not record.data[Fields.FILE].endswith(".pdf"):
             return record
 

--- a/colrev/packages/remove_last_page/src/remove_last_page.py
+++ b/colrev/packages/remove_last_page/src/remove_last_page.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Last-page removal as a PDF preparation operation"""
+"""Last-page removal as a PDF preparation operation."""
 
 from __future__ import annotations
 
@@ -45,7 +45,7 @@ class PDFLastPage(base_classes.PDFPrepPackageBaseClass):
         record: colrev.record.record_pdf.PDFRecord,
         pad: int,  # pylint: disable=unused-argument
     ) -> colrev.record.record_pdf.PDFRecord:
-        """Prepare the PDF by removing additional materials (if any)"""
+        """Prepare the PDF by removing additional materials (if any)."""
         if not record.data[Fields.FILE].endswith(".pdf"):
             return record
 

--- a/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
+++ b/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Removal of broken URLs (error 500) a prep operation"""
+"""Removal of broken URLs (error 500) a prep operation."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ from colrev.constants import Fields
 
 
 class RemoveError500URLsPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records by removing urls that are not available"""
+    """Prepares records by removing urls that are not available."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -54,8 +54,7 @@ class RemoveError500URLsPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record by removing URLs with 500 errors"""
-
+        """Prepare the record by removing URLs with 500 errors."""
         session = colrev.utils.get_cached_session()
 
         try:

--- a/colrev/packages/scientometric/src/scientometric.py
+++ b/colrev/packages/scientometric/src/scientometric.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Scientometric study"""
+"""Scientometric study."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class ScientometricReview(base_classes.ReviewTypePackageBaseClass):
-    """Scientometric study"""
+    """Scientometric study."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -36,8 +36,7 @@ class ScientometricReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a scientometric study"""
-
+        """Initialize a scientometric study."""
         settings.data.data_package_endpoints = [
             {
                 "endpoint": "colrev.paper_md",

--- a/colrev/packages/scope_prescreen/src/scope_prescreen.py
+++ b/colrev/packages/scope_prescreen/src/scope_prescreen.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Prescreen based on specified scope"""
+"""Prescreen based on specified scope."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ from colrev.constants import RecordState
 class ScopePrescreenSettings(
     colrev.package_manager.package_settings.DefaultSettings, BaseModel
 ):
-    """Settings for ScopePrescreen"""
+    """Settings for ScopePrescreen."""
 
     # pylint: disable=invalid-name
     # pylint: disable=too-many-instance-attributes
@@ -73,7 +73,7 @@ class ScopePrescreenSettings(
 
 
 class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
-    """Rule-based prescreen (scope)"""
+    """Rule-based prescreen (scope)."""
 
     settings: ScopePrescreenSettings
     ci_supported: bool = Field(default=True)
@@ -269,8 +269,7 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
 
     @classmethod
     def add_endpoint(cls, *, operation: colrev.ops.search.Search, params: str) -> None:
-        """Add  the scope_prescreen as an endpoint"""
-
+        """Add  the scope_prescreen as an endpoint."""
         if not params:
             print("Interactive mode not yet implemented.")
             return
@@ -331,8 +330,7 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
         records: dict,
         split: list,  # pylint: disable=unused-argument
     ) -> dict:
-        """Prescreen records based on the scope parameters"""
-
+        """Prescreen records based on the scope parameters."""
         for record_dict in records.values():
             self._conditional_prescreen(
                 record_dict=record_dict,

--- a/colrev/packages/scoping_review/src/scoping_review.py
+++ b/colrev/packages/scoping_review/src/scoping_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Scoping review"""
+"""Scoping review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class ScopingReview(base_classes.ReviewTypePackageBaseClass):
-    """Scoping review"""
+    """Scoping review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -36,8 +36,7 @@ class ScopingReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a scoping review"""
-
+        """Initialize a scoping review."""
         settings.data.data_package_endpoints = [
             {"endpoint": "colrev.prisma", "version": "1.0"},
             {

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Scopus"""
+"""SearchSource: Scopus."""
 
 from __future__ import annotations
 
@@ -29,7 +29,7 @@ from colrev.packages.scopus.src import scopus_api
 
 
 class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Scopus"""
+    """Scopus."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -98,8 +98,7 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         # params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         # search_source = create_db_source(
@@ -226,8 +225,7 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             return self._load_bib(
                 filename=self.search_source.search_results_path, logger=self.logger

--- a/colrev/packages/scopus/src/scopus_api.py
+++ b/colrev/packages/scopus/src/scopus_api.py
@@ -55,7 +55,6 @@ class ScopusAPI:
         self, *, eid: str
     ) -> list[dict[str, typing.Optional[str]]]:
         """Retrieve authors (names + ids) from the Scopus abstract endpoint."""
-
         url = self._SCOPUS_ABSTRACT_BY_EID_URL + urllib.parse.quote(eid)
         response = requests.get(
             url,
@@ -90,7 +89,6 @@ class ScopusAPI:
         self, *, doi: str
     ) -> list[dict[str, typing.Optional[str]]]:
         """Retrieve authors (names only) from Crossref as a fallback."""
-
         url = self._CROSSREF_WORKS_URL + urllib.parse.quote(doi)
         response = requests.get(url, headers=self._crossref_headers(), timeout=30)
         response.raise_for_status()
@@ -110,7 +108,6 @@ class ScopusAPI:
         self, *, eid: typing.Optional[str], doi: typing.Optional[str]
     ) -> tuple[str, list[dict[str, typing.Optional[str]]]]:
         """Resolve authors using Scopus Abstract Retrieval first, then Crossref."""
-
         if eid:
             try:
                 authors = self._scopus_abstract_authors_by_eid(eid=eid)

--- a/colrev/packages/scopus/src/transformer.py
+++ b/colrev/packages/scopus/src/transformer.py
@@ -65,12 +65,11 @@ def _normalize_pages(entry: typing.Dict[str, typing.Any]) -> typing.Optional[str
 
 
 def _parse_authors(entry: typing.Dict[str, typing.Any]) -> str:
-    """
-    Return compact author string like 'Surname, G.; Second, H.'.
+    """Return compact author string like 'Surname, G.; Second, H.'.
     Handles Scopus variants:
       - dc:creator (string)
       - author (list[dict] or dict)
-      - authors.author (list[dict])
+      - authors.author (list[dict]).
     """
     # pylint: disable=too-many-branches
 
@@ -218,13 +217,12 @@ def _apply_container_fields(
     entry: typing.Dict[str, typing.Any],
     entrytype: str,
 ) -> None:
-    """
-    Set container-specific fields:
-      - article -> journal, volume, number
-      - inproceedings -> booktitle (+ series if recognizable)
-      - proceedings -> title already holds proceedings title; add series
-      - incollection -> booktitle (+ series)
-      - book -> (title already set), add series if it is a book series
+    """Set container-specific fields:
+    - article -> journal, volume, number
+    - inproceedings -> booktitle (+ series if recognizable)
+    - proceedings -> title already holds proceedings title; add series
+    - incollection -> booktitle (+ series)
+    - book -> (title already set), add series if it is a book series.
     """
     # pylint: disable=too-many-branches
 
@@ -281,8 +279,7 @@ def _apply_container_fields(
 
 
 def transform_record(entry: dict) -> dict:
-    """Transform a raw Scopus record into a ColRev record"""
-
+    """Transform a raw Scopus record into a ColRev record."""
     scopus_id = _scopus_id(entry)
     eid = _eid(entry)
 

--- a/colrev/packages/screen_table/src/screen_table.py
+++ b/colrev/packages/screen_table/src/screen_table.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Screen based on a table"""
+"""Screen based on a table."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from colrev.constants import RecordState
 
 
 class TableScreen(base_classes.ScreenPackageBaseClass):
-    """Screen documents using tables (exported and imported)"""
+    """Screen documents using tables (exported and imported)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -114,8 +114,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
         split: list,
         export_table_format: str = "csv",
     ) -> None:
-        """Export a screening table"""
-
+        """Export a screening table."""
         # gh_issue https://github.com/CoLRev-Environment/colrev/issues/73
         # add delta (records not yet in the table)
         # instead of overwriting
@@ -150,8 +149,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
         records: dict,
         import_table_path: typing.Optional[Path] = None,
     ) -> None:
-        """Import a screening table"""
-
+        """Import a screening table."""
         # pylint: disable=duplicate-code
         if import_table_path is None:
             import_table_path = self.screen_table_path
@@ -200,8 +198,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
         self.review_manager.dataset.save_records_dict(records)
 
     def run_screen(self, records: dict, split: list) -> dict:
-        """Screen records based on screening tables"""
-
+        """Screen records based on screening tables."""
         if input("create screen table [y,n]?") == "y":
             self.export_table(records, split)
 

--- a/colrev/packages/screen_utils.py
+++ b/colrev/packages/screen_utils.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Screening utilities"""
+"""Screening utilities."""
 
 from __future__ import annotations
 
@@ -35,8 +35,7 @@ def _get_add_screening_criterion_dialogue(*, screening_criteria: dict) -> str:
 def get_screening_criteria_from_user_input(
     *, screen_operation: colrev.ops.screen.Screen, records: dict
 ) -> dict:
-    """Get the screening criteria from user input (initial setup)"""
-
+    """Get the screening criteria from user input (initial setup)."""
     screening_criteria = screen_operation.review_manager.settings.screen.criteria
     if len(screening_criteria) == 0 and 0 == len(
         [

--- a/colrev/packages/semanticscholar/src/record_transformer.py
+++ b/colrev/packages/semanticscholar/src/record_transformer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Utility to transform items from semanticscholar into records"""
+"""Utility to transform items from semanticscholar into records."""
 
 from __future__ import annotations
 
@@ -52,8 +52,7 @@ SUPPORTED_FIELDS = [
 
 
 def _assign_entrytype(*, record_dict: dict) -> None:
-    """Method to assign the ENTRYTYPE"""
-
+    """Method to assign the ENTRYTYPE."""
     publication_types = record_dict.get("publicationTypes")
     if publication_types is not None and len(publication_types) > 0:
         entrytype = publication_types[0]
@@ -68,8 +67,7 @@ def _assign_entrytype(*, record_dict: dict) -> None:
 
 
 def _assign_authors(*, record_dict: dict) -> None:
-    """Method to assign authors from item"""
-
+    """Method to assign authors from item."""
     authors = [
         author["name"] for author in record_dict.get("authors", []) if "name" in author
     ]
@@ -79,15 +77,14 @@ def _assign_authors(*, record_dict: dict) -> None:
 
 
 def _assign_issn(*, record_dict: dict) -> None:
-    """Method to assign the issn"""
-
+    """Method to assign the issn."""
     issn = (record_dict.get("publicationVenue", {}) or {}).get("issn")
     if issn:
         record_dict[Fields.ISSN] = issn
 
 
 def _assign_ids(*, record_dict: dict) -> None:
-    """Method to assign external IDs from item"""
+    """Method to assign external IDs from item."""
     ext_ids = record_dict.get("externalIds", {})
 
     if "DOI" in ext_ids:
@@ -97,7 +94,7 @@ def _assign_ids(*, record_dict: dict) -> None:
 
 
 def _assign_abstract(*, record_dict: dict) -> None:
-    """Method to assign external IDs from item"""
+    """Method to assign external IDs from item."""
     abstract = record_dict.get("abstract", "")
     if abstract is not None:
         record_dict[Fields.ABSTRACT] = abstract.replace("\n", " ").lstrip().rstrip()
@@ -106,8 +103,7 @@ def _assign_abstract(*, record_dict: dict) -> None:
 
 
 def _assign_article_fields(*, record_dict: dict) -> None:
-    """Method to assign pages and volume from item"""
-
+    """Method to assign pages and volume from item."""
     if record_dict.get("journal") is None:
         return
 
@@ -136,7 +132,7 @@ def _assign_article_fields(*, record_dict: dict) -> None:
 
 
 def _assign_book_fields(*, record_dict: dict) -> None:
-    """Method to assign book specific details from item"""
+    """Method to assign book specific details from item."""
     book_title = record_dict.get("journal", {}).get("name")
     title = record_dict.get(Fields.TITLE, "")
 
@@ -148,8 +144,7 @@ def _assign_book_fields(*, record_dict: dict) -> None:
 
 
 def _assign_inproc_fields(*, record_dict: dict) -> None:
-    """Method to assign inproceedings specific details from item"""
-
+    """Method to assign inproceedings specific details from item."""
     if "journal" in record_dict:
         del record_dict["journal"]
 
@@ -166,8 +161,7 @@ def _assign_fulltext(*, record_dict: dict) -> None:
 
 
 def _item_to_record(item: Paper) -> dict:
-    """Method to convert the different fields and information within item to record dictionary"""
-
+    """Method to convert the different fields and information within item to record dictionary."""
     record_dict = dict(item)
 
     record_dict[Fields.SEMANTIC_SCHOLAR_ID] = record_dict["paperId"]
@@ -194,16 +188,14 @@ def _item_to_record(item: Paper) -> dict:
 
 
 def _remove_fields(*, record: dict) -> dict:
-    """Method to remove unsupported fields from semanticscholar record"""
-
+    """Method to remove unsupported fields from semanticscholar record."""
     record_dict = {k: v for k, v in record.items() if k in SUPPORTED_FIELDS and v != ""}
 
     return record_dict
 
 
 def dict_to_record(*, item: dict) -> colrev.record.record.Record:
-    """Convert a semanticscholar item to a record dict"""
-
+    """Convert a semanticscholar item to a record dict."""
     try:
         record_dict = _item_to_record(item=item)
         record_dict = _remove_fields(record=record_dict)

--- a/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
+++ b/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Consolidation of metadata based on SemanticScholar API as a prep operation"""
+"""Consolidation of metadata based on SemanticScholar API as a prep operation."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.packages.semanticscholar.src import record_transformer
 
 
 class SemanticScholarPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on SemanticScholar metadata"""
+    """Prepares records based on SemanticScholar metadata."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=True)
@@ -58,8 +58,7 @@ class SemanticScholarPrep(base_classes.PrepPackageBaseClass):
         self,
         record_in: colrev.record.record_prep.PrepRecord,
     ) -> colrev.record.record_prep.PrepRecord:
-        """Prepare the record metadata based on SemanticScholar"""
-
+        """Prepare the record metadata based on SemanticScholar."""
         search_api_url = "https://api.semanticscholar.org/graph/v1/paper/search?query="
         url = search_api_url + record_in.data.get(Fields.TITLE, "").replace(" ", "+")
 
@@ -101,8 +100,7 @@ class SemanticScholarPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare a record based on metadata from SemanticScholar"""
-
+        """Prepare a record based on metadata from SemanticScholar."""
         try:
             retrieved_record = self._retrieve_record_from_semantic_scholar(record)
             if Fields.SEMANTIC_SCHOLAR_ID not in retrieved_record.data:

--- a/colrev/packages/semanticscholar/src/semanticscholar_api.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_api.py
@@ -25,7 +25,6 @@ class SemanticScholarAPI:
     @property
     def client(self) -> SemanticScholar:
         """Expose the underlying client (mainly for UI interactions)."""
-
         return self._client
 
     def get_paper(self, *, paper_id: str) -> dict:

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Semantic Scholar"""
+"""SearchSource: Semantic Scholar."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Semantic Scholar API Search Source"""
+    """Semantic Scholar API Search Source."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -93,8 +93,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         self.api = semanticscholar_api.SemanticScholarAPI()
 
     def check_availability(self) -> None:
-        """Check the availability of the Semantic Scholar API"""
-
+        """Check the availability of the Semantic Scholar API."""
         try:
             # pylint: disable=duplicate-code
             test_doi = "10.17705/1CAIS.04607"
@@ -126,7 +125,8 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         self, *, params: dict, rerun: bool
     ) -> PaginatedResults:
         """Get Semantic Scholar API depending on
-        the search subject and look for search parameters"""
+        the search subject and look for search parameters.
+        """
         subject = params.pop("search_subject")
         if subject == "keyword":
             _search_return = self.keyword_search(params=params, rerun=rerun)
@@ -141,8 +141,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         return _search_return
 
     def keyword_search(self, *, params: dict, rerun: bool) -> PaginatedResults:
-        """Prepare search parameters and conduct full keyword search with the python client"""
-
+        """Prepare search parameters and conduct full keyword search with the python client."""
         query = None
         year = None
         venue = None
@@ -197,8 +196,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         return record_return
 
     def paper_search(self, *, params: dict, rerun: bool) -> PaginatedResults:
-        """Method to conduct an API search of SemanticScholar with a List of Paper IDs"""
-
+        """Method to conduct an API search of SemanticScholar with a List of Paper IDs."""
         if "paper_ids" in params:
             try:
                 record_return = self.api.get_papers(params["paper_ids"])
@@ -227,8 +225,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         return record_return
 
     def author_search(self, *, params: dict, rerun: bool) -> PaginatedResults:
-        """Method to conduct an API search of SemanticScholar with a List of Author IDs"""
-
+        """Method to conduct an API search of SemanticScholar with a List of Author IDs."""
         if "author_ids" in params:
             try:
                 record_return = self.api.get_authors(params["author_ids"])
@@ -257,7 +254,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         return record_return
 
     def _get_api_key(self) -> str:
-        """Method to request an API key from the settings file - or, if empty, from user input"""
+        """Method to request an API key from the settings file - or, if empty, from user input."""
         api_key = os.getenv(self._ENV_API_KEY, "")
 
         if api_key:
@@ -271,8 +268,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         return api_key
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Semantic Scholar"""
-
+        """Run a search of Semantic Scholar."""
         # get the api key
         s2_api_key = self._get_api_key()
         if s2_api_key:
@@ -340,8 +336,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         # get search parameters from the user interface
         cls._s2_UI.main_ui()
         search_subject = cls._s2_UI.search_subject
@@ -392,13 +387,13 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 30,
     ) -> colrev.record.record.Record:
-        """Retrieve master data from Semantic Scholar"""
+        """Retrieve master data from Semantic Scholar."""
         # Not yet implemented
         return record
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Semantic Scholar"""
+        """Source heuristic for Semantic Scholar."""
         # Not yet implemented
 
         result = {"confidence": 0.0}
@@ -406,7 +401,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         return result
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
+        """Load the records from the SearchSource file."""
         # Not yet implemented
 
         if self.search_source.search_results_path.suffix == ".bib":
@@ -425,6 +420,6 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Semantic Scholar"""
+        """Source-specific preparation for Semantic Scholar."""
         # Not yet implemented
         return record

--- a/colrev/packages/semanticscholar/src/semanticscholar_ui.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_ui.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Console UI for Semantic Scholar"""
+"""Console UI for Semantic Scholar."""
 
 import datetime
 import re
@@ -12,7 +12,7 @@ from colrev.constants import Fields
 
 
 class SemanticScholarUI:
-    """Implements the User Interface for the SemanticScholar API Search within colrev"""
+    """Implements the User Interface for the SemanticScholar API Search within colrev."""
 
     search_params: dict
 
@@ -21,8 +21,7 @@ class SemanticScholarUI:
         self.search_subject = ""
 
     def main_ui(self) -> None:
-        """Display the main Menu and choose the search type"""
-
+        """Display the main Menu and choose the search type."""
         run = True
 
         print("\nWelcome to SemanticScholar! \n\n")
@@ -61,8 +60,7 @@ class SemanticScholarUI:
             )
 
     def paper_ui(self) -> bool:
-        """Ask user to enter search parameters for distinctive paper search"""
-
+        """Ask user to enter search parameters for distinctive paper search."""
         paper_id_list = []
 
         while True:
@@ -129,8 +127,7 @@ class SemanticScholarUI:
                 return True
 
     def author_ui(self) -> bool:
-        """Ask user to enter search parameters for distinctive author search"""
-
+        """Ask user to enter search parameters for distinctive author search."""
         author_id_list = []
 
         while True:
@@ -171,8 +168,7 @@ class SemanticScholarUI:
                 return True
 
     def keyword_ui(self) -> None:
-        """Ask user to enter Searchstring and limitations for Keyword search"""
-
+        """Ask user to enter Searchstring and limitations for Keyword search."""
         query = self.enter_text(msg="Please enter the query for your keyword search ")
         while not (query and isinstance(query, str)):
             query = self.enter_text(
@@ -208,8 +204,7 @@ class SemanticScholarUI:
             self.search_params["open_access_pdf"] = False
 
     def get_api_key(self, existing_key: typing.Optional[str] = "") -> str:
-        """Method to get API key from user input"""
-
+        """Method to get API key from user input."""
         ask_again = True
 
         if existing_key:
@@ -264,8 +259,7 @@ class SemanticScholarUI:
         return api_key
 
     def enter_year(self) -> str:
-        """Method to ask a specific year span in the format allowed by the SemanticScholar API"""
-
+        """Method to ask a specific year span in the format allowed by the SemanticScholar API."""
         examples = (
             "Examples for valid year spans: '2019'; '2012-2020'; '-2022'; '2015-'"
         )
@@ -312,8 +306,8 @@ class SemanticScholarUI:
 
     def enter_study_fields(self) -> list:
         """Method to ask a selection of fields of
-        study that are allowed by the Semantic Scholar API"""
-
+        study that are allowed by the Semantic Scholar API.
+        """
         msg = (
             "If you want to restrict your search to certain study fields, "
             "select them here or press Enter"
@@ -353,8 +347,7 @@ class SemanticScholarUI:
         msg: str,
         options: list,
     ) -> str:
-        """Method to display a question with single choice answers to the console using inquirer"""
-
+        """Method to display a question with single choice answers to the console using inquirer."""
         question = [
             inquirer.List(
                 name="Choice",
@@ -374,8 +367,8 @@ class SemanticScholarUI:
         options: list,
     ) -> list:
         """Method to display a question with multiple
-        choice answers to the console using inquirer"""
-
+        choice answers to the console using inquirer.
+        """
         question = [
             inquirer.Checkbox(
                 name="Choice",
@@ -394,8 +387,8 @@ class SemanticScholarUI:
         msg: str,
     ) -> str:
         """Method to display a question with free text
-        entry answer to the console using inquirer."""
-
+        entry answer to the console using inquirer.
+        """
         question = [
             inquirer.Text(
                 name="Entry",
@@ -412,15 +405,14 @@ class SemanticScholarUI:
         id_value: str,
         regex: str,
     ) -> bool:
-        """Method to validate ID formats using a regex as an argument"""
-
+        """Method to validate ID formats using a regex as an argument."""
         if re.match(regex, id_value):
             return True
 
         return False
 
     def check_format(self, *, param: str, value: str) -> bool:
-        """Method to validate certain ID formats"""
+        """Method to validate certain ID formats."""
         if param == "S2PaperId":
             if self.id_validation_with_regex(id_value=value, regex=r"^[a-zA-Z0-9]+$"):
                 return True

--- a/colrev/packages/source_specific_prep/src/source_specific_prep.py
+++ b/colrev/packages/source_specific_prep/src/source_specific_prep.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Source-specific preparation as a prep operation"""
+"""Source-specific preparation as a prep operation."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.package_manager.package_manager import PackageManager
 
 
 class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
-    """Prepares records based on the prepare scripts specified by the SearchSource"""
+    """Prepares records based on the prepare scripts specified by the SearchSource."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     source_correction_hint = "check with the developer"
@@ -50,7 +50,7 @@ class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Prepare the record by applying source-specific fixes"""
+        """Prepare the record by applying source-specific fixes."""
         # Note : we take the first origin (ie., the source-specific prep should
         # be one of the first in the prep-list)
         origin_source = record.data[Fields.ORIGIN][0].split("/")[0]

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Springer Link"""
+"""SearchSource: Springer Link."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ DEFAULT_PAGE_SIZE = 10
 
 
 class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Springer Link"""
+    """Springer Link."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -74,8 +74,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Springer Link"""
-
+        """Source heuristic for Springer Link."""
         result = {"confidence": 0.0}
 
         if filename.suffix == ".csv":
@@ -94,8 +93,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict: dict = {}  # {params.split("=")[0]: params.split("=")[1]}
         search_type = colrev.utils.select_search_type(
             search_types=cls.search_types, params=params_dict
@@ -123,8 +121,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of SpringerLink"""
-
+        """Run a search of SpringerLink."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -259,7 +256,6 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     def build_query(self, search_parameters: dict) -> str:
         """Build API query."""
-
         if "query" in search_parameters:
             query = search_parameters["query"]
 
@@ -306,7 +302,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     # pylint: disable=too-many-locals
     def get_query_return(self) -> typing.Iterator[colrev.record.record.Record]:
-        """Get the records from an API search"""
+        """Get the records from an API search."""
         query = self.build_query(self.search_source.search_parameters)
         api_key = self.get_api_key()
 
@@ -372,7 +368,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         springer_feed.save()
 
     def _create_record(self, doc: dict) -> colrev.record.record.Record:
-        """Fieldmapper API search"""
+        """Fieldmapper API search."""
         record_dict = {Fields.ID: doc["identifier"]}
         record_dict[Fields.ENTRYTYPE] = "misc"
 
@@ -440,7 +436,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -499,8 +495,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def api_ui(self) -> None:
-        """User API key insertion"""
-
+        """User API key insertion."""
         api_key = self.get_api_key()
 
         if not api_key:
@@ -524,14 +519,14 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
             return
 
     def get_api_key(self) -> str:
-        """Get API key from settings"""
+        """Get API key from settings."""
         api_key = os.getenv("SPRINGER_API_KEY")
         if api_key:
             return api_key
         return ""
 
     def _is_springer_link_api_key(self, previous: dict, answer: str) -> bool:
-        """Validate SpringerLink API key format"""
+        """Validate SpringerLink API key format."""
         api_key_pattern = re.compile(r"[a-z0-9]{32}")
         if not api_key_pattern.fullmatch(answer):
             raise inquirer.errors.ValidationError(
@@ -553,15 +548,14 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         return True
 
     def _is_year(self, previous: dict, answer: str) -> bool:
-        """Validate year format"""
+        """Validate year format."""
         year_pattern = re.compile(r"\d{4}")
         if not year_pattern.fullmatch(answer) and not answer == "":
             raise inquirer.errors.ValidationError("", reason="Invalid year format.")
         return True
 
     def _api_key_ui(self) -> None:
-        """User Interface to enter API key"""
-
+        """User Interface to enter API key."""
         questions = [
             inquirer.Text(
                 "springer_api_key",
@@ -585,8 +579,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".csv":
             return self._load_csv(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -606,6 +599,5 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Springer Link"""
-
+        """Source-specific preparation for Springer Link."""
         return record

--- a/colrev/packages/springer_link/src/springer_link_api.py
+++ b/colrev/packages/springer_link/src/springer_link_api.py
@@ -20,13 +20,11 @@ class SpringerLinkAPI:
 
     def get_json(self, url: str, *, timeout: int) -> dict:
         """Return JSON content from the API."""
-
         response = self._get(url=url, timeout=timeout)
         return response.json()
 
     def validate_api_key(self, url: str, *, timeout: int) -> None:
         """Validate the API key by performing a test request."""
-
         self._get(url=url, timeout=timeout)
 
     def _get(self, *, url: str, timeout: int) -> requests.Response:

--- a/colrev/packages/structured/src/structured.py
+++ b/colrev/packages/structured/src/structured.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Structured data extraction as part of the data operations"""
+"""Structured data extraction as part of the data operations."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ from colrev.constants import RecordState
 
 # an option: https://pypi.org/project/csv-schema/
 class DataField(BaseModel):
-    """Field definition"""
+    """Field definition."""
 
     name: str
     explanation: str
@@ -34,7 +34,7 @@ class DataField(BaseModel):
 
 
 class StructuredDataSettings(BaseModel):
-    """Settings for StructuredData"""
+    """Settings for StructuredData."""
 
     endpoint: str
     version: str
@@ -47,7 +47,7 @@ class StructuredDataSettings(BaseModel):
 
 
 class StructuredData(base_classes.DataPackageBaseClass):
-    """Summarize the literature in a structured data extraction (a table)"""
+    """Summarize the literature in a structured data extraction (a table)."""
 
     settings: StructuredDataSettings
     settings_class = StructuredDataSettings
@@ -90,8 +90,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
     # pylint: disable=unused-argument
     @classmethod
     def add_endpoint(cls, operation: colrev.ops.data.Data, params: str) -> None:
-        """Add as an endpoint"""
-
+        """Add as an endpoint."""
         add_source = {
             "endpoint": "colrev.structured",
             "version": "0.1",
@@ -101,8 +100,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
         operation.review_manager.settings.data.data_package_endpoints.append(add_source)
 
     def validate_structured_data(self) -> None:
-        """Validate the extracted data"""
-
+        """Validate the extracted data."""
         if not self.data_path.is_file():
             return
 
@@ -177,7 +175,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         silent_mode: bool,
     ) -> None:
-        """Update the data/structured data extraction"""
+        """Update the data/structured data extraction."""
 
         def update_structured_data(
             *,
@@ -255,7 +253,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
         synthesized_record_status_matrix: dict,
         endpoint_identifier: str,
     ) -> None:
-        """Update the record_status_matrix"""
+        """Update the record_status_matrix."""
 
         def get_data_extracted(
             data_path: Path, records_for_data_extraction: list
@@ -304,8 +302,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
     def get_advice(
         self,
     ) -> dict:
-        """Get advice on the next steps (for display in the colrev status)"""
-
+        """Get advice on the next steps (for display in the colrev status)."""
         data_endpoint = "Data operation [structured data endpoint]: "
 
         if self.settings.data_path_relative.is_file():

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: SYNERGY-datasets"""
+"""SearchSource: SYNERGY-datasets."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ from colrev.constants import SearchType
 
 
 class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """SYNERGY-datasets
+    """SYNERGY-datasets.
 
     https://github.com/asreview/synergy-dataset
 
@@ -66,8 +66,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for SYNERGY-datasets"""
-
+        """Source heuristic for SYNERGY-datasets."""
         result = {"confidence": 0.0}
 
         if "doi,pmid,openalex_id,label_included" in data:
@@ -124,8 +123,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             for item in params.split(";"):
@@ -258,8 +256,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         assert source.search_type == SearchType.API
 
     def search(self, rerun: bool) -> None:
-        """Run a search of the SYNERGY datasets"""
-
+        """Run a search of the SYNERGY datasets."""
         self._validate_source()
 
         dataset_df = self._load_dataset()
@@ -345,12 +342,11 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -373,8 +369,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for SYNERGY-datasets"""
-
+        """Source-specific preparation for SYNERGY-datasets."""
         record.rename_field(
             key="colrev.synergy_datasets.pubmedid", new_key=Fields.PUBMED_ID
         )

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Taylor and Francis"""
+"""SearchSource: Taylor and Francis."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Taylor and Francis"""
+    """Taylor and Francis."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -45,8 +45,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Taylor and Francis"""
-
+        """Source heuristic for Taylor and Francis."""
         result = {"confidence": 0.0}
 
         if data.count("\n@") > 1:
@@ -62,8 +61,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
@@ -76,8 +74,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of TaylorAndFrancis"""
-
+        """Run a search of TaylorAndFrancis."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -95,7 +92,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -120,8 +117,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             return self._load_bib(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -136,8 +132,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Taylor and Francis"""
-
+        """Source-specific preparation for Taylor and Francis."""
         # remove eprint and URL fields (they only have dois...)
         record.remove_field(key="colrev.taylor_and_francis.eprint")
         if "colrev.taylor_and_francis.note" in record.data and re.match(

--- a/colrev/packages/theoretical_review/src/theoretical_review.py
+++ b/colrev/packages/theoretical_review/src/theoretical_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Theoretical review"""
+"""Theoretical review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class TheoreticalReview(base_classes.ReviewTypePackageBaseClass):
-    """Theoretical review"""
+    """Theoretical review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -37,8 +37,7 @@ class TheoreticalReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize a theoretical review"""
-
+        """Initialize a theoretical review."""
         settings.data.data_package_endpoints = [
             {
                 "endpoint": "colrev.obsidian",

--- a/colrev/packages/toc_sync/src/toc_sync.py
+++ b/colrev/packages/toc_sync/src/toc_sync.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-General-purpose Markdown table-of-contents (TOC) creator/updater for journals.
+"""General-purpose Markdown table-of-contents (TOC) creator/updater for journals.
 
 What it does
 ------------
@@ -126,7 +125,7 @@ def _pair_sort_key(vol: str, iss: str) -> Tuple[Tuple[int, str], Tuple[int, str]
 
 @dataclass
 class TocConfig:
-    """TocConfig"""
+    """TocConfig."""
 
     issns: List[str]
     include_forthcoming: bool = False
@@ -398,11 +397,10 @@ def _write_full_markdown(
 def _append_incremental(
     grouped: Dict[str, Dict[str, List[dict]]], out_path: Path, cfg: TocConfig
 ) -> None:
-    """
-    Incremental update that:
-      - Removes any existing 'Forthcoming' block and re-inserts a fresh one
-      - Inserts strictly newer issues (vs. latest existing) right AFTER the header
-      - Keeps existing content intact below the inserted block
+    """Incremental update that:
+    - Removes any existing 'Forthcoming' block and re-inserts a fresh one
+    - Inserts strictly newer issues (vs. latest existing) right AFTER the header
+    - Keeps existing content intact below the inserted block.
     """
     if not out_path.exists():
         _write_full_markdown(grouped, out_path, cfg)
@@ -560,8 +558,7 @@ def create_new_toc(
     pdfs_dir: Optional[str] = None,
     fmt: str = "title_author_doi",
 ) -> Optional[Path]:
-    """Create a new toc file"""
-
+    """Create a new toc file."""
     j_name = input("Enter journal name to lookup the ISSN: ").strip()
     if not j_name:
         print("Aborted: empty journal name.", file=sys.stderr)
@@ -669,8 +666,7 @@ def _process_file(md_path: Path, only_append: bool = True) -> None:
 
 
 def main() -> None:
-    """Main entry point"""
-
+    """Main entry point."""
     parser = argparse.ArgumentParser(
         description="Update or create journal TOC markdown files from Crossref"
     )

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Transport Research International Documentation"""
+"""SearchSource: Transport Research International Documentation."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ from colrev.ops.search_db import run_db_search
 class TransportResearchInternationalDocumentation(
     base_classes.SearchSourcePackageBaseClass
 ):
-    """Transport Research International Documentation"""
+    """Transport Research International Documentation."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -51,8 +51,7 @@ class TransportResearchInternationalDocumentation(
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Transport Research International Documentation"""
-
+        """Source heuristic for Transport Research International Documentation."""
         result = {"confidence": 0.0}
         # Simple heuristic:
         if "UR  - https://trid.trb.org/view/" in data:
@@ -67,8 +66,7 @@ class TransportResearchInternationalDocumentation(
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
@@ -81,8 +79,7 @@ class TransportResearchInternationalDocumentation(
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of TRID"""
-
+        """Run a search of TRID."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -100,7 +97,7 @@ class TransportResearchInternationalDocumentation(
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -207,8 +204,7 @@ class TransportResearchInternationalDocumentation(
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".ris":
             return self._load_ris(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -223,8 +219,7 @@ class TransportResearchInternationalDocumentation(
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Transport Research International Documentation"""
-
+        """Source-specific preparation for Transport Research International Documentation."""
         if Fields.YEAR in record.data:
             if not re.match(r"^\d{4}$", record.data[Fields.YEAR]):
                 result = re.search(r"\d{4}", record.data[Fields.YEAR])

--- a/colrev/packages/ui_web/pages/home.py
+++ b/colrev/packages/ui_web/pages/home.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-"""Burn Down Chart is created here"""
+"""Burn Down Chart is created here."""
 
 from __future__ import annotations
 
@@ -23,7 +23,6 @@ dash.register_page(__name__, path="/")
 
 def analytics() -> px.line:
     """Function creating burn down chart."""
-
     # get data from get_analytics function
     review_manager = colrev.review_manager.ReviewManager()
     status_operation = review_manager.get_status_operation()

--- a/colrev/packages/ui_web/pages/synthesizedrecords.py
+++ b/colrev/packages/ui_web/pages/synthesizedrecords.py
@@ -52,7 +52,6 @@ def empty_figure() -> object:
 
 def plot_time(data_input: pd.DataFrame) -> object:
     """Create graph about papers published over time."""
-
     # check for data_input
     if data_input.empty:
         return empty_figure()
@@ -101,7 +100,6 @@ def plot_time(data_input: pd.DataFrame) -> object:
 
 def plot_journals(data_input: pd.DataFrame) -> px.bar:
     """Create graph about papers published per journal."""
-
     # check for data_input
     if data_input.empty:
         return empty_figure()

--- a/colrev/packages/ui_web/src/dashboard.py
+++ b/colrev/packages/ui_web/src/dashboard.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-"""CoLRev dashboard operation: track project progress through dashboard"""
+"""CoLRev dashboard operation: track project progress through dashboard."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ import colrev.exceptions as colrev_exceptions
 
 
 class Dashboard:
-    """Dashboard class"""
+    """Dashboard class."""
 
     def make_dashboard(self) -> Dash:
         """Create dashboard header and general structure."""
@@ -45,8 +45,7 @@ class Dashboard:
 
 
 def main() -> None:
-    """Main method for the dashboard"""
-
+    """Main method for the dashboard."""
     try:
         dashboard = Dashboard()
         app = dashboard.make_dashboard()

--- a/colrev/packages/umbrella/src/umbrella_review.py
+++ b/colrev/packages/umbrella/src/umbrella_review.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Umbrella review"""
+"""Umbrella review."""
 
 import logging
 import typing
@@ -15,7 +15,7 @@ import colrev.package_manager.package_settings
 
 
 class UmbrellaReview(base_classes.ReviewTypePackageBaseClass):
-    """Umbrella review"""
+    """Umbrella review."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
 
@@ -37,8 +37,7 @@ class UmbrellaReview(base_classes.ReviewTypePackageBaseClass):
     def initialize(
         self, settings: colrev.settings.Settings
     ) -> colrev.settings.Settings:
-        """Initialize an umbrella review"""
-
+        """Initialize an umbrella review."""
         settings.data.data_package_endpoints = [
             {
                 "endpoint": "colrev.paper_md",

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Unknown source (default for all other sources)"""
+"""SearchSource: Unknown source (default for all other sources)."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Unknown SearchSource"""
+    """Unknown SearchSource."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -67,8 +67,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for unknown sources"""
-
+        """Source heuristic for unknown sources."""
         result = {"confidence": 0.1}
 
         return result
@@ -80,8 +79,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {}
         if params:
             for item in params.split(";"):
@@ -97,8 +95,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Crossref"""
-
+        """Run a search of Crossref."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -113,7 +110,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -486,12 +483,11 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def ensure_append_only(cls, filename: Path) -> bool:
-        """Ensure that the SearchSource file is append-only"""
+        """Ensure that the SearchSource file is append-only."""
         return filename.suffix in [".ris", ".csv", ".xlsx", ".xls", ".md"]
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if not self.search_source.search_results_path.is_file():
             return {}
 
@@ -527,8 +523,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
     def _heuristically_fix_entrytypes(
         self, *, record: colrev.record.record_prep.PrepRecord
     ) -> None:
-        """Prepare the record by heuristically correcting erroneous ENTRYTYPEs"""
-
+        """Prepare the record by heuristically correcting erroneous ENTRYTYPEs."""
         # Journal articles should not have booktitles/series set.
         if record.data[Fields.ENTRYTYPE] == "article":
             if Fields.BOOKTITLE in record.data and Fields.JOURNAL not in record.data:
@@ -658,8 +653,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
             )
 
     def _format_fields(self, *, record: colrev.record.record_prep.PrepRecord) -> None:
-        """Format fields"""
-
+        """Format fields."""
         if record.data.get(Fields.ENTRYTYPE, "") == "inproceedings":
             self._format_inproceedings(record=record)
         elif record.data.get(Fields.ENTRYTYPE, "") == "article":
@@ -779,8 +773,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for unknown sources"""
-
+        """Source-specific preparation for unknown sources."""
         if not record.has_quality_defects() or record.masterdata_is_curated():
             return record
 

--- a/colrev/packages/unpaywall/src/api.py
+++ b/colrev/packages/unpaywall/src/api.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""API for Unpaywall"""
+"""API for Unpaywall."""
 
 from __future__ import annotations
 
@@ -51,7 +51,7 @@ ENTRYTYPE_MAPPING = {
 
 
 class UnpaywallAPI:
-    """API for Unpaywall"""
+    """API for Unpaywall."""
 
     def __init__(self, search_parameters: dict) -> None:
         self.search_parameters = search_parameters
@@ -79,7 +79,7 @@ class UnpaywallAPI:
         return list(affiliations)
 
     def create_record(self, article: dict) -> colrev.record.record.Record:
-        """Build record"""
+        """Build record."""
         doi = article.get("doi", "").upper()
         record_dict = {Fields.ID: doi}
 
@@ -124,7 +124,7 @@ class UnpaywallAPI:
         return record
 
     def get_query_records(self) -> typing.Iterator[colrev.record.record.Record]:
-        """Get the records from a query"""
+        """Get the records from a query."""
         all_results = []
         page = 1
         results_per_page = 50
@@ -173,7 +173,7 @@ class UnpaywallAPI:
 
     @classmethod
     def decode_html_url_encoding_to_string(cls, query: str) -> str:
-        """Decode URL encoding to string"""
+        """Decode URL encoding to string."""
         query = query.replace("AND", "%20")
         query = re.sub(r"(%20)+", "%20", query).strip()
         query = query.replace("%20OR%20", " OR ")

--- a/colrev/packages/unpaywall/src/unpaywall.py
+++ b/colrev/packages/unpaywall/src/unpaywall.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Retrieval of PDFs from the unpaywall API"""
+"""Retrieval of PDFs from the unpaywall API."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from colrev.packages.unpaywall.src import utils
 
 
 class Unpaywall(base_classes.PDFGetPackageBaseClass):
-    """Get PDFs from unpaywall.org"""
+    """Get PDFs from unpaywall.org."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -94,8 +94,7 @@ class Unpaywall(base_classes.PDFGetPackageBaseClass):
     def get_pdf(
         self, record: colrev.record.record.Record
     ) -> colrev.record.record.Record:
-        """Get PDFs from unpaywall"""
-
+        """Get PDFs from unpaywall."""
         if Fields.DOI not in record.data:
             return record
 

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Unpaywall"""
+"""SearchSource: Unpaywall."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from colrev.packages.unpaywall.src.api import UnpaywallAPI
 
 
 class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Unpaywall Search Source"""
+    """Unpaywall Search Source."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -65,7 +65,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Unpaywall"""
+        """Source heuristic for Unpaywall."""
         result = {"confidence": 0.0}
         return result
 
@@ -76,8 +76,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search -a )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search -a )."""
         params_dict = {}
         if params:
             if params.startswith("http"):
@@ -145,8 +144,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         unpaywall_feed.save()
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Unpaywall"""
-
+        """Run a search of Unpaywall."""
         unpaywall_feed = colrev.ops.search_api_feed.SearchAPIFeed(
             source_identifier=self.source_identifier,
             search_source=self.search_source,
@@ -161,8 +159,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
             raise NotImplementedError
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -179,7 +176,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def prepare(
@@ -189,5 +186,5 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Unpaywall"""
+        """Source-specific preparation for Unpaywall."""
         return record

--- a/colrev/packages/unpaywall/src/utils.py
+++ b/colrev/packages/unpaywall/src/utils.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Utils for Unpaywall"""
+"""Utils for Unpaywall."""
 
 import os
 
@@ -9,12 +9,11 @@ UNPAYWALL_EMAIL_ENV_VAR = "UNPAYWALL_EMAIL"
 
 
 def get_email() -> str:
-    """Get user's name and email,
+    """Get user's name and email,.
 
     if user have specified an email in registry, that will be returned
     otherwise it will return the email used in git
     """
-
     env_email = os.getenv(UNPAYWALL_EMAIL_ENV_VAR)
     if env_email:
         return env_email

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Web of Science"""
+"""SearchSource: Web of Science."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Web of Science"""
+    """Web of Science."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -52,16 +52,14 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
     def validate_source(
         cls, search_source: colrev.search_file.ExtendedSearchFile
     ) -> None:
-        """Validate the search source"""
-
+        """Validate the search source."""
         if search_source.search_type == SearchType.DB:
             print(f"Validating search string: {search_source.search_string}")
             parse(search_source.search_string, platform="wos")
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Web of Science"""
-
+        """Source heuristic for Web of Science."""
         result = {"confidence": 0.0}
 
         if data.count("UT WOS:") > 0.4 * data.count("TI "):
@@ -93,8 +91,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         # params_dict = {params.split("=")[0]: params.split("=")[1]}
         params_dict: dict = {}
 
@@ -108,8 +105,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of WebOfScience"""
-
+        """Run a search of WebOfScience."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -127,7 +123,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     @classmethod
@@ -174,8 +170,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         return records
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             return self._load_bib(
                 filename=self.search_source.search_results_path, logger=self.logger
@@ -190,8 +185,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Web of Science"""
-
+        """Source-specific preparation for Web of Science."""
         # pylint: disable=colrev-missed-constant-usage
         record.format_if_mostly_upper(Fields.TITLE, case="sentence")
         record.format_if_mostly_upper(Fields.JOURNAL, case="title")

--- a/colrev/packages/website_screenshot/src/website_screenshot.py
+++ b/colrev/packages/website_screenshot/src/website_screenshot.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Creation of screenshots (PDFs) for online ENTRYTYPES"""
+"""Creation of screenshots (PDFs) for online ENTRYTYPES."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ from colrev.constants import RecordState
 
 
 class WebsiteScreenshot(base_classes.PDFGetPackageBaseClass):
-    """Get PDFs from website screenshot (for "online" ENTRYTYPES)"""
+    """Get PDFs from website screenshot (for "online" ENTRYTYPES)."""
 
     settings_class = colrev.package_manager.package_settings.DefaultSettings
     ci_supported: bool = Field(default=False)
@@ -50,8 +50,7 @@ class WebsiteScreenshot(base_classes.PDFGetPackageBaseClass):
         pdf_get_operation.docker_images_to_stop.append(self.CHROME_BROWSERLESS_IMAGE)
 
     def _start_screenshot_service(self) -> None:
-        """Start the screenshot service"""
-
+        """Start the screenshot service."""
         # pylint: disable=duplicate-code
 
         if self.screenshot_service_available():
@@ -86,8 +85,7 @@ class WebsiteScreenshot(base_classes.PDFGetPackageBaseClass):
         return
 
     def screenshot_service_available(self) -> bool:
-        """Check if the screenshot service is available"""
-
+        """Check if the screenshot service is available."""
         content_type_header = {"Content-type": "text/plain"}
 
         browserless_chrome_available = False
@@ -109,8 +107,7 @@ class WebsiteScreenshot(base_classes.PDFGetPackageBaseClass):
     def _add_screenshot(
         self, *, record: colrev.record.record.Record, pdf_filepath: Path
     ) -> colrev.record.record.Record:
-        """Add a PDF screenshot to the record"""
-
+        """Add a PDF screenshot to the record."""
         if Fields.URL not in record.data:
             return record
 
@@ -153,8 +150,7 @@ class WebsiteScreenshot(base_classes.PDFGetPackageBaseClass):
     def get_pdf(
         self, record: colrev.record.record.Record
     ) -> colrev.record.record.Record:
-        """Get a PDF of the website (screenshot)"""
-
+        """Get a PDF of the website (screenshot)."""
         if record.data[Fields.ENTRYTYPE] != "online":
             return record
 

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""SearchSource: Wiley"""
+"""SearchSource: Wiley."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from colrev.ops.search_db import run_db_search
 
 
 class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
-    """Wiley"""
+    """Wiley."""
 
     CURRENT_SYNTAX_VERSION = "0.1.0"
 
@@ -46,8 +46,7 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
 
     @classmethod
     def heuristic(cls, filename: Path, data: str) -> dict:
-        """Source heuristic for Wiley"""
-
+        """Source heuristic for Wiley."""
         result = {"confidence": 0.0}
 
         # Simple heuristic:
@@ -64,8 +63,7 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         path: Path,
         logger: typing.Optional[logging.Logger] = None,
     ) -> colrev.search_file.ExtendedSearchFile:
-        """Add SearchSource as an endpoint (based on query provided to colrev search --add )"""
-
+        """Add SearchSource as an endpoint (based on query provided to colrev search --add )."""
         params_dict = {params.split("=")[0]: params.split("=")[1]}
 
         search_source = create_db_source(
@@ -78,8 +76,7 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         return search_source
 
     def search(self, rerun: bool) -> None:
-        """Run a search of Wiley"""
-
+        """Run a search of Wiley."""
         if self.search_source.search_type == SearchType.DB:
             run_db_search(
                 db_url=self.db_url,
@@ -97,12 +94,11 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         save_feed: bool = True,
         timeout: int = 10,
     ) -> colrev.record.record.Record:
-        """Not implemented"""
+        """Not implemented."""
         return record
 
     def load(self) -> dict:
-        """Load the records from the SearchSource file"""
-
+        """Load the records from the SearchSource file."""
         if self.search_source.search_results_path.suffix == ".bib":
             records = colrev.loader.load_utils.load(
                 filename=self.search_source.search_results_path,
@@ -124,8 +120,7 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
             colrev.record.qm.quality_model.QualityModel
         ] = None,
     ) -> colrev.record.record.Record:
-        """Source-specific preparation for Wiley"""
-
+        """Source-specific preparation for Wiley."""
         if record.data.get(Fields.ENTRYTYPE, "") == "inbook":
             record.rename_field(key=Fields.TITLE, new_key=Fields.CHAPTER)
             record.rename_field(key=Fields.BOOKTITLE, new_key=Fields.TITLE)

--- a/colrev/paths.py
+++ b/colrev/paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""CoLRev standard paths"""
+"""CoLRev standard paths."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from pathlib import Path
 # pylint: disable=too-few-public-methods
 # pylint: disable=too-many-instance-attributes
 class PathManager:
-    """Paths for the CoLRev review project (repository)"""
+    """Paths for the CoLRev review project (repository)."""
 
     SEARCH_DIR = Path("data/search")
     PREP_DIR = Path("data/prep")

--- a/colrev/process/__init__.py
+++ b/colrev/process/__init__.py
@@ -1,4 +1,4 @@
-"""Process model (states, transitions, corresponding operations)"""
+"""Process model (states, transitions, corresponding operations)."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/process/model.py
+++ b/colrev/process/model.py
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class ProcessModel:
-    """The ProcessModel describes transitions between RecordStates"""
+    """The ProcessModel describes transitions between RecordStates."""
 
     transitions = [
         {
@@ -108,14 +108,13 @@ class ProcessModel:
 
     @classmethod
     def get_valid_transitions(cls, *, state: RecordState) -> set:
-        """Get the list of valid transitions"""
+        """Get the list of valid transitions."""
         logging.getLogger("transitions").setLevel(logging.WARNING)
         return set({x["trigger"] for x in cls.transitions if x["source"] == state})
 
     @classmethod
     def get_preceding_states(cls, *, state: RecordState) -> set:
-        """Get the states preceding the state that is given as a parameter"""
-
+        """Get the states preceding the state that is given as a parameter."""
         logging.getLogger("transitions").setLevel(logging.WARNING)
         preceding_states: set[RecordState] = set()
         added = True
@@ -135,7 +134,7 @@ class ProcessModel:
     def check_operation_precondition(
         cls, operation: colrev.process.operation.Operation
     ) -> None:
-        """Check the preconditions for an operation"""
+        """Check the preconditions for an operation."""
 
         def get_states_set() -> set:
             records_headers = operation.review_manager.dataset.load_records_dict(

--- a/colrev/process/operation.py
+++ b/colrev/process/operation.py
@@ -21,7 +21,7 @@ F = typing.TypeVar("F", bound=typing.Callable[..., typing.Any])
 
 
 class Operation:
-    """Operations correspond to the work steps in a CoLRev project"""
+    """Operations correspond to the work steps in a CoLRev project."""
 
     type: OperationsType
 
@@ -45,7 +45,7 @@ class Operation:
     # pylint: disable=too-many-nested-blocks
     @classmethod
     def decorate(cls) -> typing.Callable:
-        """Decorator for operations"""
+        """Decorator for operations."""
 
         def decorator_func(func: F) -> typing.Callable:
             def wrapper_func(self, *args, **kwargs) -> typing.Any:  # type: ignore
@@ -115,7 +115,7 @@ class Operation:
         return True  # pragma: no cover
 
     def check_precondition(self) -> None:
-        """Check the operation precondition"""
+        """Check the operation precondition."""
         if self.review_manager.force_mode:
             return
 
@@ -159,7 +159,7 @@ class Operation:
         # ie., implicit pass for check, pdf_prep_man
 
     def notify(self, *, state_transition: bool = True) -> None:
-        """Notify the review_manager about the next operation"""
+        """Notify the review_manager about the next operation."""
         self.review_manager.notified_next_operation = self.type
         if state_transition:
             self.check_precondition()

--- a/colrev/process/status.py
+++ b/colrev/process/status.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:
 
 
 class StatusStatsCurrently(BaseModel):
-    """The current status statistics"""
+    """The current status statistics."""
 
     # pylint: disable=too-many-instance-attributes
     md_retrieved: int
@@ -42,7 +42,7 @@ class StatusStatsCurrently(BaseModel):
 
 
 class StatusStatsOverall(BaseModel):
-    """The overall-status statistics (records currently/previously in each state)"""
+    """The overall-status statistics (records currently/previously in each state)."""
 
     # pylint: disable=too-many-instance-attributes
     md_retrieved: int
@@ -107,7 +107,7 @@ def _get_nr_origins(records: dict) -> int:
 
 
 def _get_nr_incomplete(origin_states_dict: dict) -> int:
-    """Get the number of incomplete records"""
+    """Get the number of incomplete records."""
     return len(
         [
             x
@@ -334,7 +334,7 @@ REQUIRED_ATOMIC_STEPS = {
 def _get_completed_atomic_steps(
     records: dict, currently: StatusStatsCurrently, md_duplicates_removed: int
 ) -> int:
-    """Get the number of completed atomic steps"""
+    """Get the number of completed atomic steps."""
     completed_steps = 0
     for record_dict in records.values():
         completed_steps += REQUIRED_ATOMIC_STEPS[record_dict[Fields.STATUS]]
@@ -366,8 +366,7 @@ def get_status_stats(
     review_manager: colrev.review_manager.ReviewManager,
     records: dict,
 ) -> StatusStats:
-    """Get the status statistics"""
-
+    """Get the status statistics."""
     origin_states_dict = _get_origin_states_dict(records)
 
     screening_statistics = _get_screening_statistics(
@@ -411,7 +410,7 @@ def get_status_stats(
 
 
 class StatusStats(BaseModel):
-    """Data class for status statistics"""
+    """Data class for status statistics."""
 
     # pylint: disable=too-many-instance-attributes
     atomic_steps: int
@@ -429,7 +428,7 @@ class StatusStats(BaseModel):
     origin_states_dict: dict
 
     def get_active_metadata_operation_info(self) -> str:
-        """Get active metadata operation info (convenience function for status printing)"""
+        """Get active metadata operation info (convenience function for status printing)."""
         infos = []
         if self.currently.md_retrieved > 0:
             infos.append(f"{self.currently.md_retrieved} to load")
@@ -444,7 +443,7 @@ class StatusStats(BaseModel):
         return ", ".join(infos)
 
     def get_active_pdf_operation_info(self) -> str:
-        """Get active PDF operation info (convenience function for status printing)"""
+        """Get active PDF operation info (convenience function for status printing)."""
         infos = []
         if self.currently.rev_prescreen_included > 0:
             infos.append(f"{self.currently.rev_prescreen_included} to retrieve")
@@ -463,8 +462,7 @@ class StatusStats(BaseModel):
     def get_transitioned_records(
         self, review_manager: colrev.review_manager.ReviewManager
     ) -> list[typing.Dict]:
-        """Get the transitioned records"""
-
+        """Get the transitioned records."""
         committed_origin_states_dict = (
             review_manager.dataset.get_committed_origin_state_dict()
         )
@@ -508,8 +506,7 @@ class StatusStats(BaseModel):
         return transitioned_records
 
     def get_priority_operations(self) -> list:
-        """Get the priority operations"""
-
+        """Get the priority operations."""
         # get "earliest" states (going backward)
         earliest_state = []
         search_states = [RecordState.rev_synthesized]
@@ -541,8 +538,7 @@ class StatusStats(BaseModel):
         return list(set(priority_transitions))
 
     def get_active_operations(self) -> list:
-        """Get the active processing functions"""
-
+        """Get the active processing functions."""
         active_operations: typing.List[str] = []
         for state in set(self.origin_states_dict.values()):
             valid_transitions = ProcessModel.get_valid_transitions(state=state)
@@ -551,6 +547,5 @@ class StatusStats(BaseModel):
         return active_operations
 
     def get_operation_in_progress(self, *, transitioned_records: list) -> set:
-        """Get the operation currently in progress"""
-
+        """Get the operation currently in progress."""
         return {str(x["type"]) for x in transitioned_records}

--- a/colrev/record/qm/checkers/container_title_abbreviated.py
+++ b/colrev/record/qm/checkers/container_title_abbreviated.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class ContainerTitleAbbreviatedChecker:
-    """The ContainerTitleAbbreviatedChecker"""
+    """The ContainerTitleAbbreviatedChecker."""
 
     fields_to_check = [Fields.JOURNAL, Fields.BOOKTITLE]
     msg = DefectCodes.CONTAINER_TITLE_ABBREVIATED
@@ -22,8 +22,7 @@ class ContainerTitleAbbreviatedChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the container-title-abbreviated checks"""
-
+        """Run the container-title-abbreviated checks."""
         for key in self.fields_to_check:
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -48,5 +47,5 @@ class ContainerTitleAbbreviatedChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(ContainerTitleAbbreviatedChecker(quality_model))

--- a/colrev/record/qm/checkers/doi_not_matching_pattern.py
+++ b/colrev/record/qm/checkers/doi_not_matching_pattern.py
@@ -13,7 +13,7 @@ from colrev.constants import Fields
 
 
 class DOIPatternChecker:
-    """The DOIPatternChecker"""
+    """The DOIPatternChecker."""
 
     msg = DefectCodes.DOI_NOT_MATCHING_PATTERN
     # https://www.crossref.org/blog/dois-and-matching-regular-expressions/
@@ -25,8 +25,7 @@ class DOIPatternChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the doi-not-matching-pattern checks"""
-
+        """Run the doi-not-matching-pattern checks."""
         if Fields.DOI not in record.data or record.ignored_defect(
             key=Fields.DOI, defect=self.msg
         ):
@@ -39,5 +38,5 @@ class DOIPatternChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(DOIPatternChecker(quality_model))

--- a/colrev/record/qm/checkers/erroneous_symbol_in_field.py
+++ b/colrev/record/qm/checkers/erroneous_symbol_in_field.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class ErroneousSymbolInFieldChecker:
-    """The ErroneousSymbolInFieldChecker"""
+    """The ErroneousSymbolInFieldChecker."""
 
     fields_to_check = [
         Fields.AUTHOR,
@@ -29,8 +29,7 @@ class ErroneousSymbolInFieldChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the erroneous-symbol-in-field checks"""
-
+        """Run the erroneous-symbol-in-field checks."""
         for key in self.fields_to_check:
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -46,5 +45,5 @@ class ErroneousSymbolInFieldChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(ErroneousSymbolInFieldChecker(quality_model))

--- a/colrev/record/qm/checkers/erroneous_term_in_field.py
+++ b/colrev/record/qm/checkers/erroneous_term_in_field.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class ErroneousTermInFieldChecker:
-    """The ErroneousTermInFieldChecker"""
+    """The ErroneousTermInFieldChecker."""
 
     erroneous_terms = {
         Fields.AUTHOR: [
@@ -39,8 +39,7 @@ class ErroneousTermInFieldChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the erroneous-term-in-field checks"""
-
+        """Run the erroneous-term-in-field checks."""
         for key, erroneous_term_list in self.erroneous_terms.items():
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -57,5 +56,5 @@ class ErroneousTermInFieldChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(ErroneousTermInFieldChecker(quality_model))

--- a/colrev/record/qm/checkers/erroneous_title_field.py
+++ b/colrev/record/qm/checkers/erroneous_title_field.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class ErroneousTitleFieldChecker:
-    """The ErroneousTitleFieldChecker"""
+    """The ErroneousTitleFieldChecker."""
 
     msg = DefectCodes.ERRONEOUS_TITLE_FIELD
 
@@ -21,8 +21,7 @@ class ErroneousTitleFieldChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the erroneous-title-field checks"""
-
+        """Run the erroneous-title-field checks."""
         if Fields.TITLE not in record.data or record.ignored_defect(
             key=Fields.TITLE, defect=self.msg
         ):
@@ -58,5 +57,5 @@ class ErroneousTitleFieldChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(ErroneousTitleFieldChecker(quality_model))

--- a/colrev/record/qm/checkers/html_tags.py
+++ b/colrev/record/qm/checkers/html_tags.py
@@ -13,7 +13,7 @@ from colrev.constants import Fields
 
 
 class HTMLTagChecker:
-    """The HTMLTagChecker"""
+    """The HTMLTagChecker."""
 
     msg = DefectCodes.HTML_TAGS
     _fields_to_check = [
@@ -31,8 +31,7 @@ class HTMLTagChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the html-tags checks"""
-
+        """Run the html-tags checks."""
         for key in self._fields_to_check:
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -47,5 +46,5 @@ class HTMLTagChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(HTMLTagChecker(quality_model))

--- a/colrev/record/qm/checkers/identical_values_between_title_and_container.py
+++ b/colrev/record/qm/checkers/identical_values_between_title_and_container.py
@@ -12,7 +12,7 @@ from colrev.constants import FieldValues
 
 
 class IdenticalValuesChecker:
-    """The IdenticalValuesChecker"""
+    """The IdenticalValuesChecker."""
 
     msg = DefectCodes.IDENTICAL_VALUES_BETWEEN_TITLE_AND_CONTAINER
 
@@ -22,8 +22,7 @@ class IdenticalValuesChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the identical-values-between-title-and-container checks"""
-
+        """Run the identical-values-between-title-and-container checks."""
         if record.ignored_defect(key=Fields.TITLE, defect=self.msg):
             return
 
@@ -55,5 +54,5 @@ class IdenticalValuesChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(IdenticalValuesChecker(quality_model))

--- a/colrev/record/qm/checkers/incomplete_field.py
+++ b/colrev/record/qm/checkers/incomplete_field.py
@@ -12,7 +12,7 @@ from colrev.constants import FieldValues
 
 
 class IncompleteFieldChecker:
-    """The IncompleteFieldChecker"""
+    """The IncompleteFieldChecker."""
 
     msg = DefectCodes.INCOMPLETE_FIELD
 
@@ -22,8 +22,7 @@ class IncompleteFieldChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the missing-field checks"""
-
+        """Run the missing-field checks."""
         for key in [
             Fields.TITLE,
             Fields.JOURNAL,
@@ -76,5 +75,5 @@ class IncompleteFieldChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(IncompleteFieldChecker(quality_model))

--- a/colrev/record/qm/checkers/inconsistent_content.py
+++ b/colrev/record/qm/checkers/inconsistent_content.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class InconsistentContentChecker:
-    """The InconsistentContentChecker"""
+    """The InconsistentContentChecker."""
 
     msg = DefectCodes.INCONSISTENT_CONTENT
 
@@ -21,8 +21,7 @@ class InconsistentContentChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the inconsistent-content checks"""
-
+        """Run the inconsistent-content checks."""
         for key in [Fields.JOURNAL, Fields.BOOKTITLE, Fields.AUTHOR]:
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -56,5 +55,5 @@ class InconsistentContentChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(InconsistentContentChecker(quality_model))

--- a/colrev/record/qm/checkers/inconsistent_with_doi_metadata.py
+++ b/colrev/record/qm/checkers/inconsistent_with_doi_metadata.py
@@ -16,7 +16,7 @@ from colrev.packages.crossref.src.crossref_api import query_doi
 
 
 class InconsistentWithDOIMetadataChecker:
-    """The InconsistentWithDOIMetadataChecker"""
+    """The InconsistentWithDOIMetadataChecker."""
 
     msg = DefectCodes.INCONSISTENT_WITH_DOI_METADATA
     _fields_to_check = [
@@ -34,8 +34,7 @@ class InconsistentWithDOIMetadataChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the inconsistent-with-doi-metadata checks"""
-
+        """Run the inconsistent-with-doi-metadata checks."""
         if Fields.DOI not in record.data or record.ignored_defect(
             key=Fields.DOI, defect=self.msg
         ):
@@ -83,5 +82,5 @@ class InconsistentWithDOIMetadataChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(InconsistentWithDOIMetadataChecker(quality_model))

--- a/colrev/record/qm/checkers/inconsistent_with_entrytype.py
+++ b/colrev/record/qm/checkers/inconsistent_with_entrytype.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class InconsistentWithEntrytypeChecker:
-    """The InconsistentWithEntrytypeChecker"""
+    """The InconsistentWithEntrytypeChecker."""
 
     record_field_inconsistencies: dict[str, list[str]] = {
         "article": [Fields.BOOKTITLE, Fields.ISBN],
@@ -64,8 +64,7 @@ class InconsistentWithEntrytypeChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the completeness checks"""
-
+        """Run the completeness checks."""
         if "ENTRYTYPE" not in record.data:
             return
 
@@ -85,5 +84,5 @@ class InconsistentWithEntrytypeChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(InconsistentWithEntrytypeChecker(quality_model))

--- a/colrev/record/qm/checkers/isbn_not_matching_pattern.py
+++ b/colrev/record/qm/checkers/isbn_not_matching_pattern.py
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class ISBNPatternChecker:
-    """The ISBNPatternChecker"""
+    """The ISBNPatternChecker."""
 
     msg = DefectCodes.ISBN_NOT_MATCHING_PATTERN
 
@@ -31,8 +31,7 @@ class ISBNPatternChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the isbn-not-matching-pattern checks"""
-
+        """Run the isbn-not-matching-pattern checks."""
         if Fields.ISBN not in record.data or record.ignored_defect(
             key=Fields.ISBN, defect=self.msg
         ):
@@ -45,5 +44,5 @@ class ISBNPatternChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(ISBNPatternChecker(quality_model))

--- a/colrev/record/qm/checkers/language_format_error.py
+++ b/colrev/record/qm/checkers/language_format_error.py
@@ -13,7 +13,7 @@ from colrev.constants import Fields
 
 
 class LanguageFormatChecker:
-    """The LanguageFormatChecker"""
+    """The LanguageFormatChecker."""
 
     msg = DefectCodes.LANGUAGE_FORMAT_ERROR
 
@@ -24,8 +24,7 @@ class LanguageFormatChecker:
         self.language_service = colrev.env.language_service.LanguageService()
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the language-format-error checks"""
-
+        """Run the language-format-error checks."""
         if Fields.LANGUAGE not in record.data or record.ignored_defect(
             key=Fields.LANGUAGE, defect=self.msg
         ):
@@ -42,5 +41,5 @@ class LanguageFormatChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(LanguageFormatChecker(quality_model))

--- a/colrev/record/qm/checkers/language_unknown.py
+++ b/colrev/record/qm/checkers/language_unknown.py
@@ -12,7 +12,7 @@ from colrev.constants import FieldValues
 
 
 class LanguageChecker:
-    """The LanguageChecker"""
+    """The LanguageChecker."""
 
     msg = DefectCodes.LANGUAGE_UNKNOWN
 
@@ -22,8 +22,7 @@ class LanguageChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the language-unknown checks"""
-
+        """Run the language-unknown checks."""
         if record.data.get(
             Fields.TITLE, FieldValues.UNKNOWN
         ) == FieldValues.UNKNOWN or record.ignored_defect(
@@ -46,5 +45,5 @@ class LanguageChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(LanguageChecker(quality_model))

--- a/colrev/record/qm/checkers/missing_field.py
+++ b/colrev/record/qm/checkers/missing_field.py
@@ -14,7 +14,7 @@ from colrev.constants import FieldValues
 
 
 class MissingFieldChecker:
-    """The MissingFieldChecker"""
+    """The MissingFieldChecker."""
 
     # book, inbook: author <- editor
 
@@ -26,8 +26,7 @@ class MissingFieldChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the missing-field checks"""
-
+        """Run the missing-field checks."""
         if record.data[Fields.ENTRYTYPE] not in ENTRYTYPE_FIELD_REQUIREMENTS:
             return
 
@@ -81,5 +80,5 @@ class MissingFieldChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(MissingFieldChecker(quality_model))

--- a/colrev/record/qm/checkers/mostly_all_caps.py
+++ b/colrev/record/qm/checkers/mostly_all_caps.py
@@ -13,7 +13,7 @@ from colrev.constants import FieldValues
 
 
 class MostlyAllCapsFieldChecker:
-    """The MostlyAllCapsFieldChecker"""
+    """The MostlyAllCapsFieldChecker."""
 
     msg = DefectCodes.MOSTLY_ALL_CAPS
 
@@ -23,7 +23,7 @@ class MostlyAllCapsFieldChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the mostly-all-caps checks"""
+        """Run the mostly-all-caps checks."""
         for key in [
             Fields.AUTHOR,
             Fields.TITLE,
@@ -49,8 +49,7 @@ class MostlyAllCapsFieldChecker:
     def _is_mostly_all_caps(
         self, *, record: colrev.record.record.Record, key: str
     ) -> bool:
-        """Check if the field is mostly all caps"""
-
+        """Check if the field is mostly all caps."""
         # Online sources/software can be short/have caps
         if (
             record.data.get(Fields.ENTRYTYPE, "") == "online"
@@ -76,5 +75,5 @@ class MostlyAllCapsFieldChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(MostlyAllCapsFieldChecker(quality_model))

--- a/colrev/record/qm/checkers/name_abbreviated.py
+++ b/colrev/record/qm/checkers/name_abbreviated.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class NameAbbreviatedChecker:
-    """The NameAbbreviatedChecker"""
+    """The NameAbbreviatedChecker."""
 
     fields_to_check = [Fields.AUTHOR, Fields.EDITOR]
     abbreviations = ["and others", "et al", "..."]
@@ -24,8 +24,7 @@ class NameAbbreviatedChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the name-abbreviated checks"""
-
+        """Run the name-abbreviated checks."""
         for key in self.fields_to_check:
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -45,5 +44,5 @@ class NameAbbreviatedChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(NameAbbreviatedChecker(quality_model))

--- a/colrev/record/qm/checkers/name_format_separators.py
+++ b/colrev/record/qm/checkers/name_format_separators.py
@@ -15,7 +15,7 @@ from colrev.constants import FieldValues
 
 
 class NameFormatSeparatorsChecker:
-    """The NameFormatSeparatorsChecker"""
+    """The NameFormatSeparatorsChecker."""
 
     msg = DefectCodes.NAME_FORMAT_SEPARTORS
 
@@ -25,7 +25,7 @@ class NameFormatSeparatorsChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the name-format-separators checks"""
+        """Run the name-format-separators checks."""
         for key in [Fields.AUTHOR, Fields.EDITOR]:
             if (
                 key not in record.data
@@ -78,5 +78,5 @@ class NameFormatSeparatorsChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(NameFormatSeparatorsChecker(quality_model))

--- a/colrev/record/qm/checkers/name_format_titles.py
+++ b/colrev/record/qm/checkers/name_format_titles.py
@@ -13,7 +13,7 @@ from colrev.constants import Fields
 
 
 class NameFormatTitleChecker:
-    """The NameFormatTitleChecker"""
+    """The NameFormatTitleChecker."""
 
     fields_to_check = [Fields.AUTHOR, Fields.EDITOR]
     titles = ["Dr", "PhD", "Prof", "Dipl Ing"]
@@ -27,8 +27,7 @@ class NameFormatTitleChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the name-format-titles checks"""
-
+        """Run the name-format-titles checks."""
         for key in self.fields_to_check:
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -48,5 +47,5 @@ class NameFormatTitleChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(NameFormatTitleChecker(quality_model))

--- a/colrev/record/qm/checkers/name_particles.py
+++ b/colrev/record/qm/checkers/name_particles.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class NameParticlesChecker:
-    """The NameParticlesChecker"""
+    """The NameParticlesChecker."""
 
     fields_to_check = [Fields.AUTHOR, Fields.EDITOR]
 
@@ -23,8 +23,7 @@ class NameParticlesChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the name-particles checks"""
-
+        """Run the name-particles checks."""
         for key in self.fields_to_check:
             if key not in record.data or record.ignored_defect(
                 key=key, defect=self.msg
@@ -50,5 +49,5 @@ class NameParticlesChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(NameParticlesChecker(quality_model))

--- a/colrev/record/qm/checkers/page_range.py
+++ b/colrev/record/qm/checkers/page_range.py
@@ -13,7 +13,7 @@ from colrev.constants import Fields
 
 
 class PageRangeChecker:
-    """The PageRangeChecker"""
+    """The PageRangeChecker."""
 
     msg = DefectCodes.PAGE_RANGE
 
@@ -23,8 +23,7 @@ class PageRangeChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the page-range checks"""
-
+        """Run the page-range checks."""
         if (
             Fields.PAGES not in record.data
             or record.ignored_defect(key=Fields.PAGES, defect=self.msg)
@@ -48,5 +47,5 @@ class PageRangeChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(PageRangeChecker(quality_model))

--- a/colrev/record/qm/checkers/pubmedid_not_matching_pattern.py
+++ b/colrev/record/qm/checkers/pubmedid_not_matching_pattern.py
@@ -13,7 +13,7 @@ from colrev.constants import Fields
 
 
 class PubmedIDPatternChecker:
-    """The PubmedIDPatternChecker"""
+    """The PubmedIDPatternChecker."""
 
     msg = DefectCodes.PUBMED_ID_NOT_MATCHING_PATTERN
 
@@ -25,8 +25,7 @@ class PubmedIDPatternChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the pubmedid-not-matching-pattern checks"""
-
+        """Run the pubmedid-not-matching-pattern checks."""
         if Fields.PUBMED_ID not in record.data or record.ignored_defect(
             key=Fields.PUBMED_ID, defect=self.msg
         ):
@@ -39,5 +38,5 @@ class PubmedIDPatternChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(PubmedIDPatternChecker(quality_model))

--- a/colrev/record/qm/checkers/record_not_in_toc.py
+++ b/colrev/record/qm/checkers/record_not_in_toc.py
@@ -14,7 +14,7 @@ from colrev.constants import Fields
 
 
 class RecordNotInTOCChecker:
-    """The RecordNotInTOCChecker"""
+    """The RecordNotInTOCChecker."""
 
     msg = DefectCodes.RECORD_NOT_IN_TOC
 
@@ -25,8 +25,7 @@ class RecordNotInTOCChecker:
         self.local_index = colrev.env.local_index.LocalIndex(verbose_mode=False)
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the record-not-in-toc checks"""
-
+        """Run the record-not-in-toc checks."""
         if record.data[Fields.ENTRYTYPE] == ENTRYTYPES.ARTICLE:
             if record.ignored_defect(key=Fields.JOURNAL, defect=self.msg):
                 return
@@ -66,5 +65,5 @@ class RecordNotInTOCChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(RecordNotInTOCChecker(quality_model))

--- a/colrev/record/qm/checkers/thesis_with_multiple_authors.py
+++ b/colrev/record/qm/checkers/thesis_with_multiple_authors.py
@@ -11,7 +11,7 @@ from colrev.constants import Fields
 
 
 class ThesisWithMultipleAuthorsChecker:
-    """The ThesisWithMultipleAuthorsChecker"""
+    """The ThesisWithMultipleAuthorsChecker."""
 
     msg = DefectCodes.THESIS_WITH_MULTIPLE_AUTHORS
 
@@ -21,8 +21,7 @@ class ThesisWithMultipleAuthorsChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the thesis-with-multiple-authors checks"""
-
+        """Run the thesis-with-multiple-authors checks."""
         if record.ignored_defect(key=Fields.AUTHOR, defect=self.msg):
             return
 
@@ -44,5 +43,5 @@ class ThesisWithMultipleAuthorsChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(ThesisWithMultipleAuthorsChecker(quality_model))

--- a/colrev/record/qm/checkers/year_format.py
+++ b/colrev/record/qm/checkers/year_format.py
@@ -14,7 +14,7 @@ from colrev.constants import FieldValues
 
 
 class YearFormatChecker:
-    """The YearFormatChecker"""
+    """The YearFormatChecker."""
 
     msg = DefectCodes.YEAR_FORMAT
 
@@ -24,8 +24,7 @@ class YearFormatChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the year-format checks"""
-
+        """Run the year-format checks."""
         if (
             Fields.YEAR not in record.data
             or record.ignored_defect(key=Fields.YEAR, defect=self.msg)
@@ -43,5 +42,5 @@ class YearFormatChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(YearFormatChecker(quality_model))

--- a/colrev/record/qm/pdf_checkers/author_not_in_pdf.py
+++ b/colrev/record/qm/pdf_checkers/author_not_in_pdf.py
@@ -17,7 +17,7 @@ from colrev.constants import PDFDefectCodes
 
 
 class AuthorNotInPDFChecker:
-    """The AuthorNotInPDFChecker"""
+    """The AuthorNotInPDFChecker."""
 
     msg = PDFDefectCodes.AUTHOR_NOT_IN_PDF
 
@@ -27,8 +27,7 @@ class AuthorNotInPDFChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the author-not-in-pdf checks"""
-
+        """Run the author-not-in-pdf checks."""
         if (
             Fields.FILE not in record.data
             or Path(record.data[Fields.FILE]).suffix != ".pdf"
@@ -75,5 +74,5 @@ class AuthorNotInPDFChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(AuthorNotInPDFChecker(quality_model))

--- a/colrev/record/qm/pdf_checkers/no_text_in_pdf.py
+++ b/colrev/record/qm/pdf_checkers/no_text_in_pdf.py
@@ -14,7 +14,7 @@ from colrev.constants import PDFDefectCodes
 
 
 class TextInPDFChecker:
-    """The TextInPDFChecker"""
+    """The TextInPDFChecker."""
 
     msg = PDFDefectCodes.NO_TEXT_IN_PDF
 
@@ -24,8 +24,7 @@ class TextInPDFChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the no-text-in-pdf checks"""
-
+        """Run the no-text-in-pdf checks."""
         if (
             Fields.FILE not in record.data
             or Path(record.data[Fields.FILE]).suffix != ".pdf"
@@ -50,5 +49,5 @@ class TextInPDFChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(TextInPDFChecker(quality_model))

--- a/colrev/record/qm/pdf_checkers/pdf_incomplete.py
+++ b/colrev/record/qm/pdf_checkers/pdf_incomplete.py
@@ -27,7 +27,7 @@ ROMAN_PAGE_PATTERN = re.compile(
 
 
 class PDFIncompletenessChecker:
-    """The PDFIncompletenessChecker"""
+    """The PDFIncompletenessChecker."""
 
     msg = PDFDefectCodes.PDF_INCOMPLETE
 
@@ -37,8 +37,7 @@ class PDFIncompletenessChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record_pdf.PDFRecord) -> None:
-        """Run the pdf-incomplete checks"""
-
+        """Run the pdf-incomplete checks."""
         if (
             Fields.FILE not in record.data
             or Path(record.data[Fields.FILE]).suffix != ".pdf"
@@ -150,5 +149,5 @@ class PDFIncompletenessChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(PDFIncompletenessChecker(quality_model))

--- a/colrev/record/qm/pdf_checkers/title_not_in_pdf.py
+++ b/colrev/record/qm/pdf_checkers/title_not_in_pdf.py
@@ -17,7 +17,7 @@ from colrev.constants import PDFDefectCodes
 
 
 class TitleNotInPDFChecker:
-    """The TitleNotInPDFChecker"""
+    """The TitleNotInPDFChecker."""
 
     msg = PDFDefectCodes.TITLE_NOT_IN_PDF
 
@@ -27,8 +27,7 @@ class TitleNotInPDFChecker:
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the title-not-in-pdf checks"""
-
+        """Run the title-not-in-pdf checks."""
         if (
             Fields.FILE not in record.data
             or Path(record.data[Fields.FILE]).suffix != ".pdf"
@@ -65,5 +64,5 @@ class TitleNotInPDFChecker:
 
 
 def register(quality_model: colrev.record.qm.quality_model.QualityModel) -> None:
-    """Register the checker"""
+    """Register the checker."""
     quality_model.register_checker(TitleNotInPDFChecker(quality_model))

--- a/colrev/record/qm/quality_model.py
+++ b/colrev/record/qm/quality_model.py
@@ -14,7 +14,7 @@ from colrev.constants import Fields
 
 
 class QualityModel:
-    """The quality model for records"""
+    """The quality model for records."""
 
     checkers = []  # type: ignore
 
@@ -35,7 +35,6 @@ class QualityModel:
         """Register checkers from the checker directory, looking for a
         'register' function in each one.
         """
-
         self.checkers = []
         if self.pdf_mode:
             module_path = "colrev.record.qm.pdf_checkers."
@@ -64,12 +63,11 @@ class QualityModel:
                     print(f"Module {filename} does not have a register function")
 
     def register_checker(self, checker) -> None:  # type: ignore
-        """Register a checker"""
+        """Register a checker."""
         self.checkers.append(checker)
 
     def run(self, *, record: colrev.record.record.Record) -> None:
-        """Run the checkers"""
-
+        """Run the checkers."""
         if self.pdf_mode:
             if not self.path:
                 raise ValueError("Path is required for PDF mode")

--- a/colrev/record/record.py
+++ b/colrev/record/record.py
@@ -32,7 +32,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 class Record:
-    """The Record class provides a range of basic Function"""
+    """The Record class provides a range of basic Function."""
 
     pp = pprint.PrettyPrinter(indent=4, width=140, compact=False)
 
@@ -59,7 +59,7 @@ class Record:
         return self.__dict__ == other.__dict__
 
     def get_citation_format(self) -> str:
-        """Get the record as a citation"""
+        """Get the record as a citation."""
         formatted_ref = (
             f"{self.data.get(Fields.AUTHOR, '')} ({self.data.get(Fields.YEAR, '')}) "
             f"{self.data.get(Fields.TITLE, '')}. "
@@ -69,23 +69,23 @@ class Record:
         return formatted_ref
 
     def print_citation_format(self) -> None:
-        """Print the record as a citation"""
+        """Print the record as a citation."""
         print(self.get_citation_format())
 
     def copy(self) -> Record:
-        """Copy the record object"""
+        """Copy the record object."""
         return Record(deepcopy(self.data))
 
     def copy_prep_rec(self) -> colrev.record.record_prep.PrepRecord:
-        """Copy the record object (as a PrepRecord)"""
+        """Copy the record object (as a PrepRecord)."""
         return colrev.record.record_prep.PrepRecord(deepcopy(self.data))
 
     def update_by_record(self, update_record: Record) -> None:
-        """Update all data of a record object based on another record"""
+        """Update all data of a record object based on another record."""
         self.data = update_record.copy_prep_rec().get_data()
 
     def format_bib_style(self) -> str:
-        """Simple formatter for bibliography-style output"""
+        """Simple formatter for bibliography-style output."""
         return (
             f"{self.data.get(Fields.AUTHOR, '')} "
             f"({self.data.get(Fields.YEAR, '')}) "
@@ -97,8 +97,7 @@ class Record:
         )
 
     def get_data(self) -> dict:
-        """Get the record data"""
-
+        """Get the record data."""
         if not isinstance(self.data.get(Fields.ORIGIN, []), list):
             self.data[Fields.ORIGIN] = self.data[Fields.ORIGIN].rstrip(";").split(";")
         assert isinstance(self.data.get(Fields.ORIGIN, []), list)
@@ -106,7 +105,7 @@ class Record:
         return self.data
 
     def get_value(self, key: str, *, default: typing.Optional[str] = None) -> str:
-        """Get a record value (based on the key parameter)"""
+        """Get a record value (based on the key parameter)."""
         if default is not None:
             try:
                 ret = self.data[key]
@@ -127,7 +126,7 @@ class Record:
         keep_source_if_equal: bool = True,
         append_edit: bool = True,
     ) -> None:
-        """Update a record field (including provenance information)"""
+        """Update a record field (including provenance information)."""
         if keep_source_if_equal:
             if key in self.data:
                 if self.data[key] == value:
@@ -151,7 +150,7 @@ class Record:
         self.data[key] = value
 
     def rename_field(self, *, key: str, new_key: str) -> None:
-        """Rename a field"""
+        """Rename a field."""
         if key not in self.data:
             return
         value = self.data[key]
@@ -183,8 +182,7 @@ class Record:
     def remove_field(
         self, *, key: str, not_missing_note: bool = False, source: str = ""
     ) -> None:
-        """Remove a field"""
-
+        """Remove a field."""
         if key in self.data:
             del self.data[key]
 
@@ -205,14 +203,14 @@ class Record:
                 del self.data[Fields.D_PROV][key]
 
     def require_prov(self) -> None:
-        """Ensure that provenance fields are available"""
+        """Ensure that provenance fields are available."""
         if Fields.MD_PROV not in self.data:
             self.data[Fields.MD_PROV] = {}
         if Fields.D_PROV not in self.data:
             self.data[Fields.D_PROV] = {}
 
     def align_provenance(self) -> None:
-        """Remove unnecessary provenance information and add missing provenance information"""
+        """Remove unnecessary provenance information and add missing provenance information."""
         self.require_prov()
         for key in list(self.data[Fields.MD_PROV].keys()):
             if (
@@ -245,7 +243,7 @@ class Record:
                 self.data[Fields.D_PROV][key] = {"source": "manual", "note": ""}
 
     def add_provenance_all(self, *, source: str) -> None:
-        """Add a data provenance (source) to all fields"""
+        """Add a data provenance (source) to all fields."""
         self.require_prov()
         for key in self.data.keys():
             if key in FieldSet.NO_PROVENANCE:
@@ -258,8 +256,7 @@ class Record:
                 self.data[Fields.D_PROV][key] = {"source": source, "note": ""}
 
     def add_field_provenance(self, *, key: str, source: str, note: str = "") -> None:
-        """Add a field provenance, including source and note (based on a key)"""
-
+        """Add a field provenance, including source and note (based on a key)."""
         if key in FieldSet.NO_PROVENANCE:
             return
         self.require_prov()
@@ -290,7 +287,7 @@ class Record:
             prov_dict[key]["note"] += f",{note}"
 
     def add_field_provenance_note(self, *, key: str, note: str) -> None:
-        """Add a field provenance note (based on a key)"""
+        """Add a field provenance note (based on a key)."""
         if key in FieldSet.NO_PROVENANCE:
             return
         self.require_prov()
@@ -315,7 +312,7 @@ class Record:
     def get_field_provenance(
         self, *, key: str, default_source: str = "ORIGINAL"
     ) -> dict:
-        """Get the provenance for a selected field (key)"""
+        """Get the provenance for a selected field (key)."""
         default_note = ""
         note = default_note
         source = default_source
@@ -335,7 +332,7 @@ class Record:
         return {"source": source, "note": note}
 
     def get_field_provenance_notes(self, key: str) -> list:
-        """Get field provenance notes based on a key"""
+        """Get field provenance notes based on a key."""
         if key in FieldSet.MASTERDATA:
             if Fields.MD_PROV not in self.data:
                 return []
@@ -351,11 +348,11 @@ class Record:
         return [note.strip() for note in notes if note]
 
     def get_field_provenance_source(self, key: str) -> str:
-        """Get the provenance source for a selected field (key)"""
+        """Get the provenance source for a selected field (key)."""
         return self.get_field_provenance(key=key)["source"]
 
     def remove_field_provenance_note(self, *, key: str, note: str) -> None:
-        """Remove field provenance notes based on a key (also if IGNORE:note)"""
+        """Remove field provenance notes based on a key (also if IGNORE:note)."""
         if key in FieldSet.MASTERDATA:
             if Fields.MD_PROV not in self.data:
                 return
@@ -381,8 +378,7 @@ class Record:
             )
 
     def complete_provenance(self, *, source_info: str) -> bool:
-        """Complete provenance information for indexing"""
-
+        """Complete provenance information for indexing."""
         for key in list(self.data.keys()):
             if key in FieldSet.NO_PROVENANCE:
                 continue
@@ -398,7 +394,7 @@ class Record:
     def set_masterdata_complete(
         self, *, source: str, masterdata_repository: bool, replace_source: bool = True
     ) -> None:
-        """Set the masterdata to complete"""
+        """Set the masterdata to complete."""
         # pylint: disable=too-many-branches
         if self.masterdata_is_curated() or masterdata_repository:
             return
@@ -449,7 +445,7 @@ class Record:
                     }
 
     def set_masterdata_consistent(self) -> None:
-        """Set the masterdata to consistent"""
+        """Set the masterdata to consistent."""
         self.require_prov()
         md_p_dict = self.data[Fields.MD_PROV]
 
@@ -462,7 +458,7 @@ class Record:
                     )
 
     def reset_pdf_provenance_notes(self) -> None:
-        """Reset the PDF (file) provenance notes"""
+        """Reset the PDF (file) provenance notes."""
         if Fields.D_PROV not in self.data:
             self.add_field_provenance_note(key=Fields.FILE, note="")
         else:
@@ -475,7 +471,7 @@ class Record:
                 }
 
     def defects(self, key: str) -> typing.List[str]:
-        """Get a list of defects for a field"""
+        """Get a list of defects for a field."""
         self.require_prov()
         defects = []
         if key in self.data[Fields.MD_PROV]:
@@ -485,7 +481,7 @@ class Record:
         return defects
 
     def has_quality_defects(self, *, key: str = "") -> bool:
-        """Check whether a record (or specific field/key) has quality defects"""
+        """Check whether a record (or specific field/key) has quality defects."""
         if key != "":
             if key in self.data.get(Fields.MD_PROV, {}):
                 note = self.data[Fields.MD_PROV][key]["note"]
@@ -507,8 +503,7 @@ class Record:
         return bool(defect_codes)
 
     def has_fatal_quality_defects(self) -> bool:
-        """Check whether a record has fatal quality defects"""
-
+        """Check whether a record has fatal quality defects."""
         required_fields = [Fields.TITLE, Fields.AUTHOR, Fields.YEAR]
         if not all(r in self.data for r in required_fields) or not all(
             self.data[r] != FieldValues.UNKNOWN for r in required_fields
@@ -545,8 +540,7 @@ class Record:
         return False
 
     def has_pdf_defects(self) -> bool:
-        """Check whether the PDF has quality defects"""
-
+        """Check whether the PDF has quality defects."""
         return bool(
             [
                 n
@@ -556,14 +550,13 @@ class Record:
         )
 
     def ignore_defect(self, *, key: str, defect: str) -> None:
-        """Ignore a defect for a field"""
-
+        """Ignore a defect for a field."""
         ignore_code = f"IGNORE:{defect}"
         self.remove_field_provenance_note(key=key, note=defect)
         self.add_field_provenance_note(key=key, note=ignore_code)
 
     def ignored_defect(self, *, key: str, defect: str) -> bool:
-        """Get a list of ignored defects for a record"""
+        """Get a list of ignored defects for a record."""
         ignore_code = f"IGNORE:{defect}"
         if Fields.MD_PROV in self.data and key in self.data[Fields.MD_PROV]:
             notes = self.data[Fields.MD_PROV][key]["note"].split(",")
@@ -575,8 +568,7 @@ class Record:
 
     # pylint: disable=too-many-return-statements
     def get_container_title(self, *, na_string: str = "NA") -> str:
-        """Get the record's container title (journal name, booktitle, etc.)"""
-
+        """Get the record's container title (journal name, booktitle, etc.)."""
         if Fields.ENTRYTYPE not in self.data:
             return self.data.get(
                 Fields.JOURNAL, self.data.get(Fields.BOOKTITLE, na_string)
@@ -599,13 +591,13 @@ class Record:
         return na_string
 
     def set_masterdata_curated(self, source: str) -> None:
-        """Set record masterdata to curated"""
+        """Set record masterdata to curated."""
         self.data[Fields.MD_PROV] = {
             FieldValues.CURATED: {"source": source, "note": ""}
         }
 
     def masterdata_is_curated(self) -> bool:
-        """Check whether the record masterdata is curated"""
+        """Check whether the record masterdata is curated."""
         return FieldValues.CURATED in self.data.get(Fields.MD_PROV, {})
 
     def get_colrev_id(
@@ -614,7 +606,6 @@ class Record:
         assume_complete: bool = False,
     ) -> str:
         """Returns the colrev_id of the Record."""
-
         return colrev.record.record_identifier.get_colrev_id(
             self,
             assume_complete=assume_complete,
@@ -625,16 +616,15 @@ class Record:
         cls,
         pdf_path: Path,
     ) -> str:  # pragma: no cover
-        """Generate the colrev_pdf_id"""
-
+        """Generate the colrev_pdf_id."""
         return colrev.record.record_identifier.get_colrev_pdf_id(pdf_path)
 
     def get_toc_key(self) -> str:
-        """Get the record's toc-key"""
+        """Get the record's toc-key."""
         return colrev.record.record_identifier.get_toc_key(self)
 
     def prescreen_exclude(self, *, reason: str, print_warning: bool = False) -> None:
-        """Prescreen-exclude a record"""
+        """Prescreen-exclude a record."""
         # Warn when setting rev_synthesized/rev_included to prescreen_excluded
         # Especially in cases in which the prescreen-exclusion decision
         # is revised (e.g., because a paper was retracted)
@@ -673,7 +663,7 @@ class Record:
             self.remove_field(key=key)
 
     def get_tei_filename(self) -> Path:
-        """Get the TEI filename associated with the file (PDF)"""
+        """Get the TEI filename associated with the file (PDF)."""
         tei_filename = Path(f".tei/{self.data[Fields.ID]}.tei.xml")
         if Fields.FILE in self.data:
             tei_filename = Path(
@@ -687,8 +677,7 @@ class Record:
         *,
         set_prepared: bool = False,
     ) -> None:
-        """Run the PDF quality model"""
-
+        """Run the PDF quality model."""
         pdf_qm.run(record=self)
         if self.has_pdf_defects():
             self.set_status(RecordState.pdf_needs_manual_preparation)
@@ -701,8 +690,7 @@ class Record:
         *,
         set_prepared: bool = False,
     ) -> None:
-        """Update the masterdata provenance"""
-
+        """Update the masterdata provenance."""
         self.require_prov()
         self.is_retracted()
 
@@ -727,8 +715,7 @@ class Record:
             self.set_status(RecordState.md_prepared)
 
     def is_retracted(self) -> bool:
-        """Check for potential retracts"""
-
+        """Check for potential retracts."""
         # Legacy
         if (
             self.data.get("crossmark", "") == "True"
@@ -752,7 +739,7 @@ class Record:
         self,
         new_entrytype: str,
     ) -> None:
-        """Change the ENTRYTYPE"""
+        """Change the ENTRYTYPE."""
         if new_entrytype == self.data.get(Fields.ENTRYTYPE, "NA"):
             if Fields.MD_PROV in self.data:
                 self.align_provenance()
@@ -821,8 +808,7 @@ class Record:
                     self.data[Fields.MD_PROV][req_field]["note"] = DefectCodes.MISSING
 
     def set_status(self, target_state: RecordState, *, force: bool = False) -> None:
-        """Set the record status"""
-
+        """Set the record status."""
         if RecordState.md_prepared == target_state and not force:
             if self.has_fatal_quality_defects():
                 target_state = RecordState.md_needs_manual_preparation
@@ -832,8 +818,7 @@ class Record:
     def get_diff(
         self, other_record: Record, *, identifying_fields_only: bool = True
     ) -> list:
-        """Get diff between record objects"""
-
+        """Get diff between record objects."""
         if not identifying_fields_only:
             return list(dictdiffer.diff(self.get_data(), other_record.get_data()))
 
@@ -862,21 +847,20 @@ class Record:
 
     @classmethod
     def get_record_change_score(cls, record_a: Record, record_b: Record) -> float:
-        """Determine how much records changed
+        """Determine how much records changed.
 
         This method is less sensitive than get_record_similarity, especially when
         fields are missing. For example, if the journal field is missing in both
         records, get_similarity will return a value > 1.0. The get_record_changes
-        will return 0.0 (if all other fields are equal)."""
-
+        will return 0.0 (if all other fields are equal).
+        """
         return colrev.record.record_similarity.get_record_change_score(
             record_a, record_b
         )
 
     @classmethod
     def get_record_similarity(cls, record_a: Record, record_b: Record) -> float:
-        """Determine the similarity between two records (their masterdata)"""
-
+        """Determine the similarity between two records (their masterdata)."""
         return colrev.record.record_similarity.get_record_similarity(record_a, record_b)
 
     def merge(
@@ -887,11 +871,11 @@ class Record:
         preferred_masterdata_source_prefixes: typing.Optional[list] = None,
     ) -> None:
         """General-purpose record merging
-        for preparation, curated/non-curated records and records with origins
+        for preparation, curated/non-curated records and records with origins.
 
         Apply heuristics to create a fusion of the best fields based on
-        quality heuristics"""
-
+        quality heuristics
+        """
         if preferred_masterdata_source_prefixes is None:
             preferred_masterdata_source_prefixes = []
 

--- a/colrev/record/record_id_setter.py
+++ b/colrev/record/record_id_setter.py
@@ -25,7 +25,7 @@ import colrev.record.record_prep
 
 
 class IDSetter:
-    """The IDSetter class"""
+    """The IDSetter class."""
 
     def __init__(
         self,
@@ -93,8 +93,7 @@ class IDSetter:
         *,
         existing_ids: list,
     ) -> str:
-        """Get the next unique ID"""
-
+        """Get the next unique ID."""
         order = 0
         letters = list(string.ascii_lowercase)
         next_unique_id = temp_id
@@ -113,8 +112,7 @@ class IDSetter:
         *,
         existing_ids: typing.Optional[list] = None,
     ) -> str:
-        """Generate a blacklist to avoid setting duplicate IDs"""
-
+        """Generate a blacklist to avoid setting duplicate IDs."""
         if self.skip_local_index:
             temp_id = self._generate_id_from_pattern(record_dict)
         else:
@@ -138,8 +136,7 @@ class IDSetter:
     def set_ids(
         self, records: dict, *, selected_ids: typing.Optional[list] = None
     ) -> dict:
-        """Set the IDs for the records in the dataset"""
-
+        """Set the IDs for the records in the dataset."""
         id_list = list(records.keys())
 
         for record_id in tqdm(list(records.keys())):

--- a/colrev/record/record_identifier.py
+++ b/colrev/record/record_identifier.py
@@ -176,8 +176,7 @@ def _get_colrev_id_from_record(record: colrev.record.record.Record) -> str:
 
 
 def get_colrev_id(record: colrev.record.record.Record, *, assume_complete: bool) -> str:
-    """Create the colrev_id"""
-
+    """Create the colrev_id."""
     _check_colrev_id_preconditions(
         record,
         assume_complete=assume_complete,
@@ -219,8 +218,7 @@ def _get_colrev_pdf_id_cpid2(pdf_path: Path) -> str:
 
 
 def get_colrev_pdf_id(pdf_path: Path, *, cpid_version: str = "cpid2") -> str:
-    """Get the PDF hash"""
-
+    """Get the PDF hash."""
     pdf_path = pdf_path.resolve()
     try:
         file_size = os.path.getsize(pdf_path)
@@ -237,8 +235,7 @@ def get_colrev_pdf_id(pdf_path: Path, *, cpid_version: str = "cpid2") -> str:
 
 
 def get_toc_key(record: colrev.record.record.Record) -> str:
-    """Get the record's toc-key"""
-
+    """Get the record's toc-key."""
     try:
         if record.data[Fields.ENTRYTYPE] == ENTRYTYPES.ARTICLE:
             toc_key = (

--- a/colrev/record/record_merger.py
+++ b/colrev/record/record_merger.py
@@ -45,7 +45,7 @@ def _merge_origins(
     main_record: colrev.record.record.Record,
     merging_record: colrev.record.record.Record,
 ) -> None:
-    """Merge the origins with those of the merging_record"""
+    """Merge the origins with those of the merging_record."""
     if Fields.ORIGIN in merging_record.data:
         origins = main_record.data[Fields.ORIGIN] + merging_record.data[Fields.ORIGIN]
         main_record.data[Fields.ORIGIN] = sorted(list(set(origins)))
@@ -55,7 +55,7 @@ def _merge_status(
     main_record: colrev.record.record.Record,
     merging_record: colrev.record.record.Record,
 ) -> None:
-    """Merge the status with the merging_record"""
+    """Merge the status with the merging_record."""
     if Fields.STATUS in merging_record.data:
         # Set both status to the latter in the state model
         if main_record.data[Fields.STATUS] < merging_record.data[Fields.STATUS]:
@@ -187,7 +187,7 @@ def fuse_fields(
     key: str,
     default_source: str,
 ) -> None:
-    """Fuse fields based on quality heuristics"""
+    """Fuse fields based on quality heuristics."""
     # Note : the assumption is that we need masterdata_provenance notes
     # only for authors
 
@@ -327,12 +327,11 @@ def merge(
     preferred_masterdata_source_prefixes: list,
 ) -> None:
     """General-purpose record merging
-    for preparation, curated/non-curated records and records with origins
+    for preparation, curated/non-curated records and records with origins.
 
     Apply heuristics to create a fusion of the best fields based on
     quality heuristics
     """
-
     merging_record_preferred = _merging_record_preferred(
         merging_record,
         preferred_masterdata_source_prefixes=preferred_masterdata_source_prefixes,

--- a/colrev/record/record_pdf.py
+++ b/colrev/record/record_pdf.py
@@ -22,7 +22,7 @@ from colrev.constants import Fields
 
 
 class PDFRecord(colrev.record.record.Record):
-    """The PDFRecord class provides a range of Function for PDF handling"""
+    """The PDFRecord class provides a range of Function for PDF handling."""
 
     def __init__(self, data: dict, *, path: Path) -> None:
         self.data = data
@@ -81,7 +81,7 @@ class PDFRecord(colrev.record.record.Record):
         *,
         pages: typing.Optional[list] = None,
     ) -> str:
-        """Extract the text from the PDF for a given number of pages"""
+        """Extract the text from the PDF for a given number of pages."""
         pdf_path = self._get_path()
         text_list: list = []
         with pymupdf.open(pdf_path) as doc:
@@ -94,7 +94,7 @@ class PDFRecord(colrev.record.record.Record):
         return self._fix_text_encoding_issues(text_all)
 
     def set_nr_pages_in_pdf(self) -> None:
-        """Set the pages_in_file field based on the PDF"""
+        """Set the pages_in_file field based on the PDF."""
         pdf_path = self._get_path()
 
         with pymupdf.open(pdf_path) as doc:
@@ -102,7 +102,7 @@ class PDFRecord(colrev.record.record.Record):
         self.data[Fields.NR_PAGES_IN_FILE] = pages_in_file
 
     def set_text_from_pdf(self, *, first_pages: bool = False) -> None:
-        """Set the text_from_pdf field based on the PDF"""
+        """Set the text_from_pdf field based on the PDF."""
         self.data[Fields.TEXT_FROM_PDF] = ""
         self.set_nr_pages_in_pdf()
 
@@ -123,7 +123,7 @@ class PDFRecord(colrev.record.record.Record):
         pdf_path: Path,
         save_to_path: typing.Optional[Path] = None,
     ) -> None:  # pragma: no cover
-        """Extract pages from the PDF"""
+        """Extract pages from the PDF."""
         doc = pymupdf.Document(pdf_path)
         all_pages_list = list(range(doc.page_count))
 
@@ -151,14 +151,14 @@ class PDFRecord(colrev.record.record.Record):
         pages: list,
         save_to_path: typing.Optional[Path] = None,
     ) -> None:  # pragma: no cover
-        """Extract pages from the PDF"""
+        """Extract pages from the PDF."""
         pdf_path = self._get_path()
         self.extract_pages_from_pdf(
             pages=pages, pdf_path=pdf_path, save_to_path=save_to_path
         )
 
     def get_pdf_hash(self, *, page_nr: int, hash_size: int = 32) -> str:
-        """Get the PDF image hash"""
+        """Get the PDF image hash."""
         assert page_nr > 0
         assert hash_size in [16, 32]
 

--- a/colrev/record/record_prep.py
+++ b/colrev/record/record_prep.py
@@ -19,8 +19,7 @@ ALL_CAPS_DICT = {r"U\.S\.": "U.S."}
 
 
 def capitalize_entities(input_str: str) -> str:
-    """Utility function to capitalize entities"""
-
+    """Utility function to capitalize entities."""
     for all_cap in ALL_CAPS:
         input_str = re.sub(
             rf"\b{all_cap.lower()}\b", all_cap.upper(), input_str, flags=re.IGNORECASE
@@ -47,11 +46,11 @@ def capitalize_entities(input_str: str) -> str:
 
 
 class PrepRecord(colrev.record.record.Record):
-    """The PrepRecord class provides a range of Function for record preparation"""
+    """The PrepRecord class provides a range of Function for record preparation."""
 
     @classmethod
     def format_author_field(cls, input_string: str) -> str:
-        """Format the author field (recognizing first/last names based on HumanName parser)"""
+        """Format the author field (recognizing first/last names based on HumanName parser)."""
 
         def mostly_upper_case(input_string: str) -> bool:
             input_string = input_string.replace(".", "").replace(",", "")
@@ -113,8 +112,7 @@ class PrepRecord(colrev.record.record.Record):
         return author_string
 
     def format_if_mostly_upper(self, key: str, *, case: str = "sentence") -> None:
-        """Format the field if it is mostly in upper case"""
-
+        """Format the field if it is mostly in upper case."""
         if key not in self.data or self.data[key] == FieldValues.UNKNOWN:
             return
 
@@ -137,7 +135,7 @@ class PrepRecord(colrev.record.record.Record):
         self.data[key] = capitalize_entities(self.data[key])
 
     def unify_pages_field(self) -> None:
-        """Unify the format of the page field"""
+        """Unify the format of the page field."""
         if Fields.PAGES not in self.data:
             return
         if not isinstance(self.data[Fields.PAGES], str):

--- a/colrev/record/record_similarity.py
+++ b/colrev/record/record_similarity.py
@@ -41,7 +41,7 @@ def _record_str(record: colrev.record.record.Record) -> str:
 def get_record_change_score(
     record_a: colrev.record.record.Record, record_b: colrev.record.record.Record
 ) -> float:
-    """Determine how much records changed"""
+    """Determine how much records changed."""
     # At some point, this may become more sensitive to major changes
     str_a = _record_str(record_a)
     str_b = _record_str(record_b)
@@ -49,7 +49,7 @@ def get_record_change_score(
 
 
 def container_is_abbreviated(record: colrev.record.record.Record) -> bool:
-    """Check whether the container title is abbreviated"""
+    """Check whether the container title is abbreviated."""
     if Fields.CONTAINER_TITLE in record.data:
         if record.data[Fields.CONTAINER_TITLE].count(".") > 2:
             return True
@@ -112,7 +112,7 @@ def _abbreviate_container_title(
 
 
 def _get_similarity_detailed(record_a: dict, record_b: dict) -> float:
-    """Determine the detailed similarities between records"""
+    """Determine the detailed similarities between records."""
     author_similarity = (
         fuzz.ratio(record_a.get(Fields.AUTHOR, ""), record_b.get(Fields.AUTHOR, ""))
         / 100

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Review Manager
+"""Review Manager.
 
 This module provides the core `ReviewManager` class, which acts as the central interface
 for managing a CoLRev project repository. It encapsulates configuration, logging,
@@ -9,7 +9,8 @@ Key responsibilities of the `ReviewManager` include:
 
 - Initializing and validating the project repository
 - Loading, saving, and validating project settings
-- Providing access to the dataset (`colrev.dataset.Dataset`)"""
+- Providing access to the dataset (`colrev.dataset.Dataset`)
+"""
 
 from __future__ import annotations
 
@@ -35,7 +36,7 @@ from colrev.paths import PathManager
 
 
 class ReviewManager:
-    """Class for managing individual CoLRev review project (repositories)"""
+    """Class for managing individual CoLRev review project (repositories)."""
 
     # pylint: disable=import-outside-toplevel
     # pylint: disable=redefined-outer-name
@@ -123,7 +124,7 @@ class ReviewManager:
         high_level_operation: bool = False,
         exact_call: str = "",
     ) -> None:
-        """Update review_manager's state"""
+        """Update review_manager's state."""
         self.force_mode = force_mode
         self.verbose_mode = verbose_mode
         self.high_level_operation = high_level_operation
@@ -153,12 +154,12 @@ class ReviewManager:
         upgrade_operation.main()
 
     def load_settings(self) -> colrev.settings.Settings:
-        """Load the settings"""
+        """Load the settings."""
         self.settings = colrev.settings.load_settings(settings_path=self.paths.settings)
         return self.settings
 
     def save_settings(self) -> None:
-        """Save the settings"""
+        """Save the settings."""
         colrev.settings.save_settings(review_manager=self)
 
     # pylint: disable=too-many-arguments
@@ -172,7 +173,7 @@ class ReviewManager:
         skip_status_yaml: bool = False,
         skip_hooks: bool = True,
     ) -> bool:
-        """Create a commit in the git repository"""
+        """Create a commit in the git repository."""
         return self.dataset.git_repo.create_commit(
             msg=msg,
             review_manager=self,
@@ -184,8 +185,7 @@ class ReviewManager:
         )
 
     def reset_report_logger(self) -> None:
-        """Reset the report logger"""
-
+        """Reset the report logger."""
         # Stop and remove the report log file
         if self.report_logger.handlers:
             report_handler = self.report_logger.handlers[0]
@@ -200,29 +200,28 @@ class ReviewManager:
         self.report_logger.addHandler(file_handler)
 
     def check_repo(self) -> dict:
-        """Check the repository"""
+        """Check the repository."""
         checker = colrev.ops.checker.Checker(review_manager=self)
         return checker.check_repo()
 
     def in_virtualenv(self) -> bool:  # pragma: no cover
-        """Check whether CoLRev operates in a virtual environment"""
+        """Check whether CoLRev operates in a virtual environment."""
         return colrev.ops.checker.Checker.in_virtualenv()
 
     def check_repository_setup(self) -> None:
-        """Check the repository setup"""
+        """Check the repository setup."""
         checker = colrev.ops.checker.Checker(review_manager=self)
         checker.check_repository_setup()
 
     def get_colrev_versions(self) -> list[str]:
-        """Get the CoLRev versions"""
+        """Get the CoLRev versions."""
         checker = colrev.ops.checker.Checker(review_manager=self)
         return checker.get_colrev_versions()
 
     def update_status_yaml(
         self, *, add_to_git: bool = True, records: typing.Optional[dict] = None
     ) -> None:
-        """Update the STATUS_FILE"""
-
+        """Update the STATUS_FILE."""
         status_stats = self.get_status_stats(records=records)
         exported_dict = status_stats.model_dump()
         exported_dict.pop("origin_states_dict")
@@ -235,48 +234,41 @@ class ReviewManager:
             self.dataset.git_repo.add_changes(self.paths.STATUS_FILE)
 
     def get_upgrade(self) -> colrev.ops.upgrade.Upgrade:  # pragma: no cover
-        """Get an upgrade object"""
-
+        """Get an upgrade object."""
         import colrev.ops.upgrade
 
         return colrev.ops.upgrade.Upgrade(review_manager=self)
 
     def get_repare(self) -> colrev.ops.repare.Repare:  # pragma: no cover
-        """Get a a repare object"""
-
+        """Get a a repare object."""
         import colrev.ops.repare
 
         return colrev.ops.repare.Repare(review_manager=self)
 
     def get_remove_operation(self) -> colrev.ops.remove.Remove:  # pragma: no cover
-        """Get a a remove object"""
-
+        """Get a a remove object."""
         import colrev.ops.remove
 
         return colrev.ops.remove.Remove(review_manager=self)
 
     def get_merge_operation(self) -> colrev.ops.merge.Merge:  # pragma: no cover
-        """Get a merge object"""
-
+        """Get a merge object."""
         import colrev.ops.merge
 
         return colrev.ops.merge.Merge(review_manager=self)
 
     def get_advisor(self) -> colrev.ops.advisor.Advisor:  # pragma: no cover
-        """Get an advisor object"""
-
+        """Get an advisor object."""
         import colrev.ops.advisor
 
         return colrev.ops.advisor.Advisor(review_manager=self)
 
     def get_checker(self) -> colrev.ops.checker.Checker:  # pragma: no cover
-        """Get a checker object"""
-
+        """Get a checker object."""
         return colrev.ops.checker.Checker(review_manager=self)
 
     def get_qm(self) -> colrev.record.qm.quality_model.QualityModel:  # pragma: no cover
-        """Get the quality model"""
-
+        """Get the quality model."""
         return colrev.record.qm.quality_model.QualityModel(
             defects_to_ignore=self.settings.prep.defects_to_ignore
         )
@@ -284,8 +276,7 @@ class ReviewManager:
     def get_pdf_qm(
         self,
     ) -> colrev.record.qm.quality_model.QualityModel:  # pragma: no cover
-        """Get the PDF quality model"""
-
+        """Get the PDF quality model."""
         return colrev.record.qm.quality_model.QualityModel(
             defects_to_ignore=self.settings.pdf_get.defects_to_ignore,
             pdf_mode=True,
@@ -295,8 +286,7 @@ class ReviewManager:
     def get_status_stats(
         self, *, records: typing.Optional[dict] = None
     ) -> colrev.process.status.StatusStats:  # pragma: no cover
-        """Get a status stats object"""
-
+        """Get a status stats object."""
         import colrev.process.status
 
         colrev.ops.check.CheckOperation(self)
@@ -308,14 +298,14 @@ class ReviewManager:
         )
 
     def get_completeness_condition(self) -> bool:
-        """Get the completeness condition"""
+        """Get the completeness condition."""
         status_stats = self.get_status_stats()
         return status_stats.completeness_condition
 
     def get_search_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.search.Search:  # pragma: no cover
-        """Get a search operation object"""
+        """Get a search operation object."""
         import colrev.ops.search
 
         return colrev.ops.search.Search(
@@ -328,7 +318,7 @@ class ReviewManager:
         notify_state_transition_operation: bool = True,
         hide_load_explanation: bool = False,
     ) -> colrev.ops.load.Load:  # pragma: no cover
-        """Get a load operation object"""
+        """Get a load operation object."""
         import colrev.ops.load
 
         return colrev.ops.load.Load(
@@ -345,7 +335,7 @@ class ReviewManager:
         cpu: int = 4,
         debug: bool = False,
     ) -> colrev.ops.prep.Prep:  # pragma: no cover
-        """Get a prep operation object"""
+        """Get a prep operation object."""
         if debug:
             import colrev.ops.prep_debug
 
@@ -367,7 +357,7 @@ class ReviewManager:
     def get_prep_man_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.prep_man.PrepMan:  # pragma: no cover
-        """Get a prep-man operation object"""
+        """Get a prep-man operation object."""
         import colrev.ops.prep_man
 
         return colrev.ops.prep_man.PrepMan(
@@ -378,7 +368,7 @@ class ReviewManager:
     def get_dedupe_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.dedupe.Dedupe:  # pragma: no cover
-        """Get a dedupe operation object"""
+        """Get a dedupe operation object."""
         import colrev.ops.dedupe
 
         return colrev.ops.dedupe.Dedupe(
@@ -389,8 +379,7 @@ class ReviewManager:
     def get_prescreen_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.prescreen.Prescreen:  # pragma: no cover
-        """Get a prescreen operation object"""
-
+        """Get a prescreen operation object."""
         import colrev.ops.prescreen
 
         return colrev.ops.prescreen.Prescreen(
@@ -401,7 +390,7 @@ class ReviewManager:
     def get_pdf_get_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.pdf_get.PDFGet:  # pragma: no cover
-        """Get a pdf-get operation object"""
+        """Get a pdf-get operation object."""
         import colrev.ops.pdf_get
 
         return colrev.ops.pdf_get.PDFGet(
@@ -412,7 +401,7 @@ class ReviewManager:
     def get_pdf_get_man_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.pdf_get_man.PDFGetMan:  # pragma: no cover
-        """Get a pdf-get-man operation object"""
+        """Get a pdf-get-man operation object."""
         import colrev.ops.pdf_get_man
 
         return colrev.ops.pdf_get_man.PDFGetMan(
@@ -423,7 +412,7 @@ class ReviewManager:
     def get_pdf_prep_operation(
         self, *, reprocess: bool = False, notify_state_transition_operation: bool = True
     ) -> colrev.ops.pdf_prep.PDFPrep:  # pragma: no cover
-        """Get a pdfprep operation object"""
+        """Get a pdfprep operation object."""
         import colrev.ops.pdf_prep
 
         return colrev.ops.pdf_prep.PDFPrep(
@@ -435,7 +424,7 @@ class ReviewManager:
     def get_pdf_prep_man_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.pdf_prep_man.PDFPrepMan:  # pragma: no cover
-        """Get a pdf-prep-man operation object"""
+        """Get a pdf-prep-man operation object."""
         import colrev.ops.pdf_prep_man
 
         return colrev.ops.pdf_prep_man.PDFPrepMan(
@@ -446,7 +435,7 @@ class ReviewManager:
     def get_screen_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.screen.Screen:  # pragma: no cover
-        """Get a screen operation object"""
+        """Get a screen operation object."""
         import colrev.ops.screen
 
         return colrev.ops.screen.Screen(
@@ -457,7 +446,7 @@ class ReviewManager:
     def get_data_operation(
         self, *, notify_state_transition_operation: bool = True
     ) -> colrev.ops.data.Data:  # pragma: no cover
-        """Get a data operation object"""
+        """Get a data operation object."""
         import colrev.ops.data
 
         return colrev.ops.data.Data(
@@ -466,8 +455,7 @@ class ReviewManager:
         )
 
     def get_status_operation(self) -> colrev.ops.status.Status:  # pragma: no cover
-        """Get a status operation object"""
-
+        """Get a status operation object."""
         import colrev.ops.status
 
         return colrev.ops.status.Status(review_manager=self)
@@ -475,13 +463,13 @@ class ReviewManager:
     def get_validate_operation(
         self,
     ) -> colrev.ops.validate.Validate:  # pragma: no cover
-        """Get a validate operation object"""
+        """Get a validate operation object."""
         import colrev.ops.validate
 
         return colrev.ops.validate.Validate(review_manager=self)
 
     def get_trace_operation(self) -> colrev.ops.trace.Trace:  # pragma: no cover
-        """Get a trace operation object"""
+        """Get a trace operation object."""
         import colrev.ops.trace
 
         return colrev.ops.trace.Trace(review_manager=self)
@@ -489,23 +477,20 @@ class ReviewManager:
     def get_distribute_operation(
         self,
     ) -> colrev.ops.distribute.Distribute:  # pragma: no cover
-        """Get a distribute operation object"""
-
+        """Get a distribute operation object."""
         import colrev.ops.distribute
 
         return colrev.ops.distribute.Distribute(review_manager=self)
 
     # pylint: disable=line-too-long
     def get_push_operation(self, **kwargs) -> colrev.ops.push.Push:  # type: ignore # pragma: no cover
-        """Get a push operation object"""
-
+        """Get a push operation object."""
         import colrev.ops.push
 
         return colrev.ops.push.Push(review_manager=self, **kwargs)
 
     def get_pull_operation(self) -> colrev.ops.pull.Pull:  # pragma: no cover
-        """Get a pull operation object"""
-
+        """Get a pull operation object."""
         import colrev.ops.pull
 
         return colrev.ops.pull.Pull(review_manager=self)
@@ -517,13 +502,12 @@ class ReviewManager:
         force_mode: bool = False,
         verbose_mode: bool = False,
     ) -> ReviewManager:  # pragma: no cover
-        """Get a (connecting) ReviewManager object for another CoLRev repository"""
+        """Get a (connecting) ReviewManager object for another CoLRev repository."""
         return type(self)(
             path_str=path_str, force_mode=force_mode, verbose_mode=verbose_mode
         )
 
     @classmethod
     def in_test_environment(cls) -> bool:
-        """Check whether CoLRev runs in a test environment"""
-
+        """Check whether CoLRev runs in a test environment."""
         return "pytest" in os.getcwd()

--- a/colrev/search_file.py
+++ b/colrev/search_file.py
@@ -76,7 +76,7 @@ class ExtendedSearchFile(search_query.SearchFile):
         source_records_list: typing.List[typing.Dict],
         imported_origins: typing.List[str],
     ) -> None:
-        """Set the SearchSource up for the load process (initialize statistics)"""
+        """Set the SearchSource up for the load process (initialize statistics)."""
         # pylint: disable=attribute-defined-outside-init
         # Note : define outside init because the following
         # attributes are temporary. They should not be
@@ -88,18 +88,16 @@ class ExtendedSearchFile(search_query.SearchFile):
         self.source_records_list: typing.List[typing.Dict] = source_records_list
 
     def get_origin_prefix(self) -> str:
-        """Get the corresponding origin prefix"""
+        """Get the corresponding origin prefix."""
         assert not any(x in str(self.search_results_path.name) for x in [";", "/"])
         return str(self.search_results_path.name).lstrip("/")
 
     def is_md_source(self) -> bool:
-        """Check whether the source is a metadata source (for preparation)"""
-
+        """Check whether the source is a metadata source (for preparation)."""
         return str(self.search_results_path.name).startswith("md_")
 
     def is_curated_source(self) -> bool:
-        """Check whether the source is a curated source (for preparation)"""
-
+        """Check whether the source is a curated source (for preparation)."""
         return self.get_origin_prefix() == "md_curated.bib"
 
     # pylint: disable=unused-argument

--- a/colrev/settings.py
+++ b/colrev/settings.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Settings of the project"""
+"""Settings of the project."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ if typing.TYPE_CHECKING:
 
 
 class Author(BaseModel):
-    """Author of the review"""
+    """Author of the review."""
 
     # pylint: disable=too-many-instance-attributes
 
@@ -46,13 +46,13 @@ class Author(BaseModel):
 
 
 class Protocol(BaseModel):
-    """Review protocol"""
+    """Review protocol."""
 
     url: str
 
 
 class ProjectSettings(BaseModel):
-    """Project settings"""
+    """Project settings."""
 
     # pylint: disable=too-many-instance-attributes
 
@@ -80,7 +80,7 @@ class ProjectSettings(BaseModel):
 
 
 class SearchSettings(BaseModel):
-    """Search settings"""
+    """Search settings."""
 
     retrieve_forthcoming: bool
 
@@ -92,7 +92,7 @@ class SearchSettings(BaseModel):
 
 
 class PrepRound(BaseModel):
-    """Prep round settings"""
+    """Prep round settings."""
 
     name: str
     prep_package_endpoints: list
@@ -105,7 +105,7 @@ class PrepRound(BaseModel):
 
 
 class PrepSettings(BaseModel):
-    """Prep settings"""
+    """Prep settings."""
 
     fields_to_keep: typing.List[str]
     prep_rounds: typing.List[PrepRound]
@@ -126,7 +126,7 @@ class PrepSettings(BaseModel):
 
 
 class DedupeSettings(BaseModel):
-    """Dedupe settings"""
+    """Dedupe settings."""
 
     dedupe_package_endpoints: list
 
@@ -143,7 +143,7 @@ class DedupeSettings(BaseModel):
 
 
 class PrescreenSettings(BaseModel):
-    """Prescreen settings"""
+    """Prescreen settings."""
 
     explanation: str
     prescreen_package_endpoints: list
@@ -161,7 +161,7 @@ class PrescreenSettings(BaseModel):
 
 
 class PDFGetSettings(BaseModel):
-    """PDF get settings"""
+    """PDF get settings."""
 
     pdf_path_type: PDFPathType
     pdf_required_for_screen_and_synthesis: bool
@@ -187,7 +187,7 @@ class PDFGetSettings(BaseModel):
 
 
 class PDFPrepSettings(BaseModel):
-    """PDF prep settings"""
+    """PDF prep settings."""
 
     keep_backup_of_pdfs: bool
 
@@ -208,7 +208,7 @@ class PDFPrepSettings(BaseModel):
 
 
 class ScreenCriterion(BaseModel):
-    """Screen criterion"""
+    """Screen criterion."""
 
     explanation: str
     comment: typing.Optional[str]
@@ -219,7 +219,7 @@ class ScreenCriterion(BaseModel):
 
 
 class ScreenSettings(BaseModel):
-    """Screen settings"""
+    """Screen settings."""
 
     explanation: typing.Optional[str] = None
     criteria: typing.Dict[str, ScreenCriterion]
@@ -246,7 +246,7 @@ class ScreenSettings(BaseModel):
 
 
 class DataSettings(BaseModel):
-    """Data settings"""
+    """Data settings."""
 
     data_package_endpoints: list
 
@@ -260,7 +260,7 @@ class DataSettings(BaseModel):
 
 
 class Settings(BaseModel):
-    """CoLRev project settings"""
+    """CoLRev project settings."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -282,7 +282,7 @@ class Settings(BaseModel):
     def validate_sources(
         cls, value: typing.List[colrev.search_file.ExtendedSearchFile]
     ) -> typing.List[colrev.search_file.ExtendedSearchFile]:
-        """Validate the sources"""
+        """Validate the sources."""
         return [
             colrev.search_file.ExtendedSearchFile(**v) if isinstance(v, dict) else v
             for v in value
@@ -290,15 +290,13 @@ class Settings(BaseModel):
 
     def model_dump(self, **kwargs) -> dict:  # type: ignore
         """Dump the settings model with recursive handling of SearchSource."""
-
         sources_dump = [source.model_dump(**kwargs) for source in self.sources]  # type: ignore
         data = super().model_dump(**kwargs)
         data["sources"] = sources_dump
         return data
 
     def is_curated_repo(self) -> bool:
-        """Check whether data is curated in this repository"""
-
+        """Check whether data is curated in this repository."""
         curation_endpoints = [
             x
             for x in self.data.data_package_endpoints
@@ -307,8 +305,7 @@ class Settings(BaseModel):
         return bool(curation_endpoints)
 
     def is_curated_masterdata_repo(self) -> bool:
-        """Check whether the masterdata is curated in this repository"""
-
+        """Check whether the masterdata is curated in this repository."""
         curation_endpoints = [
             x
             for x in self.data.data_package_endpoints
@@ -350,7 +347,7 @@ class Settings(BaseModel):
         )
 
     def get_packages(self) -> typing.List[str]:
-        """Get the list of all package names"""
+        """Get the list of all package names."""
 
         def extract_endpoints(package_endpoints: list) -> list:
             return [
@@ -408,8 +405,7 @@ def _load_settings_from_dict(loaded_dict: dict) -> Settings:
 
 
 def load_settings(*, settings_path: Path) -> Settings:
-    """Load the settings from file"""
-
+    """Load the settings from file."""
     if not settings_path.is_file():
         raise colrev_exceptions.RepoSetupError()
 
@@ -435,8 +431,7 @@ def load_settings(*, settings_path: Path) -> Settings:
 
 
 def save_settings(*, review_manager: colrev.review_manager.ReviewManager) -> None:
-    """Save the settings"""
-
+    """Save the settings."""
     sources = review_manager.settings.sources
     review_manager.settings.sources = []
     exported_dict = review_manager.settings.model_dump()

--- a/colrev/ui_cli/__init__.py
+++ b/colrev/ui_cli/__init__.py
@@ -1,4 +1,4 @@
-"""Command-line interface"""
+"""Command-line interface."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -62,7 +62,7 @@ SHELL_MODE = False
 
 
 def _select_endpoint_interactively(add: str, endpoint_type: EndpointType) -> str:
-    """Add package interactively"""
+    """Add package interactively."""
     if add != "add_interactively":
         return add
     packages = PACKAGE_MANAGER.discover_packages(package_type=endpoint_type)
@@ -86,7 +86,7 @@ def _select_endpoint_interactively(add: str, endpoint_type: EndpointType) -> str
 def _select_source_interactively(
     selected: str, review_manager: colrev.review_manager.ReviewManager
 ) -> str:
-    """Select a source interactively"""
+    """Select a source interactively."""
     sources = [str(s.search_results_path) for s in review_manager.settings.sources]
     if selected is None:
         return ",".join(sources)
@@ -107,7 +107,7 @@ def _select_source_interactively(
 def _add_screen_criterion_interactively(
     add: str, screen_operation: colrev.ops.screen.Screen
 ) -> None:
-    """Add screening criterion interactively"""
+    """Add screening criterion interactively."""
     if add != "add_interactively":
         assert add.count(",") == 2
         (
@@ -145,7 +145,7 @@ def _add_screen_criterion_interactively(
 
 
 def get_search_files() -> list:
-    """Get the search files (for click choices)"""
+    """Get the search files (for click choices)."""
     # Take the filenames from sources because there may be API searches
     # without files (yet)
     try:
@@ -156,7 +156,7 @@ def get_search_files() -> list:
 
 
 class SpecialHelpOrder(click.Group):
-    """Order for cli commands in help page overview"""
+    """Order for cli commands in help page overview."""
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore
         self.help_priorities: dict = {}
@@ -193,7 +193,7 @@ class SpecialHelpOrder(click.Group):
 
 
 def catch_exception(func=None, *, handle) -> typing.Any:  # type: ignore
-    """Catch typical cli exceptions (e.g., CoLRevException)"""
+    """Catch typical cli exceptions (e.g., CoLRevException)."""
     if not func:
         return partial(catch_exception, handle=handle)
 
@@ -215,7 +215,7 @@ def catch_exception(func=None, *, handle) -> typing.Any:  # type: ignore
 @click.group(cls=SpecialHelpOrder)
 @click.pass_context
 def main(ctx: click.core.Context) -> None:
-    """CoLRev commands:
+    r"""CoLRev commands:
 
     \b
     status        Shows status, how to proceed, and checks for errors
@@ -235,7 +235,6 @@ def main(ctx: click.core.Context) -> None:
 
     Documentation:  https://colrev-environment.github.io/colrev/
     """
-
     try:
         if ctx.invoked_subcommand == "shell":
             ctx.obj = {"review_manager": colrev.review_manager.ReviewManager()}
@@ -249,9 +248,8 @@ def get_review_manager(
     """Get review_manager instance. If it's available in ctx object, reuse that
     if not creates a new one, Once created will update the review_manager with
     the given parameters. If params requires review_manager to be reloaded, will
-    reload it
+    reload it.
     """
-
     review_manager_params["exact_call"] = ctx.command_path
     try:
         review_manager = ctx.obj["review_manager"]
@@ -284,7 +282,7 @@ def get_review_manager(
 def shell(
     ctx: click.core.Context,
 ) -> None:
-    """Starts a interactive terminal"""
+    """Starts a interactive terminal."""
     from prompt_toolkit.history import FileHistory
 
     print(f"CoLRev version {colrev.__version__}")
@@ -305,7 +303,7 @@ def shell(
 def exit_command(
     ctx: click.core.Context,
 ) -> None:
-    """Starts a interactive terminal"""
+    """Starts a interactive terminal."""
     import inspect
 
     curframe = inspect.currentframe()
@@ -351,7 +349,7 @@ def init(
     force: bool,
     light: bool,
 ) -> None:
-    """Initialize (define review objectives and type)
+    """Initialize (define review objectives and type).
 
     Docs: https://colrev-environment.github.io/colrev/manual/problem_formulation/init.html
     """
@@ -382,7 +380,7 @@ def status(
     ctx: click.core.Context,
     verbose: bool,
 ) -> None:
-    """Show status"""
+    """Show status."""
     try:
         review_manager = get_review_manager(
             ctx,
@@ -419,7 +417,7 @@ def retrieve(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Retrieve, a high-level operation, consists of search, load, prep, and dedupe.
+    r"""Retrieve, a high-level operation, consists of search, load, prep, and dedupe.
 
     \b
     To retrieve search results:
@@ -429,7 +427,6 @@ def retrieve(
 
     https://colrev-environment.github.io/colrev/manual/metadata_retrieval/search.html
     """
-
     review_manager = get_review_manager(
         ctx,
         {"verbose_mode": verbose, "force_mode": force, "high_level_operation": True},
@@ -553,11 +550,10 @@ def search(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Search for records
+    """Search for records.
 
     Docs: https://colrev-environment.github.io/colrev/manual/metadata_retrieval/search.html
     """
-
     review_manager = get_review_manager(
         ctx, {"verbose_mode": verbose, "force_mode": force, "exact_call": EXACT_CALL}
     )
@@ -677,11 +673,10 @@ def load(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Load records
+    """Load records.
 
     Docs: https://colrev-environment.github.io/colrev/manual/metadata_retrieval/load.html
     """
-
     review_manager = get_review_manager(
         ctx, {"verbose_mode": verbose, "force_mode": force, "exact_call": EXACT_CALL}
     )
@@ -767,11 +762,10 @@ def prep(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Prepare records
+    """Prepare records.
 
     Docs: https://colrev-environment.github.io/colrev/manual/metadata_retrieval/prep.html
     """
-
     try:
         review_manager = get_review_manager(
             ctx,
@@ -869,11 +863,10 @@ def prep_man(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Prepare records manually
+    """Prepare records manually.
 
     Docs: https://colrev-environment.github.io/colrev/manual/metadata_retrieval/prep.html
     """
-
     review_manager = get_review_manager(
         ctx, {"verbose_mode": verbose, "force_mode": force, "exact_call": EXACT_CALL}
     )
@@ -988,11 +981,10 @@ def dedupe(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Deduplicate records
+    """Deduplicate records.
 
     Docs: https://colrev-environment.github.io/colrev/manual/metadata_retrieval/dedupe.html
     """
-
     review_manager = get_review_manager(
         ctx, {"verbose_mode": verbose, "force_mode": force, "exact_call": EXACT_CALL}
     )
@@ -1159,11 +1151,10 @@ def prescreen(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Pre-screen exclusion based on metadata (titles and abstracts)
+    """Pre-screen exclusion based on metadata (titles and abstracts).
 
     Docs: https://colrev-environment.github.io/colrev/manual/metadata_prescreen/prescreen.html
     """
-
     # pylint: disable=too-many-locals
 
     review_manager = get_review_manager(
@@ -1318,11 +1309,10 @@ def screen(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Screen based on PDFs and inclusion/exclusion criteria
+    """Screen based on PDFs and inclusion/exclusion criteria.
 
     Docs: https://colrev-environment.github.io/colrev/manual/pdf_screen/screen.html
     """
-
     review_manager = get_review_manager(
         ctx, {"verbose_mode": verbose, "force_mode": force, "exact_call": EXACT_CALL}
     )
@@ -1384,8 +1374,7 @@ def pdf(
     ctx: click.core.Context,
     path: str,
 ) -> None:
-    """Process a PDF"""
-
+    """Process a PDF."""
     ret = ""
     while ret in ["c", "h", ""]:
         ret = input("Option (c: remove cover page, h: show hashes, q: quit)")
@@ -1443,8 +1432,7 @@ def pdfs(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Retrieve and prepare PDFs"""
-
+    """Retrieve and prepare PDFs."""
     review_manager = get_review_manager(
         ctx,
         {
@@ -1554,11 +1542,10 @@ def pdf_get(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Get PDFs
+    """Get PDFs.
 
     Docs: https://colrev-environment.github.io/colrev/manual/pdf_retrieval/pdf_get.html
     """
-
     review_manager = get_review_manager(
         ctx,
         {
@@ -1652,11 +1639,10 @@ def pdf_get_man(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Get PDFs manually
+    """Get PDFs manually.
 
     Docs: https://colrev-environment.github.io/colrev/manual/pdf_retrieval/pdf_get.html
     """
-
     review_manager = get_review_manager(
         ctx,
         {
@@ -1813,11 +1799,10 @@ def pdf_prep(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Prepare PDFs
+    """Prepare PDFs.
 
     Docs: https://colrev-environment.github.io/colrev/manual/pdf_retrieval/pdf_prep.html
     """
-
     # pylint: disable=import-outside-toplevel
 
     review_manager = get_review_manager(
@@ -1952,11 +1937,10 @@ def pdf_prep_man(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Prepare PDFs manually
+    """Prepare PDFs manually.
 
     Docs: https://colrev-environment.github.io/colrev/manual/pdf_retrieval/pdf_prep.html
     """
-
     review_manager = get_review_manager(
         ctx,
         {
@@ -2049,11 +2033,10 @@ def data(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Complete selected forms of data analysis and synthesis
+    """Complete selected forms of data analysis and synthesis.
 
     Docs: https://colrev-environment.github.io/colrev/manual/data/data.html
     """
-
     review_manager = get_review_manager(
         ctx,
         {
@@ -2164,7 +2147,7 @@ def validate(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Validate changes in the given commit (scope)
+    r"""Validate changes in the given commit (scope).
 
     \b
     The validation scope argument can be
@@ -2173,7 +2156,6 @@ def validate(
     - HEAD~4 for commit 4 before HEAD
     - A contributor name
     """
-
     review_manager = get_review_manager(
         ctx,
         {
@@ -2216,8 +2198,7 @@ def trace(
     ctx: click.core.Context,
     record_id: str,  # pylint: disable=invalid-name
 ) -> None:
-    """Trace a record"""
-
+    """Trace a record."""
     review_manager = get_review_manager(
         ctx,
         {
@@ -2267,8 +2248,7 @@ def _select_target_repository(environment_registry: list) -> Path:
 @click.pass_context
 @catch_exception(handle=(colrev_exceptions.CoLRevException))
 def distribute(ctx: click.core.Context, path: Path, verbose: bool, force: bool) -> None:
-    """Distribute records to other local repositories"""
-
+    """Distribute records to other local repositories."""
     if not path:
         path = Path.cwd()
     review_manager = get_review_manager(
@@ -2405,8 +2385,7 @@ def env(
     update_package_list: bool,
     verbose: bool,
 ) -> None:
-    """Manage the environment"""
-
+    """Manage the environment."""
     # pylint: disable=too-many-branches
 
     options_set = any(
@@ -2527,8 +2506,7 @@ def package(
     init: bool,
     check: bool,
 ) -> None:
-    """Manage CoLRev packages"""
-
+    """Manage CoLRev packages."""
     # Collect all options
     options_set = any([init, check])
 
@@ -2595,8 +2573,7 @@ def settings(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Settings of the CoLRev project"""
-
+    """Settings of the CoLRev project."""
     # pylint: disable=reimported
 
     # Collect all options
@@ -2710,8 +2687,7 @@ def pull(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Pull CoLRev project remote and record updates"""
-
+    """Pull CoLRev project remote and record updates."""
     review_manager = get_review_manager(
         ctx,
         {"verbose_mode": verbose, "force_mode": force},
@@ -2728,8 +2704,7 @@ def clone(
     ctx: click.core.Context,
     git_url: str,
 ) -> None:
-    """Create local clone from shared CoLRev repository with git_url"""
-
+    """Create local clone from shared CoLRev repository with git_url."""
     import colrev.ops.clone
 
     clone_operation = colrev.ops.clone.Clone(git_url=git_url)
@@ -2783,8 +2758,7 @@ def push(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Push CoLRev project remote and record updates"""
-
+    """Push CoLRev project remote and record updates."""
     review_manager = get_review_manager(
         ctx,
         {"verbose_mode": verbose, "force_mode": force},
@@ -2826,8 +2800,7 @@ def show(  # type: ignore
     force: bool,
     callback=_validate_show,
 ) -> None:
-    """Show aspects (sample, ...)"""
-
+    """Show aspects (sample, ...)."""
     import colrev.process.operation
     import colrev.ui_cli.show_printer
 
@@ -2921,7 +2894,6 @@ def upgrade(
     force: bool,
 ) -> None:
     """Upgrade to the latest CoLRev project version."""
-
     if disable_auto:
         review_manager = colrev.review_manager.ReviewManager(
             force_mode=True, verbose_mode=verbose, skip_upgrade=True
@@ -2960,7 +2932,6 @@ def repare(
     force: bool,
 ) -> None:
     """Repare file formatting errors in the CoLRev project."""
-
     review_manager = get_review_manager(
         ctx,
         {"verbose_mode": verbose, "force_mode": force},
@@ -2997,8 +2968,7 @@ def remove(
     verbose: bool,
     force: bool,
 ) -> None:
-    """Remove records, ... from CoLRev repositories"""
-
+    """Remove records, ... from CoLRev repositories."""
     review_manager = get_review_manager(
         ctx,
         {"verbose_mode": verbose, "force_mode": force},
@@ -3066,7 +3036,6 @@ def merge(
     force: bool,
 ) -> None:
     """Merge git branches."""
-
     review_manager = get_review_manager(
         ctx,
         {"verbose_mode": verbose, "force_mode": force},
@@ -3107,7 +3076,6 @@ def undo(
     force: bool,
 ) -> None:
     """Undo operations."""
-
     review_manager = get_review_manager(
         ctx,
         {"verbose_mode": verbose, "force_mode": force},
@@ -3120,7 +3088,7 @@ def undo(
 
 
 def select_format() -> str:
-    """Select the format"""
+    """Select the format."""
     questions = [
         inquirer.List(
             "format",
@@ -3154,9 +3122,7 @@ def convert(
     input_file: str,
     output_format: str,
 ) -> None:
-    """
-    Convert a file to the specified format.
-    """
+    """Convert a file to the specified format."""
     # Example placeholder logic
     click.echo(f"Converting file: {input_file}")
     if output_format:
@@ -3193,7 +3159,6 @@ def version(
     ctx: click.core.Context,
 ) -> None:
     """Show colrev version."""
-
     from importlib.metadata import version
 
     print(f'colrev version {version("colrev")}')
@@ -3220,11 +3185,11 @@ def version(
 def install(
     packages: typing.List[str], upgrade: bool, editable: bool, uv: bool
 ) -> None:
-    """Install packages
+    r"""Install packages.
 
     To install all internal packages, run\n
-        colrev install all_internal_packages"""
-
+        colrev install all_internal_packages
+    """
     if len(packages) == 1 and packages[0] == ".":
         review_manager = colrev.review_manager.ReviewManager()
         PACKAGE_MANAGER.install_project(review_manager=review_manager, uv=uv)

--- a/colrev/ui_cli/cli_status_printer.py
+++ b/colrev/ui_cli/cli_status_printer.py
@@ -18,8 +18,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 def print_review_instructions(review_instructions: dict) -> None:
-    """Print the review instructions on cli"""
-
+    """Print the review instructions on cli."""
     print("Next operation")
 
     verbose = False
@@ -94,8 +93,7 @@ def _print_collaboration_instructions_items(
 def print_collaboration_instructions(
     *, status_operation: colrev.ops.status.Status, collaboration_instructions: dict
 ) -> None:
-    """Print the collaboration instructions on cli"""
-
+    """Print the collaboration instructions on cli."""
     if (
         not status_operation.review_manager.verbose_mode
         and collaboration_instructions["items"]
@@ -116,8 +114,7 @@ def print_collaboration_instructions(
 
 
 def print_environment_instructions(environment_instructions: dict) -> None:
-    """Print the environment instructions on cli"""
-
+    """Print the environment instructions on cli."""
     if not environment_instructions:
         return
 
@@ -144,8 +141,7 @@ def print_environment_instructions(environment_instructions: dict) -> None:
 
 
 def print_progress(*, total_atomic_steps: int, completed_steps: int) -> None:
-    """Print the progress bar on cli"""
-
+    """Print the progress bar on cli."""
     # Prints the percentage of atomic processing tasks that have been completed
     # possible extension: estimate the number of manual tasks (making assumptions on
     # frequencies of man-prep, ...)?
@@ -170,8 +166,7 @@ def print_progress(*, total_atomic_steps: int, completed_steps: int) -> None:
 
 
 def print_project_status(status_operation: colrev.ops.status.Status) -> None:
-    """Print the project status on cli"""
-
+    """Print the project status on cli."""
     # pylint: disable=too-many-statements
     # pylint: disable=too-many-branches
 

--- a/colrev/ui_cli/cli_validation.py
+++ b/colrev/ui_cli/cli_validation.py
@@ -48,8 +48,7 @@ def print_string_diff(change: tuple) -> str:
 
 
 def print_diff(origin: dict, record_dict: dict) -> None:
-    """Print the diff between two records"""
-
+    """Print the diff between two records."""
     for key in keys:
 
         if key not in origin and key not in record_dict:
@@ -77,8 +76,7 @@ def print_diff(origin: dict, record_dict: dict) -> None:
 
 
 def print_diff_pair(record_pair: list) -> None:
-    """Print the diff between two records"""
-
+    """Print the diff between two records."""
     for key in keys:
         prev_val = "_FIRST_VAL"
         for rec in record_pair:
@@ -384,8 +382,7 @@ def validate(
     validation_details: dict,
     threshold: float,
 ) -> None:
-    """Validate details in the cli"""
-
+    """Validate details in the cli."""
     for key, details in validation_details.items():
         if key == "prep":
             _validate_prep(

--- a/colrev/ui_cli/dedupe_errors.py
+++ b/colrev/ui_cli/dedupe_errors.py
@@ -12,7 +12,7 @@ from colrev.constants import Fields
 
 
 def load_dedupe_false_positives(*, dedupe_operation: colrev.ops.dedupe.Dedupe) -> list:
-    """Load the dedupe false positives marked in the Excel or txt file"""
+    """Load the dedupe false positives marked in the Excel or txt file."""
     false_positives = []
     if dedupe_operation.dupe_file.is_file():
         dupes = pd.read_excel(dedupe_operation.dupe_file)
@@ -28,8 +28,7 @@ def load_dedupe_false_positives(*, dedupe_operation: colrev.ops.dedupe.Dedupe) -
 
 
 def load_dedupe_false_negatives(*, dedupe_operation: colrev.ops.dedupe.Dedupe) -> list:
-    """Load the dedupe false negatives marked in the Excel file"""
-
+    """Load the dedupe false negatives marked in the Excel file."""
     false_negatives: typing.List[dict] = []
     if (
         dedupe_operation.non_dupe_file_xlsx.is_file()

--- a/colrev/ui_cli/detect_and_add_source.py
+++ b/colrev/ui_cli/detect_and_add_source.py
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
 
 
 class CLISourceAdder:
-    """CLI utility to add SearchSources"""
+    """CLI utility to add SearchSources."""
 
     def __init__(self, *, search_operation: colrev.ops.search.Search) -> None:
         self.search_operation = search_operation
@@ -89,7 +89,6 @@ class CLISourceAdder:
 
     def add_new_sources(self) -> typing.List[colrev.search_file.ExtendedSearchFile]:
         """Select the new source from the heuristic_result_list."""
-
         new_search_files = self.search_operation.get_new_search_files()
         sources_added = []
 

--- a/colrev/ui_cli/search_backward_selective.py
+++ b/colrev/ui_cli/search_backward_selective.py
@@ -18,8 +18,7 @@ if typing.TYPE_CHECKING:
 
 
 def main(*, search_operation: colrev.ops.search.Search, bws: str) -> None:
-    """Run a selective backward search (interactively on the cli)"""
-
+    """Run a selective backward search (interactively on the cli)."""
     items = search_operation.review_manager.dataset.read_next_record(
         conditions=[{Fields.ID: bws}]
     )

--- a/colrev/ui_cli/setup_custom_scripts.py
+++ b/colrev/ui_cli/setup_custom_scripts.py
@@ -15,8 +15,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 def setup_custom_search_script(
     *, review_manager: colrev.review_manager.ReviewManager
 ) -> None:
-    """Setup a custom search script"""
-
+    """Setup a custom search script."""
     filedata = colrev.env.utils.get_package_file_content(
         module="colrev.ops",
         filename=Path("custom_scripts/custom_search_source_script.py"),

--- a/colrev/ui_cli/show_printer.py
+++ b/colrev/ui_cli/show_printer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Scripts printing information for the colrev show command"""
+"""Scripts printing information for the colrev show command."""
 
 import platform
 from pathlib import Path
@@ -12,8 +12,7 @@ from colrev.constants import RecordState
 
 
 def print_sample(review_manager: colrev.review_manager.ReviewManager) -> None:
-    """Print the sample on cli"""
-
+    """Print the sample on cli."""
     colrev.ops.check.CheckOperation(review_manager)
     records = review_manager.dataset.load_records_dict()
     sample = [
@@ -33,8 +32,7 @@ def print_sample(review_manager: colrev.review_manager.ReviewManager) -> None:
 
 
 def print_venv_notes() -> None:
-    """Print the virtual environment details on cli"""
-
+    """Print the virtual environment details on cli."""
     current_platform = platform.system()
     if current_platform == "Linux":
         print("Detected platform: Linux")

--- a/colrev/utils.py
+++ b/colrev/utils.py
@@ -33,8 +33,7 @@ def p_print(obj: typing.Any) -> None:
 
 
 def get_cached_session() -> requests_cache.CachedSession:  # pragma: no cover
-    """Get a cached session"""
-
+    """Get a cached session."""
     return requests_cache.CachedSession(
         str(Filepaths.PREP_REQUESTS_CACHE_FILE),
         backend="sqlite",
@@ -44,7 +43,6 @@ def get_cached_session() -> requests_cache.CachedSession:  # pragma: no cover
 
 def in_ci_environment() -> bool:
     """Return True if running in a CI environment (e.g., GitHub Actions)."""
-
     identifier_list = ["GITHUB_ACTIONS", "CIRCLECI", "TRAVIS", "GITLAB_CI"]
     return any("true" == os.getenv(x) for x in identifier_list)
 
@@ -56,8 +54,7 @@ def get_unique_filename(
     suffix: str = ".bib",
     prefix: str = "data/search/",
 ) -> Path:
-    """Get a unique filename for a (new) SearchSource"""
-
+    """Get a unique filename for a (new) SearchSource."""
     base_path = base_path / Path(prefix)
     existing_filenames = []
     for search_file_path in base_path.glob("*_search_history.json"):
@@ -86,8 +83,7 @@ def get_unique_filename(
 
 
 def select_search_type(*, search_types: list, params: dict) -> SearchType:
-    """Select the SearchType (interactively if neccessary)"""
-
+    """Select the SearchType (interactively if neccessary)."""
     # pylint: disable=import-outside-toplevel
     import inquirer
 
@@ -113,7 +109,8 @@ def select_search_type(*, search_types: list, params: dict) -> SearchType:
 
 def get_project_home_dir(*, path_str: typing.Optional[str] = None) -> Path:
     """Get the root directory of the CoLRev project
-    (i.e., the directory containing the .git directory)"""
+    (i.e., the directory containing the .git directory).
+    """
     if path_str:
         original_dir = Path(path_str)
     else:
@@ -194,7 +191,7 @@ def _strip_diacritics(text: str) -> str:
 def remove_stopwords(
     input_str: str, stopwords: typing.Optional[typing.Set[str]] = None
 ) -> str:
-    """Remove stopwords from a string"""
+    """Remove stopwords from a string."""
     if stopwords is None:
         stopwords = STOPWORDS
     text = _strip_diacritics(input_str)

--- a/colrev/writer/__init__.py
+++ b/colrev/writer/__init__.py
@@ -1,4 +1,4 @@
-"""Writers for different data formats, including BibTex, RIS, CSV/Excel files"""
+"""Writers for different data formats, including BibTex, RIS, CSV/Excel files."""
 
 __author__ = """Gerit Wagner"""
 __email__ = "gerit.wagner@uni-bamberg.de"

--- a/colrev/writer/bib.py
+++ b/colrev/writer/bib.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to write bib files"""
+"""Function to write bib files."""
 
 from __future__ import annotations
 
@@ -38,7 +38,7 @@ RECORDS_FIELD_ORDER = [
 
 
 def _sanitize_string_for_dict(input_string: str) -> str:
-    """Sanitize a string for dict keys"""
+    """Sanitize a string for dict keys."""
     return (
         input_string.replace(";", "_")
         .replace("=", "_")
@@ -102,7 +102,7 @@ def _get_stringified_record(*, record_dict: dict) -> dict:
 
 
 def to_string(*, records_dict: dict) -> str:
-    """Convert a records dict to a bibtex string"""
+    """Convert a records dict to a bibtex string."""
     # Note: we need a deepcopy because the parsing modifies dicts
     recs_dict = deepcopy(records_dict)
 
@@ -139,7 +139,7 @@ def to_string(*, records_dict: dict) -> str:
 
 
 def write_file(*, records_dict: dict, filename: Path) -> None:
-    """Write a bib file from a records dict"""
+    """Write a bib file from a records dict."""
     bibtexstr = to_string(records_dict=records_dict)
     with open(filename, "w", encoding="utf-8") as file:
         file.write(bibtexstr)

--- a/colrev/writer/csv.py
+++ b/colrev/writer/csv.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to write csv files"""
+"""Function to write csv files."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ def to_dataframe(
     sort_fields_first: bool = True,
     drop_empty_fields: bool = True,
 ) -> pd.DataFrame:
-    """Convert a records dict to a pandas DataFrame"""
+    """Convert a records dict to a pandas DataFrame."""
     all_keys = {k for v in records_dict.values() for k in v.keys()}
     additional_fields = sorted(all_keys - set(FIELDS))
     fields = FIELDS + additional_fields if sort_fields_first else sorted(all_keys)

--- a/colrev/writer/excel.py
+++ b/colrev/writer/excel.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to write Excel files with flexible field handling"""
+"""Function to write Excel files with flexible field handling."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ def to_dataframe(
     sort_fields_first: bool = True,
     drop_empty_fields: bool = True,
 ) -> pd.DataFrame:
-    """Convert a records dict to a pandas DataFrame"""
+    """Convert a records dict to a pandas DataFrame."""
     all_keys = {k for v in records_dict.values() for k in v.keys()}
     additional_fields = sorted(all_keys - set(FIELDS))
     fields = FIELDS + additional_fields if sort_fields_first else sorted(all_keys)
@@ -57,7 +57,7 @@ def write_file(
     sort_fields_first: bool = True,
     drop_empty_fields: bool = True,
 ) -> None:
-    """Write an Excel file from a records dict"""
+    """Write an Excel file from a records dict."""
     data_frame = to_dataframe(
         records_dict=records_dict,
         sort_fields_first=sort_fields_first,

--- a/colrev/writer/markdown.py
+++ b/colrev/writer/markdown.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to write Markdown (table) files"""
+"""Function to write Markdown (table) files."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ def to_dataframe(
     sort_fields_first: bool = True,
     drop_empty_fields: bool = True,
 ) -> pd.DataFrame:
-    """Convert a records dict to a pandas DataFrame"""
+    """Convert a records dict to a pandas DataFrame."""
     all_keys = {k for v in records_dict.values() for k in v.keys()}
     additional_fields = sorted(all_keys - set(FIELDS))
     fields = FIELDS + additional_fields if sort_fields_first else sorted(all_keys)
@@ -56,7 +56,7 @@ def to_string(
     sort_fields_first: bool = True,
     drop_empty_fields: bool = True,
 ) -> str:
-    """Convert a records dict to a markdown string with a table"""
+    """Convert a records dict to a markdown string with a table."""
     data_frame = to_dataframe(
         records_dict=records_dict,
         sort_fields_first=sort_fields_first,
@@ -82,7 +82,7 @@ def write_file(
     sort_fields_first: bool = True,
     drop_empty_fields: bool = True,
 ) -> None:
-    """Write a markdown file with a table from a records dict"""
+    """Write a markdown file with a table from a records dict."""
     md_string = to_string(
         records_dict=records_dict,
         sort_fields_first=sort_fields_first,

--- a/colrev/writer/ris.py
+++ b/colrev/writer/ris.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to write ris files"""
+"""Function to write ris files."""
 
 from __future__ import annotations
 
@@ -48,7 +48,7 @@ RECORD_FIELD_MAP = {
 
 
 def _add_pages(record_dict: dict) -> str:
-    """Add pages to the RIS string"""
+    """Add pages to the RIS string."""
     pages_str = ""
     if Fields.PAGES in record_dict:
         pages = str(record_dict[Fields.PAGES])
@@ -66,7 +66,7 @@ def _add_pages(record_dict: dict) -> str:
 
 
 def _add_sn(record_dict: dict) -> str:
-    """Add SN (ISSN/ISBN) to the RIS string"""
+    """Add SN (ISSN/ISBN) to the RIS string."""
     sn_list = []
     if Fields.ISSN in record_dict:
         sn_list.append(str(record_dict[Fields.ISSN]))
@@ -78,7 +78,7 @@ def _add_sn(record_dict: dict) -> str:
 
 
 def to_string(*, records_dict: dict) -> str:
-    """Convert a records dict to a RIS string"""
+    """Convert a records dict to a RIS string."""
     ris_str = ""
     for record_id in sorted(records_dict.keys()):
         record_dict = records_dict[record_id]
@@ -108,7 +108,7 @@ def to_string(*, records_dict: dict) -> str:
 
 
 def write_file(*, records_dict: dict, filename: str) -> None:
-    """Write a RIS file from a records dict"""
+    """Write a RIS file from a records dict."""
     ris_str = to_string(records_dict=records_dict)
     with open(filename, "w", encoding="utf-8") as file:
         file.write(ris_str)

--- a/colrev/writer/write_utils.py
+++ b/colrev/writer/write_utils.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Function to write files (BiBTeX, RIS, CSV, etc.)
+"""Function to write files (BiBTeX, RIS, CSV, etc.).
 
 Usage::
 
@@ -32,6 +32,7 @@ def write_file(records_dict: dict, *, filename: Path, **kw) -> dict:  # type: ig
         For tabular formats (csv, xlsx, md), the following options are supported:
             - sort_fields_first: list of fields to appear first in the output
             - drop_empty_fields: if True, empty fields will be omitted
+
     """
     if isinstance(filename, str):
         filename = Path(filename)


### PR DESCRIPTION
### Motivation
- Fix a large number of PEP 257 / docstring-style lint issues reported by Ruff across the `colrev/` package to improve consistency and reduce automatic lint failures. 

### Description
- Ran a broad Ruff autofix pass (including unsafe fixes) to standardize docstrings (closing punctuation, blank-line rules before class docstrings, multi-line docstring layout, one-line vs multi-line adjustments, and minor wording) across core modules and packages. 
- Changes touch many modules including `colrev/constants.py`, `colrev/dataset.py`, `colrev/env/*`, `colrev/ops/*`, package endpoints under `colrev/packages/*`, loader modules, linters, hooks, and utilities to align with PEP 257 conventions. 
- Adjusted magic method and class docstrings where appropriate and added or reflowed docstrings to satisfy formatting checks; no behavioral logic changes intended. 
- All edits were committed with message: `Apply broad PEP 257 docstring lint autofixes across colrev`.

### Testing
- Ran `ruff check . --select D` to enumerate docstring issues prior to fixes, and then applied fixes with `ruff check colrev --select D --fix --unsafe-fixes`, which performed the automated modifications and produced the changes committed to the branch. (Autofix run completed and changes were committed.)
- Follow-up `ruff check` runs were used to re-evaluate remaining docstring diagnostics; the broad pass resolved many issues but additional docstring/style findings remain and will require targeted manual attention (the focused check for specific D-codes still reported remaining violations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0477095ea4832ab95084ffb77c7654)