### PR TITLE
docs: address PEP 257 docstring conventions across the codebase

### DIFF
--- a/colrev/constants.py
+++ b/colrev/constants.py
@@ -425,9 +425,11 @@ class RecordState(Enum):
     # Note : TBD: rev_coded
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return f"{self.name}"
 
     def __lt__(self, other) -> bool:  # type: ignore
+        """Return whether this instance is less than another."""
         if self.__class__ == RecordState and other.__class__ == RecordState:
             return self.value < other.value
         raise NotImplementedError
@@ -593,6 +595,7 @@ class OperationsType(Enum):
     check = "check"
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return f"{self.name}"
 
     @classmethod
@@ -625,6 +628,7 @@ class SortedEnumMeta(EnumMeta):
     def __init__(
         cls, name: str, bases: typing.Tuple[type, ...], classdict: dict
     ) -> None:
+        """Initialize the instance."""
         super().__init__(name, bases, classdict)
         # Sort the members by their values
         # pylint: disable=unsubscriptable-object
@@ -652,9 +656,11 @@ class SearchType(Enum, metaclass=SortedEnumMeta):
         return cls._member_names_
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return self.name
 
     def __lt__(self, other: "SearchType") -> bool:
+        """Return whether this instance is less than another."""
         if isinstance(other, SearchType):
             return self.value < other.value
         return NotImplemented
@@ -670,6 +676,7 @@ class SearchSourceHeuristicStatus(Enum):
     todo = "to_be_implemented"
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return f"{self.name}"  # pragma: no cover
 
 
@@ -701,6 +708,7 @@ class ScreenCriterionType(Enum):
         return cls._member_names_
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return self.name
 
 

--- a/colrev/dataset.py
+++ b/colrev/dataset.py
@@ -28,6 +28,7 @@ class Dataset:
     """The CoLRev dataset (records and their history in git)."""
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
+        """Initialize the instance."""
         self.review_manager = review_manager
 
     @cached_property

--- a/colrev/env/environment_manager.py
+++ b/colrev/env/environment_manager.py
@@ -26,6 +26,7 @@ class EnvironmentManager:
     load_yaml = False
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         self.environment_registry = self.load_environment_registry()
         self._registered_ports: typing.List[str] = []
 

--- a/colrev/env/grobid_service.py
+++ b/colrev/env/grobid_service.py
@@ -21,6 +21,7 @@ class GrobidService:
     GROBID_IMAGE = "lfoppiano/grobid:0.8.2"
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         colrev.env.docker_manager.DockerManager.build_docker_image(
             imagename=self.GROBID_IMAGE
         )

--- a/colrev/env/language_service.py
+++ b/colrev/env/language_service.py
@@ -24,7 +24,7 @@ class LanguageService:
         # It performs particularly well for short strings (single words/word pairs)
         # The langdetect library is non-deterministic, especially for short strings
         # https://pypi.org/project/langdetect/
-
+        """Initialize the instance."""
         self._lingua_language_detector = (
             LanguageDetectorBuilder.from_all_languages_with_latin_script().build()
         )

--- a/colrev/env/local_index.py
+++ b/colrev/env/local_index.py
@@ -31,6 +31,7 @@ class LocalIndex:
         index_tei: bool = False,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.verbose_mode = verbose_mode
         self.environment_manager = colrev.env.environment_manager.EnvironmentManager()
         self._index_tei = index_tei

--- a/colrev/env/local_index_builder.py
+++ b/colrev/env/local_index_builder.py
@@ -44,6 +44,7 @@ class LocalIndexBuilder:
         index_tei: bool = False,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.verbose_mode = verbose_mode
         self.environment_manager = colrev.env.environment_manager.EnvironmentManager()
         self._index_tei = index_tei

--- a/colrev/env/local_index_sqlite.py
+++ b/colrev/env/local_index_sqlite.py
@@ -54,6 +54,7 @@ class SQLiteIndex:
     def __init__(
         self, *, index_name: str, index_keys: list, reinitialize: bool
     ) -> None:
+        """Initialize the instance."""
         self.index_name = index_name
         self.index_keys = index_keys
         self.connection = sqlite3.connect(
@@ -152,6 +153,7 @@ class SQLiteIndexRecord(SQLiteIndex):
             WHERE {LocalIndexFields.ID}=?"""
 
     def __init__(self, *, reinitialize: bool = False) -> None:
+        """Initialize the instance."""
         super().__init__(
             index_name=self.INDEX_NAME,
             index_keys=self.KEYS,
@@ -266,6 +268,7 @@ class SQLiteIndexRankings(SQLiteIndex):
     SELECT_QUERY = f"SELECT * FROM {INDEX_NAME} WHERE journal_name = ?"
 
     def __init__(self, *, reinitialize: bool = False) -> None:
+        """Initialize the instance."""
         super().__init__(
             index_name=self.INDEX_NAME,
             index_keys=self.KEYS,
@@ -306,6 +309,7 @@ class SQLiteIndexTOC(SQLiteIndex):
     INSERT_MANY_QUERY = f"INSERT INTO {INDEX_NAME} VALUES(?, ?)"
 
     def __init__(self, *, reinitialize: bool = False) -> None:
+        """Initialize the instance."""
         super().__init__(
             index_name=self.INDEX_NAME,
             index_keys=self.KEYS,

--- a/colrev/exceptions.py
+++ b/colrev/exceptions.py
@@ -21,6 +21,7 @@ class RepoSetupError(CoLRevException):
     )
 
     def __init__(self, msg: typing.Optional[str] = None) -> None:
+        """Initialize the instance."""
         try:
             Path(".report.log").unlink(missing_ok=True)
         except PermissionError:
@@ -72,6 +73,7 @@ class CoLRevUpgradeError(CoLRevException):
     """
 
     def __init__(self, old: str, new: str) -> None:
+        """Initialize the instance."""
         self.message = (
             f"Detected upgrade from {old} to {new}. To upgrade use\n     "
             f"{Colors.ORANGE}colrev upgrade{Colors.END}"
@@ -116,6 +118,7 @@ class ReviewManagerNotNotifiedError(CoLRevException):
     """
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         self.message = (
             "Instantiate the intended operation so the review manager can "
             "run its precondition checks before accessing records.\n"
@@ -130,6 +133,7 @@ class ParameterError(CoLRevException):
     """An invalid parameter was passed to CoLRev."""
 
     def __init__(self, *, parameter: str, value: str, options: list) -> None:
+        """Initialize the instance."""
         options_string = "\n  - ".join(sorted(options))
         self.message = f"Invalid parameter {parameter}: {value}."
         if options:
@@ -141,6 +145,7 @@ class InvalidSettingsError(CoLRevException):
     """Invalid value in SETTINGS_FILE."""
 
     def __init__(self, *, msg: str, fix_per_upgrade: bool = True) -> None:
+        """Initialize the instance."""
         msg = f"Error in SETTINGS_FILE: {msg}"
         if fix_per_upgrade:
             msg += (
@@ -157,6 +162,7 @@ class UnstagedGitChangesError(CoLRevException):
     """Unstaged git changes were found although a clean repository is required."""
 
     def __init__(self, changedFiles: list) -> None:
+        """Initialize the instance."""
         self.message = (
             f"changes not yet staged: {changedFiles} (use git add . or stash)"
         )
@@ -167,6 +173,7 @@ class CleanRepoRequiredError(CoLRevException):
     """A clean git repository would be required."""
 
     def __init__(self, changedFiles: list, ignore_pattern: str) -> None:
+        """Initialize the instance."""
         self.message = (
             "clean repository required (use git commit, discard or stash "
             + f"{changedFiles}; ignore_pattern={ignore_pattern})."
@@ -178,6 +185,7 @@ class GitConflictError(CoLRevException):
     """There are git conflicts to be resolved before resuming operations."""
 
     def __init__(self, path: Path) -> None:
+        """Initialize the instance."""
         self.message = f"please resolve git conflict in {path}"
         super().__init__(self.message)
 
@@ -186,6 +194,7 @@ class DirtyRepoAfterProcessingError(CoLRevException):
     """The git repository was not clean after completing the operation."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -194,6 +203,7 @@ class GitNotAvailableError(CoLRevException):
     """Git is currently not available."""
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         self.message = "Git is currently not available (remove .git/index.lock exists)."
         super().__init__(self.message)
 
@@ -202,6 +212,7 @@ class AppendOnlyViolation(Exception):
     """Invalid changes to a file in append-only mode."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -215,6 +226,7 @@ class ProcessOrderViolation(CoLRevException):
         required_state: str,
         violating_records: list,
     ) -> None:
+        """Initialize the instance."""
         self.message = (
             f" {operations_type}() requires all records to have at least "
             + f"'{required_state}', but there are records with {violating_records}."
@@ -226,6 +238,7 @@ class StatusTransitionError(CoLRevException):
     """An invalid status transition was observed."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = f" {msg}"
         super().__init__(self.message)
 
@@ -234,6 +247,7 @@ class NoRecordsError(CoLRevException):
     """The operation cannot be started because no records have been imported yet."""
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         self.message = "no records imported yet"
         super().__init__(self.message)
 
@@ -242,6 +256,7 @@ class FieldValueError(CoLRevException):
     """An error in field values was detected (in the main records)."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = f" {msg}"
         super().__init__(self.message)
 
@@ -250,6 +265,7 @@ class MissingRecordQualityRuleSpecification(CoLRevException):
     """A quality rule is missing."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -258,6 +274,7 @@ class StatusFieldValueError(CoLRevException):
     """An error in the status field values was detected."""
 
     def __init__(self, record: str, status_type: str, status_value: str) -> None:
+        """Initialize the instance."""
         self.message = f"{status_type} set to '{status_value}' in {record}."
         super().__init__(self.message)
 
@@ -266,6 +283,7 @@ class OriginError(CoLRevException):
     """An error in the colrev_origin field values was detected."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = f" {msg}"
         super().__init__(self.message)
 
@@ -274,6 +292,7 @@ class DuplicateIDsError(CoLRevException):
     """Duplicate IDs were detected."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = f" {msg}"
         super().__init__(self.message)
 
@@ -287,6 +306,7 @@ class NotEnoughDataToIdentifyException(CoLRevException):
         msg: typing.Optional[str] = None,
         missing_fields: typing.Optional[list] = None,
     ) -> None:
+        """Initialize the instance."""
         self.message = msg
         self.missing_fields = missing_fields
         super().__init__(self.message)
@@ -299,6 +319,7 @@ class NotTOCIdentifiableException(CoLRevException):
     """
 
     def __init__(self, msg: typing.Optional[str] = None) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -307,6 +328,7 @@ class RecordNotInTOCException(CoLRevException):
     """The record is not part of the table-of-contents (TOC)."""
 
     def __init__(self, *, record_id: str, toc_key: str) -> None:
+        """Initialize the instance."""
         self.record_id = record_id
         self.toc_key = toc_key
         self.message = f"{record_id} not part of toc: {toc_key}"
@@ -317,6 +339,7 @@ class PropagatedIDChange(CoLRevException):
     """Changes in propagated records ID detected."""
 
     def __init__(self, notifications: list) -> None:
+        """Initialize the instance."""
         self.message = "\n    ".join(notifications)
         super().__init__("Attempt to change propagated IDs:" + self.message)
 
@@ -328,6 +351,7 @@ class NonEmptyDirectoryError(CoLRevException):
     """Trying to initialize CoLRev in a non-empty directory."""
 
     def __init__(self, *, filepath: Path, content: list) -> None:
+        """Initialize the instance."""
         if len(content) > 3:
             content = content[0:5] + ["..."]
         self.message = (
@@ -342,6 +366,7 @@ class RepoInitError(CoLRevException):
     """Error during initialization of CoLRev project."""
 
     def __init__(self, *, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -353,6 +378,7 @@ class SearchNotAutomated(CoLRevException):
     """The search cannot be completed automatically."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -361,6 +387,7 @@ class InvalidQueryException(CoLRevException):
     """The query format is not valid."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -369,6 +396,7 @@ class RecordNotParsableException(CoLRevException):
     """The record could not be parsed."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -377,6 +405,7 @@ class NotFeedIdentifiableException(CoLRevException):
     """The record does not contain the required source_identifier (cannot be added to the feed)."""
 
     def __init__(self, msg: typing.Optional[str] = None) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -385,6 +414,7 @@ class SearchSourceException(CoLRevException):
     """Records cannot be retrieved from the SearchSource."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -393,6 +423,7 @@ class RecordNotFoundException(CoLRevException):
     """Record not found in the main records file."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -407,6 +438,7 @@ class ImportException(CoLRevException):
         self,
         msg: str,
     ) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -418,6 +450,7 @@ class NoRecordsToImport(CoLRevException):
         self,
         msg: str,
     ) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -429,6 +462,7 @@ class UnsupportedImportFormatError(CoLRevException):
         self,
         import_path: Path,
     ) -> None:
+        """Initialize the instance."""
         self.import_path = import_path
         self.message = (
             f"Format of SearchSource file not supported ({self.import_path.name}) "
@@ -447,6 +481,7 @@ class RecordNotFoundInPrepSourceException(CoLRevException):
         *,
         msg: str,
     ) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -458,6 +493,7 @@ class DedupeError(CoLRevException):
     """An exception in the dedupe operation."""
 
     def __init__(self, message: str) -> None:
+        """Initialize the instance."""
         self.message = message
         super().__init__(self.message)
 
@@ -469,6 +505,7 @@ class DataException(CoLRevException):
     """Exception in the data operation."""
 
     def __init__(self, *, msg: str) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__("DataException: " + self.message)
 
@@ -480,6 +517,7 @@ class RecordNotInRepoException(CoLRevException):
     """The record was not found in the main records."""
 
     def __init__(self, record_id: str) -> None:
+        """Initialize the instance."""
         if id is not None:
             self.message = f"Record not in repository ({record_id})"
         else:
@@ -491,6 +529,7 @@ class CorrectionPreconditionException(CoLRevException):
     """Precondition for corrections not given (clean git repository)."""
 
     def __init__(self, message: str) -> None:
+        """Initialize the instance."""
         self.message = message
         super().__init__(self.message)
 
@@ -502,6 +541,7 @@ class InvalidPDFException(CoLRevException):
     """The PDF is invalid (empty, encrypted or broken)."""
 
     def __init__(self, path: Path) -> None:
+        """Initialize the instance."""
         self.message = f"Invalid PDF (empty/broken): {path}"
         super().__init__(self.message)
 
@@ -510,6 +550,7 @@ class PDFHashError(CoLRevException):
     """An error occurred during PDF hashing."""
 
     def __init__(self, path: Path) -> None:
+        """Initialize the instance."""
         self.message = f"Error during PDF hashing: {path}"
         super().__init__(self.message)
 
@@ -521,6 +562,7 @@ class MissingDependencyError(CoLRevException):
     """The required dependency is not available."""
 
     def __init__(self, dep: str) -> None:
+        """Initialize the instance."""
         self.message = f"{dep}"
         super().__init__(self.message)
 
@@ -529,6 +571,7 @@ class PackageParameterError(CoLRevException):
     """The parameter for the package are not correct."""
 
     def __init__(self, dep: str) -> None:
+        """Initialize the instance."""
         self.message = f"{dep}"
         super().__init__(self.message)
 
@@ -537,6 +580,7 @@ class DependencyConfigurationError(CoLRevException):
     """The required dependency is not configured correctly."""
 
     def __init__(self, dep: str) -> None:
+        """Initialize the instance."""
         self.message = f"{dep}"
         super().__init__(self.message)
 
@@ -545,6 +589,7 @@ class ServiceNotAvailableException(CoLRevException):
     """An environment service is not available."""
 
     def __init__(self, dep: str, detailed_trace: str = "") -> None:
+        """Initialize the instance."""
         self.dep = dep
         self.detailed_trace = detailed_trace
         super().__init__(f"Service not available: {self.dep}")
@@ -554,6 +599,7 @@ class PortAlreadyRegisteredException(CoLRevException):
     """The port (localhost) is already registered."""
 
     def __init__(self, message: str) -> None:
+        """Initialize the instance."""
         self.message = message
         super().__init__(self.message)
 
@@ -570,6 +616,7 @@ class RecordNotInIndexException(CoLRevException):
     """The requested record was not found in the LocalIndex."""
 
     def __init__(self, record_id: str) -> None:
+        """Initialize the instance."""
         if id is not None:
             self.message = f"Record not in index ({record_id})"
         else:
@@ -585,6 +632,7 @@ class RecordNotIndexableException(CoLRevException):
         record_id: typing.Optional[str] = None,
         missing_key: typing.Optional[str] = None,
     ) -> None:
+        """Initialize the instance."""
         self.missing_key = missing_key
         if missing_key is None:
             missing_key = "-"
@@ -599,6 +647,7 @@ class TOCNotAvailableException(CoLRevException):
     """Tables of contents (toc) are not available for the requested item."""
 
     def __init__(self, msg: typing.Optional[str] = None) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -607,6 +656,7 @@ class CuratedOutletNotUnique(CoLRevException):
     """The outlets (journals or conferences) with curated metadata are not unique."""
 
     def __init__(self, msg: typing.Optional[str] = None) -> None:
+        """Initialize the instance."""
         self.message = msg
         super().__init__(self.message)
 
@@ -615,6 +665,7 @@ class InvalidLanguageCodeException(CoLRevException):
     """Language code field does not comply with the required standard."""
 
     def __init__(self, invalid_language_codes: list) -> None:
+        """Initialize the instance."""
         self.invalid_language_codes = invalid_language_codes
 
         super().__init__(f"Invalid language codes: {', '.join(invalid_language_codes)}")
@@ -624,6 +675,7 @@ class PackageSettingMustStartWithPackagesException(CoLRevException):
     """Package settings must start with `packages` key."""
 
     def __init__(self, invalid_key: str) -> None:
+        """Initialize the instance."""
         self.invalid_key = invalid_key
         super().__init__(
             f"Package settings must start with `packages` key. {invalid_key}"
@@ -634,5 +686,6 @@ class TemplateNotAvailableError(CoLRevException):
     """The requested template is not available."""
 
     def __init__(self, template_path: str) -> None:
+        """Initialize the instance."""
         self.message = f"Template not available: {template_path}"
         super().__init__(self.message)

--- a/colrev/git_repo.py
+++ b/colrev/git_repo.py
@@ -26,6 +26,7 @@ class GitRepo:
     """Wrapper for Git repository interactions."""
 
     def __init__(self, path: typing.Optional[Path]) -> None:
+        """Initialize the instance."""
         self.path = path if path else Path.cwd()
         if not self.path.is_absolute():
             self.path = self.path.resolve()

--- a/colrev/loader/bib.py
+++ b/colrev/loader/bib.py
@@ -343,6 +343,7 @@ class BIBLoader(colrev.loader.loader.Loader):
         format_names: bool = False,
         resolve_crossref: bool = False,
     ):
+        """Initialize the instance."""
         self.resolve_crossref = resolve_crossref
 
         super().__init__(

--- a/colrev/loader/enl.py
+++ b/colrev/loader/enl.py
@@ -40,7 +40,7 @@ class ENLLoader(colrev.loader.loader.Loader):
         logger: logging.Logger = logging.getLogger(__name__),
         format_names: bool = False,
     ):
-
+        """Initialize the instance."""
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,

--- a/colrev/loader/json.py
+++ b/colrev/loader/json.py
@@ -30,6 +30,7 @@ class JSONLoader(colrev.loader.loader.Loader):
         logger: logging.Logger = logging.getLogger(__name__),
         format_names: bool = False,
     ):
+        """Initialize the instance."""
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,

--- a/colrev/loader/load_utils_formatter.py
+++ b/colrev/loader/load_utils_formatter.py
@@ -56,6 +56,7 @@ class LoadFormatter:
     ]
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         self.language_service = colrev.env.language_service.LanguageService()
 
     def _fix_author_particles(self, record: colrev.record.record.Record) -> None:

--- a/colrev/loader/load_utils_name_formatter.py
+++ b/colrev/loader/load_utils_name_formatter.py
@@ -47,6 +47,7 @@ class NameParser:
     """Parse a name string."""
 
     def __init__(self, name: str) -> None:
+        """Initialize the instance."""
         self._first: list[str] = []
         self._middle: list[str] = []
         self._prelast: list[str] = []

--- a/colrev/loader/loader.py
+++ b/colrev/loader/loader.py
@@ -26,6 +26,7 @@ class Loader:
         logger: logging.Logger,
         format_names: bool = False,
     ):
+        """Initialize the instance."""
         self.filename = filename
         self.unique_id_field = unique_id_field
         assert id_labeler is not None or unique_id_field != ""

--- a/colrev/loader/nbib.py
+++ b/colrev/loader/nbib.py
@@ -40,7 +40,7 @@ class NBIBLoader(colrev.loader.loader.Loader):
         logger: logging.Logger = logging.getLogger(__name__),
         format_names: bool = False,
     ):
-
+        """Initialize the instance."""
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,

--- a/colrev/loader/ris.py
+++ b/colrev/loader/ris.py
@@ -40,6 +40,7 @@ class RISLoader(colrev.loader.loader.Loader):
         logger: logging.Logger = logging.getLogger(__name__),
         format_names: bool = False,
     ):
+        """Initialize the instance."""
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,

--- a/colrev/loader/table.py
+++ b/colrev/loader/table.py
@@ -30,7 +30,7 @@ class TableLoader(colrev.loader.loader.Loader):
         logger: logging.Logger = logging.getLogger(__name__),
         format_names: bool = False,
     ):
-
+        """Initialize the instance."""
         super().__init__(
             filename=filename,
             id_labeler=id_labeler,

--- a/colrev/ops/advisor.py
+++ b/colrev/ops/advisor.py
@@ -48,6 +48,7 @@ class Advisor:
         *,
         review_manager: colrev.review_manager.ReviewManager,
     ) -> None:
+        """Initialize the instance."""
         self.review_manager = review_manager
         colrev.ops.check.CheckOperation(self.review_manager)
         self.records = self.review_manager.dataset.load_records_dict()

--- a/colrev/ops/check.py
+++ b/colrev/ops/check.py
@@ -20,6 +20,7 @@ class CheckOperation(colrev.process.operation.Operation):
     type = OperationsType.check
 
     def __init__(self, review_manager: colrev.review_manager.ReviewManager) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/checker.py
+++ b/colrev/ops/checker.py
@@ -36,6 +36,7 @@ class Checker:
         *,
         review_manager: colrev.review_manager.ReviewManager,
     ) -> None:
+        """Initialize the instance."""
         self.review_manager = review_manager
         self.review_manager.notified_next_operation = OperationsType.check
 

--- a/colrev/ops/commit.py
+++ b/colrev/ops/commit.py
@@ -49,6 +49,7 @@ class Commit:
         saved_args: typing.Optional[dict] = None,
         skip_hooks: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.review_manager = review_manager
         self.msg = msg
         self.manual_author = manual_author

--- a/colrev/ops/correct.py
+++ b/colrev/ops/correct.py
@@ -57,6 +57,7 @@ class Corrections:
         *,
         review_manager: colrev.review_manager.ReviewManager,
     ) -> None:
+        """Initialize the instance."""
         self.review_manager = review_manager
         self.corrections_path = self.review_manager.paths.corrections
         self.corrections_path.mkdir(exist_ok=True)

--- a/colrev/ops/custom_scripts/custom_data_script.py
+++ b/colrev/ops/custom_scripts/custom_data_script.py
@@ -19,6 +19,7 @@ class CustomData(base_classes.DataPackageBaseClass):
         data_operation: colrev.ops.data.Data,  # pylint: disable=unused-argument
         settings: dict,
     ) -> None:
+        """Initialize the instance."""
         self.settings = self.settings_class(**settings)
         self.data_operation = data_operation
 

--- a/colrev/ops/custom_scripts/custom_pdf_get_script.py
+++ b/colrev/ops/custom_scripts/custom_pdf_get_script.py
@@ -22,6 +22,7 @@ class CustomPDFGet(base_classes.PDFGetPackageBaseClass):
         pdf_get_operation: colrev.ops.pdf_get.PDFGet,  # pylint: disable=unused-argument
         settings: dict,
     ) -> None:
+        """Initialize the instance."""
         self.settings = self.settings_class(**settings)
         self.pdf_get_operation = pdf_get_operation
 

--- a/colrev/ops/custom_scripts/custom_pdf_prep_script.py
+++ b/colrev/ops/custom_scripts/custom_pdf_prep_script.py
@@ -26,6 +26,7 @@ class CustomPDFPrep(base_classes.PDFPrepPackageBaseClass):
         pdf_prep_operation: colrev.ops.pdf_prep.PDFPrep,
         settings: dict,
     ) -> None:
+        """Initialize the instance."""
         self.settings = self.settings_class(**settings)
         self.pdf_prep_operation = pdf_prep_operation
 

--- a/colrev/ops/custom_scripts/custom_prep_script.py
+++ b/colrev/ops/custom_scripts/custom_prep_script.py
@@ -26,6 +26,7 @@ class CustomPrep(base_classes.PrepPackageBaseClass):
         prep_operation: colrev.ops.prep.Prep,
         settings: dict,
     ) -> None:
+        """Initialize the instance."""
         self.settings = self.settings_class(**settings)
 
     def prepare(

--- a/colrev/ops/custom_scripts/custom_prescreen_script.py
+++ b/colrev/ops/custom_scripts/custom_prescreen_script.py
@@ -24,6 +24,7 @@ class CustomPrescreen(base_classes.PrescreenPackageBaseClass):
         prescreen_operation: colrev.ops.prescreen.Prescreen,  # pylint: disable=unused-argument
         settings: dict,
     ) -> None:
+        """Initialize the instance."""
         self.settings = self.settings_class(**settings)
         self.prescreen_operation = prescreen_operation
 

--- a/colrev/ops/custom_scripts/custom_screen_script.py
+++ b/colrev/ops/custom_scripts/custom_screen_script.py
@@ -29,6 +29,7 @@ class CustomScreen(base_classes.ScreenPackageBaseClass):
         screen_operation: colrev.screen.Screen,  # pylint: disable=unused-argument
         settings: dict,
     ) -> None:
+        """Initialize the instance."""
         self.settings = self.settings_class(**settings)
         self.screen_operation = screen_operation
 

--- a/colrev/ops/custom_scripts/custom_search_source_script.py
+++ b/colrev/ops/custom_scripts/custom_search_source_script.py
@@ -25,6 +25,7 @@ class CustomSearch(base_classes.SearchSourcePackageBaseClass):
         *,
         settings: colrev.search_file.ExtendedSearchFile,
     ) -> None:
+        """Initialize the instance."""
         self.search_source: colrev.search_file.ExtendedSearchFile = settings
 
     def search(self, rerun: bool) -> None:

--- a/colrev/ops/data.py
+++ b/colrev/ops/data.py
@@ -32,6 +32,7 @@ class Data(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/dedupe.py
+++ b/colrev/ops/dedupe.py
@@ -66,6 +66,7 @@ class Dedupe(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/distribute.py
+++ b/colrev/ops/distribute.py
@@ -25,6 +25,7 @@ class Distribute(colrev.process.operation.Operation):
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
         # pylint: disable=duplicate-code
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/init.py
+++ b/colrev/ops/init.py
@@ -51,6 +51,7 @@ class Initializer:
         light: bool = False,
         exact_call: str = "",
     ) -> None:
+        """Initialize the instance."""
         p_man = PackageManager()
         self.review_type = self._format_review_type(review_type)
         if not p_man.is_installed(self.review_type):

--- a/colrev/ops/load.py
+++ b/colrev/ops/load.py
@@ -36,6 +36,7 @@ class Load(colrev.process.operation.Operation):
         notify_state_transition_operation: bool = True,
         hide_load_explanation: bool = False,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/merge.py
+++ b/colrev/ops/merge.py
@@ -27,6 +27,7 @@ class Merge(colrev.process.operation.Operation):
         *,
         review_manager: colrev.review_manager.ReviewManager,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/pdf_get.py
+++ b/colrev/ops/pdf_get.py
@@ -183,6 +183,7 @@ class PDFGet(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/pdf_get_man.py
+++ b/colrev/ops/pdf_get_man.py
@@ -34,6 +34,7 @@ class PDFGetMan(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/pdf_prep.py
+++ b/colrev/ops/pdf_prep.py
@@ -43,6 +43,7 @@ class PDFPrep(colrev.process.operation.Operation):
         reprocess: bool = False,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/pdf_prep_man.py
+++ b/colrev/ops/pdf_prep_man.py
@@ -33,6 +33,7 @@ class PDFPrepMan(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/prep.py
+++ b/colrev/ops/prep.py
@@ -105,6 +105,7 @@ class Prep(colrev.process.operation.Operation):
         polish: bool,
         cpu: int,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/prep_debug.py
+++ b/colrev/ops/prep_debug.py
@@ -42,7 +42,7 @@ class PrepDebug(colrev.ops.prep.Prep):
         notify_state_transition_operation: bool,
         polish: bool,
     ) -> None:
-
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             notify_state_transition_operation=notify_state_transition_operation,

--- a/colrev/ops/prep_man.py
+++ b/colrev/ops/prep_man.py
@@ -32,6 +32,7 @@ class PrepMan(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/prescreen.py
+++ b/colrev/ops/prescreen.py
@@ -33,6 +33,7 @@ class Prescreen(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/pull.py
+++ b/colrev/ops/pull.py
@@ -18,6 +18,7 @@ class Pull(colrev.process.operation.Operation):
     type = OperationsType.format
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/push.py
+++ b/colrev/ops/push.py
@@ -21,6 +21,7 @@ class Push(colrev.process.operation.Operation):
     type = OperationsType.check
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/remove.py
+++ b/colrev/ops/remove.py
@@ -21,6 +21,7 @@ class Remove(colrev.process.operation.Operation):
         *,
         review_manager: colrev.review_manager.ReviewManager,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/repare.py
+++ b/colrev/ops/repare.py
@@ -32,6 +32,7 @@ class Repare(colrev.process.operation.Operation):
         *,
         review_manager: colrev.review_manager.ReviewManager,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/screen.py
+++ b/colrev/ops/screen.py
@@ -29,6 +29,7 @@ class Screen(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/search.py
+++ b/colrev/ops/search.py
@@ -30,6 +30,7 @@ class Search(colrev.process.operation.Operation):
         review_manager: colrev.review_manager.ReviewManager,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/search_api_feed.py
+++ b/colrev/ops/search_api_feed.py
@@ -83,6 +83,7 @@ class SearchAPIFeed:
         verbose_mode: bool = False,
         records: typing.Optional[dict] = None,
     ):
+        """Initialize the instance."""
         self.source = search_source
         self.feed_file = Path(search_source.search_results_path)
 

--- a/colrev/ops/search_db.py
+++ b/colrev/ops/search_db.py
@@ -21,11 +21,13 @@ from colrev.package_manager.package_manager import PackageManager
 
 class _Paths:
     def __init__(self, root: Path) -> None:
+        """Initialize the instance."""
         self.git_ignore = root / ".gitignore"
 
 
 class _ReviewManagerStub:
     def __init__(self, root: Path) -> None:
+        """Initialize the instance."""
         self.path = root
         self.paths = _Paths(root)
 

--- a/colrev/ops/status.py
+++ b/colrev/ops/status.py
@@ -20,6 +20,7 @@ class Status(colrev.process.operation.Operation):
     type = OperationsType.check
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/trace.py
+++ b/colrev/ops/trace.py
@@ -23,6 +23,7 @@ class Trace(colrev.process.operation.Operation):
     type = OperationsType.check
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/ops/upgrade.py
+++ b/colrev/ops/upgrade.py
@@ -43,6 +43,7 @@ class Upgrade(colrev.process.operation.Operation):
         *,
         review_manager: colrev.review_manager.ReviewManager,
     ) -> None:
+        """Initialize the instance."""
         prev_force_mode = review_manager.force_mode
         review_manager.force_mode = True
         super().__init__(
@@ -945,6 +946,7 @@ class CoLRevVersion:
     """Class for handling the CoLRev version."""
 
     def __init__(self, version_string: str) -> None:
+        """Initialize the instance."""
         if "+" in version_string:
             version_string = version_string[: version_string.find("+")]
         assert re.match(r"\d+\.\d+\.\d+$", version_string)
@@ -955,6 +957,7 @@ class CoLRevVersion:
         self.patch = int(version_string[version_string.rfind(".") + 1 :])
 
     def __eq__(self, other) -> bool:  # type: ignore
+        """Return whether two instances are equal."""
         return (
             self.major == other.major
             and self.minor == other.minor
@@ -962,6 +965,7 @@ class CoLRevVersion:
         )
 
     def __lt__(self, other) -> bool:  # type: ignore
+        """Return whether this instance is less than another."""
         if self.major < other.major:
             return True
         if self.major == other.major and self.minor < other.minor:
@@ -988,4 +992,5 @@ class CoLRevVersion:
         return False
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return f"{self.major}.{self.minor}.{self.patch}"

--- a/colrev/ops/validate.py
+++ b/colrev/ops/validate.py
@@ -25,6 +25,7 @@ class Validate(colrev.process.operation.Operation):
     type = OperationsType.check
 
     def __init__(self, *, review_manager: colrev.review_manager.ReviewManager) -> None:
+        """Initialize the instance."""
         super().__init__(
             review_manager=review_manager,
             operations_type=self.type,

--- a/colrev/package_manager/doc_registry_manager.py
+++ b/colrev/package_manager/doc_registry_manager.py
@@ -52,6 +52,7 @@ class PackageDoc:
     docs_rst_path: Path
 
     def __init__(self, package_id: str) -> None:
+        """Initialize the instance."""
         self.package_id = package_id
 
         methods = [
@@ -328,6 +329,7 @@ class PackageDoc:
         return item
 
     def __repr__(self) -> str:
+        """Return a developer representation."""
         package_str = f"Package name: {self.package_id}\n"
         package_str += f"Package license: {self.license}\n"
         package_str += f"Package endpoints: {self.endpoints}\n"
@@ -371,6 +373,7 @@ class DocRegistryManager:
     packages_data: typing.Dict[str, dict] = {}
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         self.packages: typing.List[PackageDoc] = []
 
         with open(Filepaths.PACKAGES_JSON, encoding="utf-8") as file:

--- a/colrev/package_manager/package.py
+++ b/colrev/package_manager/package.py
@@ -26,6 +26,7 @@ class Package:
     """A Python package for CoLRev."""
 
     def __init__(self, package_identifier: str) -> None:
+        """Initialize the instance."""
         try:
             self.package = distribution(package_identifier)
         except PackageNotFoundError as exc:

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -45,7 +45,6 @@ class ReviewTypePackageBaseClass(abc.ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def initialize(self, settings: colrev.settings.Settings) -> dict:
@@ -83,7 +82,6 @@ class SearchSourcePackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @classmethod
     @abstractmethod
@@ -153,7 +151,6 @@ class PrepPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def prepare(
@@ -185,7 +182,6 @@ class PrepManPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def prepare_manual(self, records: dict) -> dict:
@@ -214,7 +210,6 @@ class DedupePackageBaseClass(ABC):
         verbose_mode: bool = False,
     ):
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def run_dedupe(self) -> None:
@@ -244,7 +239,6 @@ class PrescreenPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def run_prescreen(self, records: dict, split: list) -> dict:
@@ -273,7 +267,6 @@ class PDFGetPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def get_pdf(
@@ -304,7 +297,6 @@ class PDFGetManPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def pdf_get_man(self, records: dict) -> dict:
@@ -333,7 +325,6 @@ class PDFPrepPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def prep_pdf(
@@ -364,7 +355,6 @@ class PDFPrepManPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def pdf_prep_man(self, records: dict) -> dict:
@@ -394,7 +384,6 @@ class ScreenPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def run_screen(self, records: dict, split: list) -> dict:
@@ -423,7 +412,6 @@ class DataPackageBaseClass(ABC):
         verbose_mode: bool = False,
     ) -> None:
         """Initialize the instance."""
-        pass
 
     @abstractmethod
     def update_data(

--- a/colrev/package_manager/package_base_classes.py
+++ b/colrev/package_manager/package_base_classes.py
@@ -44,6 +44,7 @@ class ReviewTypePackageBaseClass(abc.ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -81,6 +82,7 @@ class SearchSourcePackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @classmethod
@@ -150,6 +152,7 @@ class PrepPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -181,6 +184,7 @@ class PrepManPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -209,6 +213,7 @@ class DedupePackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ):
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -238,6 +243,7 @@ class PrescreenPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -266,6 +272,7 @@ class PDFGetPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -296,6 +303,7 @@ class PDFGetManPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -324,6 +332,7 @@ class PDFPrepPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -354,6 +363,7 @@ class PDFPrepManPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -383,6 +393,7 @@ class ScreenPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod
@@ -411,6 +422,7 @@ class DataPackageBaseClass(ABC):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         pass
 
     @abstractmethod

--- a/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
+++ b/colrev/packages/abi_inform_proquest/src/abi_inform_proquest.py
@@ -44,6 +44,7 @@ class ABIInformProQuestSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/packages/acm_digital_library/src/acm_digital_library.py
+++ b/colrev/packages/acm_digital_library/src/acm_digital_library.py
@@ -46,6 +46,7 @@ class ACMDigitalLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
+++ b/colrev/packages/add_journal_ranking/src/add_journal_ranking.py
@@ -33,6 +33,7 @@ class AddJournalRanking(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.local_index = colrev.env.local_index.LocalIndex()

--- a/colrev/packages/ais_library/src/aisel.py
+++ b/colrev/packages/ais_library/src/aisel.py
@@ -80,6 +80,7 @@ class AISeLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/ais_library/src/aisel_api.py
+++ b/colrev/packages/ais_library/src/aisel_api.py
@@ -28,6 +28,7 @@ class AISeLAPI:
         session: typing.Optional[requests.Session] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
     ) -> None:
+        """Initialize the instance."""
         self.search_file = search_file
         self.session = session or requests.Session()
         self.headers = headers or {}

--- a/colrev/packages/arxiv/src/arxiv.py
+++ b/colrev/packages/arxiv/src/arxiv.py
@@ -51,6 +51,7 @@ class ArXivSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/arxiv/src/arxiv_api.py
+++ b/colrev/packages/arxiv/src/arxiv_api.py
@@ -28,6 +28,7 @@ class ArxivAPI:
         search_file: colrev.search_file.ExtendedSearchFile,
         session: typing.Optional[requests.Session] = None,
     ) -> None:
+        """Initialize the instance."""
         self.session = session or requests.Session()
         self.search_file = search_file
 

--- a/colrev/packages/bibliography_export/src/bibliography_export.py
+++ b/colrev/packages/bibliography_export/src/bibliography_export.py
@@ -67,6 +67,7 @@ class BibliographyExport(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
 

--- a/colrev/packages/blank/src/blank.py
+++ b/colrev/packages/blank/src/blank.py
@@ -27,10 +27,12 @@ class BlankReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "blank review"
 
     def initialize(

--- a/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
+++ b/colrev/packages/cli_prep_man/src/cli_prep_man_prep_man.py
@@ -26,6 +26,7 @@ class CliPrepMan(PrepManPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> "None":
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         """Initialize self.  See help(type(self)) for accurate signature."""
 

--- a/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_get_man/src/pdf_get_man_cli.py
@@ -37,6 +37,7 @@ class CoLRevCLIPDFGetMan(base_classes.PDFGetManPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_man_operation.review_manager

--- a/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
+++ b/colrev/packages/colrev_cli_pdf_prep_man/src/pdf_prep_man_cli.py
@@ -42,6 +42,7 @@ class CoLRevCLIPDFManPrep(base_classes.PDFPrepManPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_man_operation.review_manager

--- a/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
+++ b/colrev/packages/colrev_cli_prescreen/src/prescreen_cli.py
@@ -66,6 +66,7 @@ class CoLRevCLIPrescreen(base_classes.PrescreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prescreen_operation = prescreen_operation

--- a/colrev/packages/colrev_cli_screen/src/screen_cli.py
+++ b/colrev/packages/colrev_cli_screen/src/screen_cli.py
@@ -37,6 +37,7 @@ class CoLRevCLIScreen(base_classes.ScreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = screen_operation.review_manager
         self.screen_operation = screen_operation

--- a/colrev/packages/colrev_curation/src/colrev_curation.py
+++ b/colrev/packages/colrev_curation/src/colrev_curation.py
@@ -49,6 +49,7 @@ class ColrevCuration(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         # Set default values (if necessary)
         if "version" not in settings:

--- a/colrev/packages/colrev_curation/src/curation_prep.py
+++ b/colrev/packages/colrev_curation/src/curation_prep.py
@@ -36,6 +36,7 @@ class CurationPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/colrev_project/src/colrev_project.py
+++ b/colrev/packages/colrev_project/src/colrev_project.py
@@ -51,6 +51,7 @@ class ColrevProjectSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/conceptual_review/src/conceptual_review.py
+++ b/colrev/packages/conceptual_review/src/conceptual_review.py
@@ -28,10 +28,12 @@ class ConceptualReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "conceptual review"
 
     def initialize(

--- a/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
+++ b/colrev/packages/conditional_prescreen/src/conditional_prescreen.py
@@ -31,6 +31,7 @@ class ConditionalPrescreen(base_classes.PrescreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = prescreen_operation.review_manager

--- a/colrev/packages/critical_review/src/critical_review.py
+++ b/colrev/packages/critical_review/src/critical_review.py
@@ -27,10 +27,12 @@ class CriticalReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "critical review"
 
     def initialize(

--- a/colrev/packages/crossref/src/crossref_api.py
+++ b/colrev/packages/crossref/src/crossref_api.py
@@ -47,6 +47,7 @@ class HTTPRequest:
     """HTTP Request."""
 
     def __init__(self, *, timeout: int, cache: bool = True) -> None:
+        """Initialize the instance."""
         self.rate_limits = {"x-rate-limit-limit": 50, "x-rate-limit-interval": 1}
         self.timeout = timeout
         self.cache = cache
@@ -120,7 +121,7 @@ class Endpoint:
         cache: bool = True,
         crossref_plus_token: str = "",
     ) -> None:
-
+        """Initialize the instance."""
         self.httpr = HTTPRequest(timeout=60, cache=cache)
 
         self.headers = {
@@ -229,7 +230,7 @@ class Endpoint:
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-return-statements
     def __iter__(self) -> typing.Iterator[dict]:
-
+        """Return an iterator."""
         request_url = str(self.request_url)
 
         if request_url.startswith("https://api.crossref.org/works/"):
@@ -329,6 +330,7 @@ class CrossrefAPI:
         rerun: bool = False,
         cache: typing.Optional[bool] = None,
     ):
+        """Initialize the instance."""
         assert url.startswith(self._api_url)
         self.url = url
 

--- a/colrev/packages/crossref/src/crossref_prep.py
+++ b/colrev/packages/crossref/src/crossref_prep.py
@@ -42,6 +42,7 @@ class CrossrefMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/crossref/src/crossref_search_source.py
+++ b/colrev/packages/crossref/src/crossref_search_source.py
@@ -61,6 +61,7 @@ class CrossrefSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/curated_masterdata/src/curated_masterdata.py
+++ b/colrev/packages/curated_masterdata/src/curated_masterdata.py
@@ -30,11 +30,13 @@ class CuratedMasterdata(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = operation.review_manager
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "curated masterdata repository"
 
     def initialize(

--- a/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
+++ b/colrev/packages/curation_full_outlet_dedupe/src/curation_dedupe.py
@@ -49,6 +49,7 @@ class CurationDedupe(base_classes.DedupePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ):
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.dedupe_operation = dedupe_operation

--- a/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
+++ b/colrev/packages/curation_missing_dedupe/src/curation_missing_dedupe.py
@@ -37,6 +37,7 @@ class CurationMissingDedupe(base_classes.DedupePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ):
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = dedupe_operation.review_manager

--- a/colrev/packages/dblp/src/dblp.py
+++ b/colrev/packages/dblp/src/dblp.py
@@ -81,6 +81,7 @@ class DBLPSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/dblp/src/dblp_api.py
+++ b/colrev/packages/dblp/src/dblp_api.py
@@ -39,6 +39,7 @@ class DBLPAPI:
         rerun: bool = False,
         timeout: int = 60,
     ):
+        """Initialize the instance."""
         self.params = params
         self.email = email
         self.session = session

--- a/colrev/packages/dblp/src/dblp_metadata_prep.py
+++ b/colrev/packages/dblp/src/dblp_metadata_prep.py
@@ -40,6 +40,7 @@ class DBLPMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/dedupe/src/dedupe.py
+++ b/colrev/packages/dedupe/src/dedupe.py
@@ -40,6 +40,7 @@ class Dedupe(base_classes.DedupePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ):
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)

--- a/colrev/packages/descriptive_review/src/descriptive_review.py
+++ b/colrev/packages/descriptive_review/src/descriptive_review.py
@@ -27,10 +27,12 @@ class DescriptiveReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "descriptive review"
 
     def initialize(

--- a/colrev/packages/download_from_website/src/download_from_website.py
+++ b/colrev/packages/download_from_website/src/download_from_website.py
@@ -44,6 +44,7 @@ class WebsiteDownload(base_classes.PDFGetPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_operation.review_manager

--- a/colrev/packages/ebsco_host/src/ebsco_host.py
+++ b/colrev/packages/ebsco_host/src/ebsco_host.py
@@ -47,6 +47,7 @@ class EbscoHostSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
         self.validate_source(self.search_source)

--- a/colrev/packages/eric/src/eric.py
+++ b/colrev/packages/eric/src/eric.py
@@ -51,6 +51,7 @@ class ERICSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/eric/src/eric_api.py
+++ b/colrev/packages/eric/src/eric_api.py
@@ -54,6 +54,7 @@ class ERICAPI:
     FIELD_MAPPING = {"publicationdateyear": "year", "description": "abstract"}
 
     def __init__(self, params: dict) -> None:
+        """Initialize the instance."""
         self.params = params
         self.language_service = colrev.env.language_service.LanguageService()
 

--- a/colrev/packages/europe_pmc/src/europe_pmc.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc.py
@@ -63,6 +63,7 @@ class EuropePMCSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/europe_pmc/src/europe_pmc_api.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc_api.py
@@ -23,6 +23,7 @@ class EPMCAPI:
     """Connector for the Europe PMC API."""
 
     def __init__(self, params: dict, email: str, session: requests.Session) -> None:
+        """Initialize the instance."""
         self.params = params
 
         self.url = (

--- a/colrev/packages/europe_pmc/src/europe_pmc_prep.py
+++ b/colrev/packages/europe_pmc/src/europe_pmc_prep.py
@@ -38,6 +38,7 @@ class EuropePMCMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/exclude_collections/src/exclude_collections.py
+++ b/colrev/packages/exclude_collections/src/exclude_collections.py
@@ -35,6 +35,7 @@ class ExcludeCollectionsPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
+++ b/colrev/packages/exclude_complementary_materials/src/exclude_complementary_materials.py
@@ -37,6 +37,7 @@ class ExcludeComplementaryMaterialsPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/exclude_languages/src/exclude_languages.py
+++ b/colrev/packages/exclude_languages/src/exclude_languages.py
@@ -38,6 +38,7 @@ class ExcludeLanguagesPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
+++ b/colrev/packages/exclude_non_latin_alphabets/src/exclude_non_latin_alphabets.py
@@ -38,6 +38,7 @@ class ExcludeNonLatinAlphabetsPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/export_man_prep/src/prep_man_export.py
+++ b/colrev/packages/export_man_prep/src/prep_man_export.py
@@ -77,6 +77,7 @@ class ExportManPrep(base_classes.PrepManPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         if "pdf_handling_mode" not in settings:
             settings["pdf_handling_mode"] = "symlink"

--- a/colrev/packages/files_dir/src/files_dir.py
+++ b/colrev/packages/files_dir/src/files_dir.py
@@ -60,6 +60,7 @@ class FilesSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/genai/src/genai_data.py
+++ b/colrev/packages/genai/src/genai_data.py
@@ -47,6 +47,7 @@ class GenAIData(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
         self.data_operation = data_operation

--- a/colrev/packages/genai/src/genai_prescreen.py
+++ b/colrev/packages/genai/src/genai_prescreen.py
@@ -65,6 +65,7 @@ class GenAIPrescreen(base_classes.PrescreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = prescreen_operation.review_manager
         self.settings = self.settings_class(**settings)

--- a/colrev/packages/genai/src/genai_screen.py
+++ b/colrev/packages/genai/src/genai_screen.py
@@ -31,6 +31,7 @@ class GenAIScreen(base_classes.ScreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = screen_operation.review_manager
         self.screen_operation = screen_operation

--- a/colrev/packages/general_polish/src/general_polish.py
+++ b/colrev/packages/general_polish/src/general_polish.py
@@ -57,6 +57,7 @@ class GeneralPolishPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
+++ b/colrev/packages/get_doi_from_urls/src/doi_from_urls_prep.py
@@ -47,6 +47,7 @@ class DOIFromURLsPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
+++ b/colrev/packages/get_masterdata_from_citeas/src/citeas_prep.py
@@ -44,6 +44,7 @@ class CiteAsPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
+++ b/colrev/packages/get_masterdata_from_doi/src/doi_metadata_prep.py
@@ -38,6 +38,7 @@ class DOIMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
+++ b/colrev/packages/get_year_from_vol_iss_jour/src/year_vol_iss_prep.py
@@ -71,6 +71,7 @@ class YearVolIssPrep(base_classes.PrepPackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)

--- a/colrev/packages/github/src/github_prep.py
+++ b/colrev/packages/github/src/github_prep.py
@@ -39,6 +39,7 @@ class GithubMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/github/src/github_search_source.py
+++ b/colrev/packages/github/src/github_search_source.py
@@ -67,6 +67,7 @@ class GitHubSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/github_pages/src/github_pages.py
+++ b/colrev/packages/github_pages/src/github_pages.py
@@ -58,6 +58,7 @@ class GithubPages(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         # Set default values (if necessary)
         if "version" not in settings:

--- a/colrev/packages/google_scholar/src/google_scholar.py
+++ b/colrev/packages/google_scholar/src/google_scholar.py
@@ -43,6 +43,7 @@ class GoogleScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/packages/grobid_tei/src/grobid_tei.py
+++ b/colrev/packages/grobid_tei/src/grobid_tei.py
@@ -36,6 +36,7 @@ class GROBIDTEI(base_classes.PDFPrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager

--- a/colrev/packages/ieee/src/ieee.py
+++ b/colrev/packages/ieee/src/ieee.py
@@ -58,6 +58,7 @@ class IEEEXploreSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/ieee/src/ieee_api.py
+++ b/colrev/packages/ieee/src/ieee_api.py
@@ -102,6 +102,7 @@ class XPLORE:
 
     def __init__(self, *, parameters: dict, api_key: str) -> None:
         # API key
+        """Initialize the instance."""
         self.apiKey = api_key
 
         # flag that some search criteria has been provided

--- a/colrev/packages/jstor/src/jstor.py
+++ b/colrev/packages/jstor/src/jstor.py
@@ -43,6 +43,7 @@ class JSTORSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/packages/literature_review/src/literature_review.py
+++ b/colrev/packages/literature_review/src/literature_review.py
@@ -29,10 +29,12 @@ class LiteratureReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "literature review"
 
     def initialize(

--- a/colrev/packages/local_index/src/local_index.py
+++ b/colrev/packages/local_index/src/local_index.py
@@ -70,6 +70,7 @@ class LocalIndexSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/local_index/src/local_index_pdf_get.py
+++ b/colrev/packages/local_index/src/local_index_pdf_get.py
@@ -35,6 +35,7 @@ class LocalIndexPDFGet(base_classes.PDFGetPackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)

--- a/colrev/packages/local_index/src/local_index_prep.py
+++ b/colrev/packages/local_index/src/local_index_prep.py
@@ -44,6 +44,7 @@ class LocalIndexPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/meta_analysis/src/meta_analysis.py
+++ b/colrev/packages/meta_analysis/src/meta_analysis.py
@@ -33,10 +33,12 @@ class MetaAnalysis(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "meta-analysis"
 
     def initialize(

--- a/colrev/packages/methodological_review/src/methodological_review.py
+++ b/colrev/packages/methodological_review/src/methodological_review.py
@@ -27,10 +27,12 @@ class MethodologicalReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "methodological review"
 
     def initialize(

--- a/colrev/packages/narrative_review/src/narrative_review.py
+++ b/colrev/packages/narrative_review/src/narrative_review.py
@@ -27,10 +27,12 @@ class NarrativeReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "narrative review"
 
     def initialize(

--- a/colrev/packages/obsidian/src/obsidian.py
+++ b/colrev/packages/obsidian/src/obsidian.py
@@ -59,6 +59,7 @@ class Obsidian(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
         self.data_operation = data_operation

--- a/colrev/packages/ocrmypdf/src/ocrmypdf.py
+++ b/colrev/packages/ocrmypdf/src/ocrmypdf.py
@@ -38,6 +38,7 @@ class OCRMyPDF(base_classes.PDFPrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager

--- a/colrev/packages/open_alex/src/open_alex.py
+++ b/colrev/packages/open_alex/src/open_alex.py
@@ -44,6 +44,7 @@ class OpenAlexSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/open_alex/src/open_alex_api.py
+++ b/colrev/packages/open_alex/src/open_alex_api.py
@@ -30,6 +30,7 @@ class OpenAlexAPI:
         # query: typing.Optional[str] = None,
         # timeout: int = 60,
     ):
+        """Initialize the instance."""
         pyalex.config.email = email
         self.language_service = colrev.env.language_service.LanguageService()
 

--- a/colrev/packages/open_alex/src/open_alex_metadata_prep.py
+++ b/colrev/packages/open_alex/src/open_alex_metadata_prep.py
@@ -38,6 +38,7 @@ class OpenAlexMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/open_citations_forward_search/src/open_citations_api.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_api.py
@@ -23,6 +23,7 @@ class OpenCitationsAPI:
         session: typing.Optional[requests.Session] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
     ) -> None:
+        """Initialize the instance."""
         self.session = session or requests.Session()
         # headers = {"authorization": "YOUR-OPENCITATIONS-ACCESS-TOKEN"}
         self.headers: typing.Dict[str, str] = headers or {}

--- a/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
+++ b/colrev/packages/open_citations_forward_search/src/open_citations_forward_search.py
@@ -48,6 +48,7 @@ class OpenCitationsSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/open_library/src/open_library.py
+++ b/colrev/packages/open_library/src/open_library.py
@@ -57,6 +57,7 @@ class OpenLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/open_library/src/open_library_api.py
+++ b/colrev/packages/open_library/src/open_library_api.py
@@ -23,6 +23,7 @@ class OpenLibraryAPI:
         session: typing.Optional[requests.Session] = None,
         headers: typing.Optional[dict] = None,
     ) -> None:
+        """Initialize the instance."""
         self.session = session or requests.Session()
         self.headers = headers or {}
 

--- a/colrev/packages/open_library/src/open_library_prep.py
+++ b/colrev/packages/open_library/src/open_library_prep.py
@@ -37,6 +37,7 @@ class OpenLibraryMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/osf/src/osf.py
+++ b/colrev/packages/osf/src/osf.py
@@ -54,6 +54,7 @@ class OSFSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/osf/src/osf_api.py
+++ b/colrev/packages/osf/src/osf_api.py
@@ -18,6 +18,7 @@ class OSFApiQuery:
     fields = ["id", "type", "title", "year", "description", "tags", "date_created"]
 
     def __init__(self, *, parameters: dict, api_key: str) -> None:
+        """Initialize the instance."""
         self.api_key = api_key
         self.headers = {"Authorization": f"Bearer {self.api_key}"}
         self.params: typing.Dict[str, str] = {}

--- a/colrev/packages/paper_md/src/paper_md.py
+++ b/colrev/packages/paper_md/src/paper_md.py
@@ -95,6 +95,7 @@ class PaperMarkdown(base_classes.DataPackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.data_operation = data_operation
@@ -857,5 +858,6 @@ class PaperMarkdownRecordSourceTagError(Exception):
     """NEW_RECORD_SOURCE_TAG not found in paper.md."""
 
     def __init__(self, msg: str) -> None:
+        """Initialize the instance."""
         self.message = f" {msg}"
         super().__init__(self.message)

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search.py
@@ -62,6 +62,7 @@ class BackwardSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/pdf_backward_search/src/pdf_backward_search_api.py
+++ b/colrev/packages/pdf_backward_search/src/pdf_backward_search_api.py
@@ -23,6 +23,7 @@ class PDFBackwardSearchAPI:
         session: typing.Optional[requests.Session] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
     ) -> None:
+        """Initialize the instance."""
         self.session = session or requests.Session()
         self.headers = headers or {}
 

--- a/colrev/packages/plos/src/plos_api.py
+++ b/colrev/packages/plos/src/plos_api.py
@@ -51,6 +51,7 @@ class HTTPRequest:
     def __init__(self, *, timeout: int) -> None:
         # https://api.plos.org/solr/faq/
         # 10 request per minute (60s)
+        """Initialize the instance."""
         self.rate_limits = {"x-rate-limit-limit": 10, "x-rate-limit-interval": 60}
         self.timeout = timeout
 
@@ -114,7 +115,7 @@ class Endpoint:
         email: str = "",
         plos_plus_token: str = "",
     ) -> None:
-
+        """Initialize the instance."""
         self.retrieve = HTTPRequest(timeout=60).retrieve
 
         # List of http headers
@@ -199,6 +200,7 @@ class Endpoint:
         return req.url
 
     def __iter__(self) -> typing.Iterator[dict]:
+        """Return an iterator."""
         request_url = str(self.request_url)
         if request_url.startswith("https://api.plos.org/search?q=doi:10"):
             result = self.retrieve(request_url, headers=self.headers)
@@ -280,6 +282,7 @@ class PlosAPI:
         url: str,
         rerun: bool = False,
     ):
+        """Initialize the instance."""
         self.url = url
 
         _, self.email = (

--- a/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
+++ b/colrev/packages/prep_man_curation_jupyter/src/curation_jupyter_prep_man.py
@@ -30,6 +30,7 @@ class CurationJupyterNotebookManPrep(base_classes.PrepManPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 

--- a/colrev/packages/prescreen_table/src/prescreen_table.py
+++ b/colrev/packages/prescreen_table/src/prescreen_table.py
@@ -36,6 +36,7 @@ class TablePrescreen(base_classes.PrescreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = prescreen_operation.review_manager
         self.settings = self.settings_class(**settings)

--- a/colrev/packages/prisma/src/prisma.py
+++ b/colrev/packages/prisma/src/prisma.py
@@ -52,6 +52,7 @@ class PRISMA(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
         self.data_operation = data_operation

--- a/colrev/packages/profile/src/profile.py
+++ b/colrev/packages/profile/src/profile.py
@@ -40,6 +40,7 @@ class Profile(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
         self.data_operation = data_operation

--- a/colrev/packages/prospero/src/prospero_api.py
+++ b/colrev/packages/prospero/src/prospero_api.py
@@ -28,7 +28,7 @@ class PROSPEROAPI:
     URL_PREFIX = "https://www.crd.york.ac.uk/prospero/display_record.php?RecordID="
 
     def __init__(self, search_word: str, logger: logging.Logger) -> None:
-
+        """Initialize the instance."""
         self.search_word = search_word
 
         self.logger = logger

--- a/colrev/packages/psycinfo/src/psycinfo.py
+++ b/colrev/packages/psycinfo/src/psycinfo.py
@@ -43,6 +43,7 @@ class PsycINFOSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/packages/pubmed/src/pubmed.py
+++ b/colrev/packages/pubmed/src/pubmed.py
@@ -62,6 +62,7 @@ class PubMedSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/pubmed/src/pubmed_api.py
+++ b/colrev/packages/pubmed/src/pubmed_api.py
@@ -37,6 +37,7 @@ class PubmedAPI:
         timeout: int = 60,
         logger: typing.Optional[logging.Logger] = None,
     ):
+        """Initialize the instance."""
         self.email = email
         self.session = session
         self._timeout = timeout

--- a/colrev/packages/pubmed/src/pubmed_metadata_prep.py
+++ b/colrev/packages/pubmed/src/pubmed_metadata_prep.py
@@ -40,6 +40,7 @@ class PubmedMetadataPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
+++ b/colrev/packages/qualitative_systematic_review/src/qualitative_systematic_review.py
@@ -34,10 +34,12 @@ class QualitativeSystematicReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "qualitative systematic review"
 
     def initialize(

--- a/colrev/packages/ref_check/src/ref_check.py
+++ b/colrev/packages/ref_check/src/ref_check.py
@@ -21,6 +21,7 @@ class RefCheck(DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.data_operation = data_operation
         self.review_manager = data_operation.review_manager

--- a/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
+++ b/colrev/packages/remove_broken_ids/src/remove_broken_ids.py
@@ -34,6 +34,7 @@ class RemoveBrokenIDPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = colrev.package_manager.package_settings.DefaultSettings(
             **settings

--- a/colrev/packages/remove_coverpage/src/remove_cover_page.py
+++ b/colrev/packages/remove_coverpage/src/remove_cover_page.py
@@ -36,6 +36,7 @@ class PDFCoverPage(base_classes.PDFPrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager

--- a/colrev/packages/remove_last_page/src/remove_last_page.py
+++ b/colrev/packages/remove_last_page/src/remove_last_page.py
@@ -36,6 +36,7 @@ class PDFLastPage(base_classes.PDFPrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_prep_operation.review_manager

--- a/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
+++ b/colrev/packages/remove_urls_with_500_errors/src/remove_urls_with_500_errors.py
@@ -41,6 +41,7 @@ class RemoveError500URLsPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/scientometric/src/scientometric.py
+++ b/colrev/packages/scientometric/src/scientometric.py
@@ -27,10 +27,12 @@ class ScientometricReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "scientometric study"
 
     def initialize(

--- a/colrev/packages/scope_prescreen/src/scope_prescreen.py
+++ b/colrev/packages/scope_prescreen/src/scope_prescreen.py
@@ -87,6 +87,7 @@ class ScopePrescreen(base_classes.PrescreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         if "TimeScopeFrom" in settings:
             settings["TimeScopeFrom"] = int(settings["TimeScopeFrom"])

--- a/colrev/packages/scoping_review/src/scoping_review.py
+++ b/colrev/packages/scoping_review/src/scoping_review.py
@@ -27,10 +27,12 @@ class ScopingReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "scoping review"
 
     def initialize(

--- a/colrev/packages/scopus/src/scopus.py
+++ b/colrev/packages/scopus/src/scopus.py
@@ -48,6 +48,7 @@ class ScopusSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
         self.verbose_mode = verbose_mode

--- a/colrev/packages/scopus/src/scopus_api.py
+++ b/colrev/packages/scopus/src/scopus_api.py
@@ -29,6 +29,7 @@ class ScopusAPI:
     _THROTTLE_S = 0.34
 
     def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
 
     @staticmethod

--- a/colrev/packages/screen_table/src/screen_table.py
+++ b/colrev/packages/screen_table/src/screen_table.py
@@ -36,6 +36,7 @@ class TableScreen(base_classes.ScreenPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = screen_operation.review_manager
         self.screen_operation = screen_operation

--- a/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
+++ b/colrev/packages/semanticscholar/src/semantic_scholar_prep.py
@@ -43,6 +43,7 @@ class SemanticScholarPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.prep_operation = prep_operation

--- a/colrev/packages/semanticscholar/src/semanticscholar_api.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_api.py
@@ -18,6 +18,7 @@ class SemanticScholarAPI:
     """Light wrapper around the Semantic Scholar client."""
 
     def __init__(self, *, api_key: typing.Optional[str] = None) -> None:
+        """Initialize the instance."""
         self._client = (
             SemanticScholar(api_key=api_key) if api_key else SemanticScholar()
         )

--- a/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_search_source.py
@@ -74,6 +74,7 @@ class SemanticScholarSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/semanticscholar/src/semanticscholar_ui.py
+++ b/colrev/packages/semanticscholar/src/semanticscholar_ui.py
@@ -17,6 +17,7 @@ class SemanticScholarUI:
     search_params: dict
 
     def __init__(self) -> None:
+        """Initialize the instance."""
         self.search_params = {}
         self.search_subject = ""
 

--- a/colrev/packages/source_specific_prep/src/source_specific_prep.py
+++ b/colrev/packages/source_specific_prep/src/source_specific_prep.py
@@ -37,6 +37,7 @@ class SourceSpecificPrep(base_classes.PrepPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = prep_operation.review_manager

--- a/colrev/packages/springer_link/src/springer_link.py
+++ b/colrev/packages/springer_link/src/springer_link.py
@@ -63,6 +63,7 @@ class SpringerLinkSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/springer_link/src/springer_link_api.py
+++ b/colrev/packages/springer_link/src/springer_link_api.py
@@ -16,6 +16,7 @@ class SpringerLinkAPI:
     """Handle HTTP interactions with the Springer Link API."""
 
     def __init__(self, *, session: typing.Optional[requests.Session] = None) -> None:
+        """Initialize the instance."""
         self.session = session or requests.Session()
 
     def get_json(self, url: str, *, timeout: int) -> dict:

--- a/colrev/packages/structured/src/structured.py
+++ b/colrev/packages/structured/src/structured.py
@@ -72,6 +72,7 @@ class StructuredData(base_classes.DataPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.review_manager = data_operation.review_manager
 

--- a/colrev/packages/synergy_datasets/src/synergy_datasets.py
+++ b/colrev/packages/synergy_datasets/src/synergy_datasets.py
@@ -60,6 +60,7 @@ class SYNERGYDatasetsSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.search_source = search_file

--- a/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
+++ b/colrev/packages/taylor_and_francis/src/taylor_and_francis.py
@@ -40,6 +40,7 @@ class TaylorAndFrancisSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/packages/theoretical_review/src/theoretical_review.py
+++ b/colrev/packages/theoretical_review/src/theoretical_review.py
@@ -28,10 +28,12 @@ class TheoreticalReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "theoretical review"
 
     def initialize(

--- a/colrev/packages/trid/src/trid.py
+++ b/colrev/packages/trid/src/trid.py
@@ -46,6 +46,7 @@ class TransportResearchInternationalDocumentation(
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/packages/umbrella/src/umbrella_review.py
+++ b/colrev/packages/umbrella/src/umbrella_review.py
@@ -28,10 +28,12 @@ class UmbrellaReview(base_classes.ReviewTypePackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return "umbrella review"
 
     def initialize(

--- a/colrev/packages/unknown_source/src/unknown_source.py
+++ b/colrev/packages/unknown_source/src/unknown_source.py
@@ -61,6 +61,7 @@ class UnknownSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
         self.language_service = colrev.env.language_service.LanguageService()

--- a/colrev/packages/unpaywall/src/api.py
+++ b/colrev/packages/unpaywall/src/api.py
@@ -54,6 +54,7 @@ class UnpaywallAPI:
     """API for Unpaywall."""
 
     def __init__(self, search_parameters: dict) -> None:
+        """Initialize the instance."""
         self.search_parameters = search_parameters
 
     def _get_authors(self, article: dict) -> typing.List[str]:

--- a/colrev/packages/unpaywall/src/unpaywall.py
+++ b/colrev/packages/unpaywall/src/unpaywall.py
@@ -41,6 +41,7 @@ class Unpaywall(base_classes.PDFGetPackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
         self.settings = self.settings_class(**settings)

--- a/colrev/packages/unpaywall/src/unpaywall_search_source.py
+++ b/colrev/packages/unpaywall/src/unpaywall_search_source.py
@@ -47,6 +47,7 @@ class UnpaywallSearchSource(base_classes.SearchSourcePackageBaseClass):
         logger: typing.Optional[logging.Logger] = None,
         verbose_mode: bool = False,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.verbose_mode = verbose_mode
 

--- a/colrev/packages/web_of_science/src/web_of_science.py
+++ b/colrev/packages/web_of_science/src/web_of_science.py
@@ -44,6 +44,7 @@ class WebOfScienceSearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
         self.validate_source(self.search_source)

--- a/colrev/packages/website_screenshot/src/website_screenshot.py
+++ b/colrev/packages/website_screenshot/src/website_screenshot.py
@@ -40,6 +40,7 @@ class WebsiteScreenshot(base_classes.PDFGetPackageBaseClass):
         settings: dict,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.settings = self.settings_class(**settings)
         self.review_manager = pdf_get_operation.review_manager

--- a/colrev/packages/wiley/src/wiley.py
+++ b/colrev/packages/wiley/src/wiley.py
@@ -41,6 +41,7 @@ class WileyOnlineLibrarySearchSource(base_classes.SearchSourcePackageBaseClass):
         search_file: colrev.search_file.ExtendedSearchFile,
         logger: typing.Optional[logging.Logger] = None,
     ) -> None:
+        """Initialize the instance."""
         self.logger = logger or logging.getLogger(__name__)
         self.search_source = search_file
 

--- a/colrev/paths.py
+++ b/colrev/paths.py
@@ -32,6 +32,7 @@ class PathManager:
     RECORDS_FILE_GIT = str(RECORDS_FILE).replace("\\", "/")
 
     def __init__(self, base_path: Path) -> None:
+        """Initialize the instance."""
         self.base_path = base_path
 
         self.search = base_path / self.SEARCH_DIR

--- a/colrev/process/operation.py
+++ b/colrev/process/operation.py
@@ -32,6 +32,7 @@ class Operation:
         operations_type: OperationsType,
         notify_state_transition_operation: bool = True,
     ) -> None:
+        """Initialize the instance."""
         self.review_manager = review_manager
         self.type = operations_type
         self.notify_state_transition_operation = notify_state_transition_operation

--- a/colrev/record/qm/checkers/container_title_abbreviated.py
+++ b/colrev/record/qm/checkers/container_title_abbreviated.py
@@ -19,6 +19,7 @@ class ContainerTitleAbbreviatedChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/doi_not_matching_pattern.py
+++ b/colrev/record/qm/checkers/doi_not_matching_pattern.py
@@ -22,6 +22,7 @@ class DOIPatternChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/erroneous_symbol_in_field.py
+++ b/colrev/record/qm/checkers/erroneous_symbol_in_field.py
@@ -26,6 +26,7 @@ class ErroneousSymbolInFieldChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/erroneous_term_in_field.py
+++ b/colrev/record/qm/checkers/erroneous_term_in_field.py
@@ -36,6 +36,7 @@ class ErroneousTermInFieldChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/erroneous_title_field.py
+++ b/colrev/record/qm/checkers/erroneous_title_field.py
@@ -18,6 +18,7 @@ class ErroneousTitleFieldChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/html_tags.py
+++ b/colrev/record/qm/checkers/html_tags.py
@@ -28,6 +28,7 @@ class HTMLTagChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/identical_values_between_title_and_container.py
+++ b/colrev/record/qm/checkers/identical_values_between_title_and_container.py
@@ -19,6 +19,7 @@ class IdenticalValuesChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/inconsistent_content.py
+++ b/colrev/record/qm/checkers/inconsistent_content.py
@@ -18,6 +18,7 @@ class InconsistentContentChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/inconsistent_with_doi_metadata.py
+++ b/colrev/record/qm/checkers/inconsistent_with_doi_metadata.py
@@ -31,6 +31,7 @@ class InconsistentWithDOIMetadataChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/inconsistent_with_entrytype.py
+++ b/colrev/record/qm/checkers/inconsistent_with_entrytype.py
@@ -61,6 +61,7 @@ class InconsistentWithEntrytypeChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/isbn_not_matching_pattern.py
+++ b/colrev/record/qm/checkers/isbn_not_matching_pattern.py
@@ -28,6 +28,7 @@ class ISBNPatternChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/language_format_error.py
+++ b/colrev/record/qm/checkers/language_format_error.py
@@ -20,6 +20,7 @@ class LanguageFormatChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
         self.language_service = colrev.env.language_service.LanguageService()
 

--- a/colrev/record/qm/checkers/language_unknown.py
+++ b/colrev/record/qm/checkers/language_unknown.py
@@ -19,6 +19,7 @@ class LanguageChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/missing_field.py
+++ b/colrev/record/qm/checkers/missing_field.py
@@ -23,6 +23,7 @@ class MissingFieldChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/mostly_all_caps.py
+++ b/colrev/record/qm/checkers/mostly_all_caps.py
@@ -20,6 +20,7 @@ class MostlyAllCapsFieldChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/name_abbreviated.py
+++ b/colrev/record/qm/checkers/name_abbreviated.py
@@ -21,6 +21,7 @@ class NameAbbreviatedChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/name_format_separators.py
+++ b/colrev/record/qm/checkers/name_format_separators.py
@@ -22,6 +22,7 @@ class NameFormatSeparatorsChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/name_format_titles.py
+++ b/colrev/record/qm/checkers/name_format_titles.py
@@ -24,6 +24,7 @@ class NameFormatTitleChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/name_particles.py
+++ b/colrev/record/qm/checkers/name_particles.py
@@ -20,6 +20,7 @@ class NameParticlesChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/page_range.py
+++ b/colrev/record/qm/checkers/page_range.py
@@ -20,6 +20,7 @@ class PageRangeChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/pubmedid_not_matching_pattern.py
+++ b/colrev/record/qm/checkers/pubmedid_not_matching_pattern.py
@@ -22,6 +22,7 @@ class PubmedIDPatternChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/record_not_in_toc.py
+++ b/colrev/record/qm/checkers/record_not_in_toc.py
@@ -21,6 +21,7 @@ class RecordNotInTOCChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
         self.local_index = colrev.env.local_index.LocalIndex(verbose_mode=False)
 

--- a/colrev/record/qm/checkers/thesis_with_multiple_authors.py
+++ b/colrev/record/qm/checkers/thesis_with_multiple_authors.py
@@ -18,6 +18,7 @@ class ThesisWithMultipleAuthorsChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/checkers/year_format.py
+++ b/colrev/record/qm/checkers/year_format.py
@@ -21,6 +21,7 @@ class YearFormatChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/pdf_checkers/author_not_in_pdf.py
+++ b/colrev/record/qm/pdf_checkers/author_not_in_pdf.py
@@ -24,6 +24,7 @@ class AuthorNotInPDFChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/pdf_checkers/no_text_in_pdf.py
+++ b/colrev/record/qm/pdf_checkers/no_text_in_pdf.py
@@ -21,6 +21,7 @@ class TextInPDFChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/pdf_checkers/pdf_incomplete.py
+++ b/colrev/record/qm/pdf_checkers/pdf_incomplete.py
@@ -34,6 +34,7 @@ class PDFIncompletenessChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record_pdf.PDFRecord) -> None:

--- a/colrev/record/qm/pdf_checkers/title_not_in_pdf.py
+++ b/colrev/record/qm/pdf_checkers/title_not_in_pdf.py
@@ -24,6 +24,7 @@ class TitleNotInPDFChecker:
     def __init__(
         self, quality_model: colrev.record.qm.quality_model.QualityModel
     ) -> None:
+        """Initialize the instance."""
         self.quality_model = quality_model
 
     def run(self, *, record: colrev.record.record.Record) -> None:

--- a/colrev/record/qm/quality_model.py
+++ b/colrev/record/qm/quality_model.py
@@ -25,6 +25,7 @@ class QualityModel:
         pdf_mode: bool = False,
         path: typing.Optional[Path] = None,
     ) -> None:
+        """Initialize the instance."""
         self.pdf_mode = pdf_mode
         self.defects_to_ignore = defects_to_ignore
         self._register_checkers()

--- a/colrev/record/record.py
+++ b/colrev/record/record.py
@@ -37,15 +37,18 @@ class Record:
     pp = pprint.PrettyPrinter(indent=4, width=140, compact=False)
 
     def __init__(self, data: dict) -> None:
+        """Initialize the instance."""
         self.data = data
         """Dictionary containing the record data"""
         # Note : avoid parsing upon Record instantiation as much as possible
         # to maintain high performance and ensure pickle-abiligy (in multiprocessing)
 
     def __repr__(self) -> str:  # pragma: no cover
+        """Return a developer representation."""
         return self.pp.pformat(self.data)
 
     def __str__(self) -> str:
+        """Return a string representation."""
         ik_order = [Fields.ID, Fields.ENTRYTYPE]
         ik_order += [k for k in FieldSet.IDENTIFYING_FIELD_KEYS if k in self.data]
         ck_order = [k for k, v in self.data.items() if k not in ik_order]
@@ -56,6 +59,7 @@ class Record:
         return ret_str
 
     def __eq__(self, other: object) -> bool:
+        """Return whether two instances are equal."""
         return self.__dict__ == other.__dict__
 
     def get_citation_format(self) -> str:

--- a/colrev/record/record_id_setter.py
+++ b/colrev/record/record_id_setter.py
@@ -34,7 +34,7 @@ class IDSetter:
         skip_local_index: bool = False,
         logger: logging.Logger = logging.getLogger(__name__),
     ) -> None:
-
+        """Initialize the instance."""
         self.id_pattern = id_pattern
         self.skip_local_index = skip_local_index
         if not self.skip_local_index:

--- a/colrev/record/record_pdf.py
+++ b/colrev/record/record_pdf.py
@@ -25,6 +25,7 @@ class PDFRecord(colrev.record.record.Record):
     """The PDFRecord class provides a range of Function for PDF handling."""
 
     def __init__(self, data: dict, *, path: Path) -> None:
+        """Initialize the instance."""
         self.data = data
         """Dictionary containing the record data"""
 

--- a/colrev/review_manager.py
+++ b/colrev/review_manager.py
@@ -67,6 +67,7 @@ class ReviewManager:
         exact_call: str = "",
         skip_upgrade: bool = True,
     ) -> None:
+        """Initialize the instance."""
         self.force_mode = force_mode
         """Force mode variable (bool)"""
         self.verbose_mode = verbose_mode

--- a/colrev/search_file.py
+++ b/colrev/search_file.py
@@ -32,6 +32,7 @@ class ExtendedSearchFile(search_query.SearchFile):
     ) -> None:
 
         # Mandatory attribute
+        """Initialize the instance."""
         self.search_type = SearchType(search_type)
 
         if not str(search_results_path).replace("\\", "/").startswith("data/search"):
@@ -134,6 +135,7 @@ class ExtendedSearchFile(search_query.SearchFile):
             git_repo.add_changes(path)
 
     def __repr__(self) -> str:
+        """Return a developer representation."""
         return (
             f"{self.__class__.__name__}("
             f"platform={self.platform!r}, "
@@ -144,6 +146,7 @@ class ExtendedSearchFile(search_query.SearchFile):
 
     def __str__(self) -> str:
         # pylint: disable=broad-exception-caught
+        """Return a string representation."""
         try:
             payload = self.to_dict()
         except Exception:

--- a/colrev/settings.py
+++ b/colrev/settings.py
@@ -71,6 +71,7 @@ class ProjectSettings(BaseModel):
     auto_upgrade: bool
 
     def __str__(self) -> str:
+        """Return a string representation."""
         project_str = f"- review ({self.review_type}):"
         project_str += f"\n- title: {self.title}"
         return project_str
@@ -85,6 +86,7 @@ class SearchSettings(BaseModel):
     retrieve_forthcoming: bool
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return f"- retrieve_forthcoming: {self.retrieve_forthcoming}"
 
 
@@ -98,6 +100,7 @@ class PrepRound(BaseModel):
     prep_package_endpoints: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         short_list = [script["endpoint"] for script in self.prep_package_endpoints][:3]
         if len(self.prep_package_endpoints) > 3:
             short_list.append("...")
@@ -115,6 +118,7 @@ class PrepSettings(BaseModel):
     defects_to_ignore: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return (
             f"- fields_to_keep: {self.fields_to_keep}\n"
             + "- prep_rounds:\n - endpoints:\n   - "
@@ -131,6 +135,7 @@ class DedupeSettings(BaseModel):
     dedupe_package_endpoints: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         endpoints_str = "- endpoints: []\n"
         if self.dedupe_package_endpoints:
             endpoints_str = "- endpoints:\n - " + "\n - ".join(
@@ -149,6 +154,7 @@ class PrescreenSettings(BaseModel):
     prescreen_package_endpoints: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         endpoints_str = "- endpoints: []\n"
         if self.prescreen_package_endpoints:
             endpoints_str = "- endpoints:\n - " + "\n - ".join(
@@ -175,6 +181,7 @@ class PDFGetSettings(BaseModel):
     defects_to_ignore: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         endpoints_str = "- endpoints: []\n"
         if self.pdf_get_man_package_endpoints:
             endpoints_str = "- endpoints:\n - " + "\n - ".join(
@@ -196,6 +203,7 @@ class PDFPrepSettings(BaseModel):
     pdf_prep_man_package_endpoints: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         endpoints_str = "- endpoints: []\n"
         if self.pdf_prep_package_endpoints:
             endpoints_str = "- endpoints:\n - " + "\n - ".join(
@@ -215,6 +223,7 @@ class ScreenCriterion(BaseModel):
     criterion_type: ScreenCriterionType
 
     def __str__(self) -> str:
+        """Return a string representation."""
         return f"{self.explanation} ({self.criterion_type}, {self.comment})"
 
 
@@ -226,6 +235,7 @@ class ScreenSettings(BaseModel):
     screen_package_endpoints: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         endpoints_str = "- endpoints: []\n"
         if self.screen_package_endpoints:
             endpoints_str = "- endpoints:\n - " + "\n - ".join(
@@ -251,6 +261,7 @@ class DataSettings(BaseModel):
     data_package_endpoints: list
 
     def __str__(self) -> str:
+        """Return a string representation."""
         endpoints_str = "- endpoints: []\n"
         if self.data_package_endpoints:
             endpoints_str = "- endpoints:\n - " + "\n - ".join(
@@ -319,6 +330,7 @@ class Settings(BaseModel):
         return False
 
     def __str__(self) -> str:
+        """Return a string representation."""
         sources_str = "\n- " + "\n- ".join(
             [str(s) for s in self.sources if s.is_md_source()]
             + [str(s) for s in self.sources if not s.is_md_source()]

--- a/colrev/ui_cli/cli.py
+++ b/colrev/ui_cli/cli.py
@@ -159,6 +159,7 @@ class SpecialHelpOrder(click.Group):
     """Order for cli commands in help page overview."""
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore
+        """Initialize the instance."""
         self.help_priorities: dict = {}
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
### Motivation
- Reduce pydocstyle/Ruff violations classified under “Enforce PEP 257 Docstring Conventions” without changing runtime behavior. 
- Provide concise, consistent docstrings for missing magic methods and `__init__` methods to improve code clarity and satisfy D105/D107 rules. 
- Normalize small formatting issues (blank lines between summary and description, terminal punctuation and short imperative summaries) to improve uniformity across packages. 

### Description
- Added short, non-functional docstrings to many missing magic methods (e.g., `__init__`, `__str__`, `__repr__`, `__eq__`, `__lt__`, `__iter__`) and other constructors across the codebase to address D105/D107 violations. 
- Inserted required blank lines and adjusted multi-line summaries and final punctuation in numerous docstrings to address D203/D205/D213/D415 and related rules. 
- Normalized a number of small docstring wording/formatting items (argument descriptions, start-of-docstring capitalization and phrasing) to reduce D401/D417/D404/D419/D402/D403/D406/D407/D417 style issues while preserving public APIs and runtime behavior. 
- Changes are documentation-only and do not modify logic, signatures, imports, or behavior; updates were applied across many modules and packages (over 200 files touched). 

### Testing
- Ran `ruff check colrev --select D --statistics` and `ruff check colrev --select D --fix`, which substantially reduced docstring violations from roughly 520 to ~193 D-rule issues and applied all available auto-fixes. 
- Attempted to run `pytest -q`, but the test run failed in this environment with an import path/module resolution error (`ModuleNotFoundError: No module named 'colrev'`), so the full test-suite could not be executed here. 
- No runtime tests failed as a result of these edits because the changes are documentation-only and do not alter executable behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04844d5624832ab745857f1d3d2e3d)